### PR TITLE
Report map and age with ?status packet query

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -220,6 +220,9 @@ var/world_topic_spam_protect_time = world.timeofday
 
 			s["players"] = n
 			s["admins"] = admins
+			if (map)
+				s["map"] = map.name
+				s["age"] = map.age
 
 		return list2params(s)
 


### PR DESCRIPTION
Tested and confirmed working, except the map name seems to be reporting weird? For example, a game running on Nomads.dmm reports the map.name as 'control'