### PR TITLE
Early-Midgame apparel additions, tweaks & re-organization

### DIFF
--- a/code/modules/1713/apparel_ancient.dm
+++ b/code/modules/1713/apparel_ancient.dm
@@ -1,3 +1,21 @@
+/*Index*/
+/* 1 - Roman Uniform & Sandals
+ * 2 - Greek Uniforms
+ * 3 - Celtic Uniforms
+ * 4 - Mayan & Aztec Uniforms + Sandals
+ * 5 - Egyptian Uniforms
+ * 6 - Ancient Armor
+ * 7 - Ancient Capes
+ * 8 - Ancient Headpieces
+ * 9 - Ancient Helmets
+ * 10 - Royal & Imperial Headwear
+ * 11 - Pelts
+ * 12 - Fur Coats
+ * 13 - Fur Shoes
+ * 14 - Ancient Facemasks & Covers
+ * 15 - Miscallaneous*/
+
+/*Roman Uniforms & Sandals*/
 
 /obj/item/clothing/shoes/roman
 	name = "sandals"
@@ -41,6 +59,8 @@
 	worn_state = "roman_centurion"
 	heat_protection = LOWER_TORSO|LEGS|UPPER_TORSO
 
+/*Greek Uniforms*/
+
 /obj/item/clothing/under/greek1
 	name = "Greek uniform"
 	desc = "A light tunic, covered with bronze and leather armor. Used by the Hellenic armies."
@@ -81,7 +101,7 @@
 	worn_state = "toxotai"
 	heat_protection = LOWER_TORSO|LEGS|UPPER_TORSO
 
-//celtic
+/*Celtic Uniforms*/
 
 /obj/item/clothing/under/celtic_green
 	name = "green celtic trousers"
@@ -123,6 +143,8 @@
 	worn_state = "celtic_long_braccae"
 	heat_protection = LOWER_TORSO|LEGS
 
+/*Mayan & Aztec Uniforms + Sandals*/
+
 /obj/item/clothing/under/mayan_loincloth
 	name = "mayan loincloth"
 	desc = "Mayan-style loincloth."
@@ -149,23 +171,30 @@
 	armor = list(melee = 10, arrow = 5, gun = FALSE, energy = FALSE, bomb = 1, bio = FALSE, rad = FALSE)
 	siemens_coefficient = 0.6
 
+/*Egyptian Uniforms*/
+
 /obj/item/clothing/under/pharaoh
-	name = "fancy shendyt"
+	name = "pharaohic shendyt"
 	desc = "A fancy, decorated shendyt."
 	icon_state = "pharaoh"
 	item_state = "pharaoh"
 	worn_state = "pharaoh"
+	heat_protection = LOWER_TORSO|UPPER_TORSO
 
 /obj/item/clothing/under/pharaoh2
-	name = "great shendyt"
+	name = "nemes shendyt"
 	desc = "A fancy, decorated shendyt."
 	icon_state = "greatshendyt"
 	item_state = "greatshendyt"
 	worn_state = "greatshendyt"
-	heat_protection = LOWER_TORSO
+	heat_protection = LOWER_TORSO|UPPER_TORSO
+
+/*Ancient Armor*/
+
 /obj/item/clothing/suit/armor
 	health = 40
 	ripable = FALSE
+
 /obj/item/clothing/suit/armor/ancient/scale
 	name = "scale armor"
 	desc = "A thick, expensive scaled iron armor, covering the torso."
@@ -202,6 +231,8 @@
 	slowdown = 0.2
 	health = 18
 
+/*Ancient Capes*/
+
 /obj/item/clothing/suit/cape
 	name = "red cape"
 	desc = "A long red cape."
@@ -215,6 +246,44 @@
 	icon_state = "bluecape"
 	item_state = "bluecape"
 	worn_state = "bluecape"
+
+/*Ancient Headpieces*/
+
+/obj/item/clothing/head/toxotai
+	name = "toxotai hat"
+	desc = "a wide brim hat, used by the toxotai."
+	icon_state = "toxotai"
+	item_state = "toxotai"
+	worn_state = "toxotai"
+
+/obj/item/clothing/head/egyptian_headdress_black
+	name = "black egyptian headdress"
+	desc = "a plain sun-protective linen headdress, despite its black stripes."
+	icon_state = "egyptian_headdress_black"
+	item_state = "egyptian_headdress_black"
+	worn_state = "egyptian_headdress_black"
+	flags_inv = BLOCKHEADHAIR
+	heat_protection = HEAD|FACE|EYES
+
+/obj/item/clothing/head/egyptian_headdress_blue
+	name = "blue egyptian headdress"
+	desc = "a plain sun-protective blue linen headdress."
+	icon_state = "egyptian_headdress_blue"
+	item_state = "egyptian_headdress_blue"
+	worn_state = "egyptian_headdress_blue"
+	flags_inv = BLOCKHEADHAIR
+	heat_protection = HEAD|FACE|EYES
+
+/obj/item/clothing/head/egyptian_headdress_red
+	name = "red egyptian headdress"
+	desc = "a plain sun-protective red linen headdress."
+	icon_state = "egyptian_headdress_red"
+	item_state = "egyptian_headdress_red"
+	worn_state = "egyptian_headdress_red"
+	flags_inv = BLOCKHEADHAIR
+	heat_protection = HEAD|FACE|EYES
+
+/*Ancient Helmets*/
 
 /obj/item/clothing/head/helmet/roman
 	name = "Roman legionary helmet"
@@ -313,6 +382,8 @@
 	armor = list(melee = 27, arrow = 15, gun = FALSE, energy = 15, bomb = 25, bio = 20, rad = FALSE)
 	health = 20
 
+/*Royal & Laurel Headwear*/
+
 /obj/item/clothing/head/nemes
 	name = "nemes headdress"
 	desc = "a fancy, golden headdress."
@@ -320,6 +391,7 @@
 	item_state = "nemes_headdress"
 	worn_state = "nemes_headdress"
 	flags_inv = BLOCKHEADHAIR
+	heat_protection = HEAD|FACE|EYES
 
 /obj/item/clothing/head/doublecrown
 	name = "double crown"
@@ -327,6 +399,22 @@
 	icon_state = "doublecrown"
 	item_state = "doublecrown"
 	worn_state = "doublecrown"
+
+/obj/item/clothing/head/laurelcrown
+	name = "laurel crown"
+	desc = "a crown made of laurel."
+	icon_state = "laurelcrown"
+	item_state = "laurelcrown"
+	body_parts_covered = FALSE
+
+/obj/item/clothing/head/laurelcrown/gold
+	name = "gold laurel crown"
+	desc = "a crown made of gold, imitating a laurel crown."
+	icon_state = "laurelcrown_gold"
+	item_state = "laurelcrown_gold"
+	body_parts_covered = FALSE
+
+/*Pelts*/
 
 /obj/item/clothing/head/bearpelt
 	name = "bearpelt headcover"
@@ -358,12 +446,17 @@
 	cold_protection = HEAD
 	var/colortype = "black"
 
-/obj/item/clothing/head/toxotai
-	name = "toxotai hat"
-	desc = "a wide brim hat, used by the toxotai."
-	icon_state = "toxotai"
-	item_state = "toxotai"
-	worn_state = "toxotai"
+/obj/item/clothing/head/lionpelt
+	name = "lionpelt headcover"
+	desc = "A lion pelt turned into a headcover."
+	icon_state = "lionpelt"
+	item_state = "lionpelt"
+	worn_state = "lionpelt"
+	flags_inv = BLOCKHEADHAIR
+	cold_protection = HEAD
+	var/colortype = "brown" //I haven't knocked together the coloration idea yet - @fantasticfwoosh
+
+/*Fur Coats*/
 
 /obj/item/clothing/suit/storage/coat
 	var/hood = FALSE
@@ -427,6 +520,7 @@
 	worn_state = "fur_jacket5"
 	specific = TRUE
 	colorn = 5
+
 /obj/item/clothing/suit/storage/coat/fur/orc
 	name = "orc fur coat"
 	desc = "A thick dark green fur coat, made from disgusting orc pelts."
@@ -435,6 +529,7 @@
 	worn_state = "fur_jacket6"
 	specific = TRUE
 	colorn = 6
+
 /obj/item/clothing/suit/storage/coat/fur/New()
 	..()
 	if (!specific)
@@ -474,6 +569,7 @@
 		usr.update_inv_wear_suit(1)
 		return
 
+/*Fur Shoes*/
 
 /obj/item/clothing/shoes/fur
 	name = "fur boots"
@@ -545,6 +641,8 @@
 		item_state = "fur[colorn]"
 		worn_state = "fur[colorn]"
 
+/*Ancient Facemasks & Covers*/
+
 /obj/item/clothing/mask/redkerchief
 	name = "red kerchief"
 	desc = "A piece of light cloth, worn around the neck."
@@ -593,6 +691,7 @@
 	partscovered = FACE
 	flags_inv = 0
 	w_class = 2
+
 /obj/item/clothing/mask/shemagh/update_icon()
 	if (toggled == FALSE)
 		body_parts_covered = 0
@@ -609,7 +708,6 @@
 		worn_state = usedstate
 		heat_protection = HEAD|FACE|EYES
 	..()
-
 
 /obj/item/clothing/mask/shemagh/verb/toggle_hood()
 	set category = null
@@ -638,23 +736,12 @@
 		usr.update_inv_wear_mask(1)
 		return
 
-/obj/item/clothing/head/laurelcrown
-	name = "laurel crown"
-	desc = "a crown made of laurel."
-	icon_state = "laurelcrown"
-	item_state = "laurelcrown"
-	body_parts_covered = FALSE
+/*Miscallaneous*/
 
-/obj/item/clothing/head/laurelcrown/gold
-	name = "gold laurel crown"
-	desc = "a crown made of gold, imitating a laurel crown."
-	icon_state = "laurelcrown_gold"
-	item_state = "laurelcrown_gold"
-	body_parts_covered = FALSE
-
-/obj/item/clothing/suit/towel
+/obj/item/clothing/under/towel  //this was incorrectly reported as a exterior suit, it is actually a interior uniform
 	name = "white towel"
 	desc = "A simple towel to wrap around yourself."
 	icon_state = "towel"
 	item_state = "towel"
 	worn_state = "towel"
+	heat_protection = LOWER_TORSO

--- a/code/modules/1713/apparel_imperial.dm
+++ b/code/modules/1713/apparel_imperial.dm
@@ -1,4 +1,25 @@
-// civs
+/*Index*/
+/*   * 1 - Colonial Suits
+     * 2 - Colonial Uniforms
+     * 3 - Colonial Hats
+     * 4 - Colonial Boots
+     * 5 - Colonial Accessories & Items
+     * 6 - Colonial Pirate Clothing
+     ///////////////////////////////////
+     * 7 - Colonial Infantry & Sailor Clothes
+     * 7a - Colonial Infantry & Sailor Boots
+     * 7b - Colonial British Army & Navy Clothes
+     * 7c - Colonial Portuguese Army & Navy Clothes
+     * 7d - Colonial Spanish Army & Navy Clothes
+     * 7e - Colonial French Army & Navy Clothes
+     * 7f - Colonial Dutch Army & Navy Clothes
+     ///////////////////////////////////
+     * 8 - Colonial Army Clothes
+     * 8a - Colonial Army Uniforms
+     ///////////////////////////////////
+     * 9 - Miscallaneous */
+
+/* Colonial Suits*/
 
 /obj/item/clothing/suit/storage/jacket/kool_kids_klub
 	name = "white robe with hood"
@@ -7,6 +28,8 @@
 	item_state = "kool_kids_klub"
 	worn_state = "kool_kids_klub"
 	body_parts_covered = FULL_BODY
+
+/* Colonial Uniforms*/
 
 /obj/item/clothing/under/civ4
 	name = "Fancy Colonial Clothing"
@@ -50,14 +73,11 @@
 	item_state = "civuni6"
 	worn_state = "civuni6"
 
-/obj/item/clothing/head/kerchief
-	name = "kerchief"
-	icon_state = "kerchief"
-	item_state = "kerchief"
-	worn_state = "kerchief"
-	desc = "A kerchief, worn by women over the hair."
-	flags_inv = BLOCKHAIR
-	body_parts_covered = HEAD
+/obj/item/clothing/under/doctor
+	name = "doctor's uniform"
+	desc = "A sterile, nicely pressed suit for doctors."
+	icon_state = "ba_suit"
+	item_state = "ba_suit"
 
 /obj/item/clothing/under/civf1
 	name = "Dark dress"
@@ -94,8 +114,116 @@
 	item_state = "dressr"
 	worn_state = "dressr"
 
-// WEBBING - can hold everything but clothing
+/* Colonial Hats*/
 
+/obj/item/clothing/head/furhat
+	name = "fur hat"
+	desc = "A hat made of fur."
+	icon_state = "furhat_hat"
+	item_state = "furhat_hat"
+
+/obj/item/clothing/head/furcap
+	name = "fur cap"
+	desc = "A cap made of fur."
+	icon_state = "furcap_hat"
+	item_state = "furcap_hat"
+
+/obj/item/clothing/head/roundcap
+	name = "roundcap"
+	desc = "A cap made of leather."
+	icon_state = "roundcap_hat"
+	item_state = "roundcap_hat"
+
+/obj/item/clothing/head/kerchief
+	name = "kerchief"
+	icon_state = "kerchief"
+	item_state = "kerchief"
+	worn_state = "kerchief"
+	desc = "A kerchief, worn by women over the hair."
+	flags_inv = BLOCKHAIR
+	body_parts_covered = HEAD
+
+/obj/item/clothing/head/red_beret
+	name = "red sailor beret"
+	desc = "A red beret."
+	icon_state = "redberet"
+	item_state = "redberet"
+
+/obj/item/clothing/head/blackberet
+	name = "black beret"
+	desc = "A black military beret."
+	icon_state = "blackberret"
+	item_state = "blackberret"
+
+/obj/item/clothing/head/blue_beret
+	name = "blue sailor beret"
+	desc = "A blue beret."
+	icon_state = "blueberet"
+	item_state = "blueberet"
+
+/obj/item/clothing/head/tarred_hat
+	name = "tarred hat"
+	desc = "A tarred hat, commonly used by sailors."
+	icon_state = "tarred_hat"
+	item_state = "tarred_hat"
+	flags_inv = BLOCKHEADHAIR
+
+/obj/item/clothing/head/strawhat
+	name = "straw hat"
+	icon_state = "boater_hat"
+	desc = "A straw hat, commonly used by sailors."
+	flags_inv = BLOCKHEADHAIR
+
+/obj/item/clothing/head/tricorne_black
+	name = "black tricorne"
+	desc = "A black tricorne. In fashion."
+	icon_state = "tricorne_black"
+	item_state = "tricorne_black"
+
+/* Colonial Boots*/
+
+/obj/item/clothing/shoes/blackboots1
+	name = "black boots"
+	desc = "Classic black boots."
+	icon_state = "sailorboots1"
+	item_state = "sailorboots1"
+	worn_state = "sailorboots1"
+	force = WEAPON_FORCE_WEAK
+	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 30)
+	item_flags = NOSLIP
+	siemens_coefficient = 0.6
+	cold_protection = FEET
+	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/shoes/leatherboots1
+	name = "leather boots"
+	desc = "Classic leather boots."
+	icon_state = "sailorboots2"
+	item_state = "sailorboots2"
+	worn_state = "sailorboots2"
+	force = WEAPON_FORCE_WEAK
+	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 30)
+	item_flags = NOSLIP
+	siemens_coefficient = 0.6
+	cold_protection = FEET
+	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/shoes/winterboots
+	name = "winter boots"
+	desc = "Classic winter boots."
+	icon_state = "winterboots"
+	item_state = "winterboots"
+	worn_state = "winterboots"
+	force = WEAPON_FORCE_WEAK
+	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 40)
+	item_flags = NOSLIP
+	siemens_coefficient = 0.9
+	cold_protection = FEET
+	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+
+/* Colonial Accessories & Items*/
+
+// WEBBING - can hold everything but clothing
 /obj/item/clothing/accessory/storage/webbing
 	name = "bandolier"
 	desc = "two leather belts with small pouches for ammunition."
@@ -106,12 +234,6 @@
 	New()
 		..()
 		hold.can_hold = list(/obj/item/ammo_casing)
-
-/obj/item/clothing/under/doctor
-	name = "doctor's uniform"
-	desc = "A sterile, nicely pressed suit for doctors."
-	icon_state = "ba_suit"
-	item_state = "ba_suit"
 
 /obj/item/clothing/accessory/storage/coinpouch
 	name = "coin pouch"
@@ -227,32 +349,7 @@
 		qdel(src)
 		return
 
-
-/obj/item/weapon/storage/backpack/quiver
-	name = "quiver"
-	desc = "The best way to carry a bow and arrows."
-	icon = 'icons/obj/storage.dmi'
-	icon_state = "quiver"
-	item_state = "quiver"
-
-/obj/item/weapon/storage/backpack/quiver/New()
-		..()
-		can_hold = list(/obj/item/ammo_casing/bolt, /obj/item/ammo_casing/arrow, /obj/item/weapon/gun/projectile/bow, /obj/item/weapon/material/pilum)
-
-/obj/item/weapon/storage/backpack/quiver/full/New()
-	..()
-	can_hold = list(/obj/item/ammo_casing/bolt, /obj/item/ammo_casing/arrow, /obj/item/weapon/gun/projectile/bow, /obj/item/weapon/material/pilum)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-	new /obj/item/ammo_casing/arrow/bronze(src)
-//pirate stuff
+//* Colonial Pirate Clothing*/
 
 /obj/item/clothing/suit/storage/jacket/piratejacket1
 	name = "black jacket"
@@ -335,6 +432,9 @@
 	item_state = "piratebandana1"
 	flags_inv = BLOCKHAIR
 
+/* Colonial Infantry Clothes*/
+	/* Colonial Infantry & Sailor Boots*/
+
 /obj/item/clothing/shoes/soldiershoes
 	name = "infantry shoes"
 	desc = "Low black infantry shoes."
@@ -358,6 +458,7 @@
 	siemens_coefficient = 0.6
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+
 /obj/item/clothing/shoes/sailorboots2
 	name = "leather sailor boots"
 	desc = "Classic leather sailor boots."
@@ -370,7 +471,21 @@
 	siemens_coefficient = 0.6
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
-/////////british stuff/////////
+
+/obj/item/clothing/shoes/usmc
+	name = "military boots"
+	desc = "Classic tan military boots."
+	icon_state = "usmc"
+	item_state = "usmc"
+	worn_state = "usmc"
+	force = WEAPON_FORCE_WEAK
+	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 40)
+	item_flags = NOSLIP
+	siemens_coefficient = 0.7
+	cold_protection = FEET
+	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+
+	/* Colonial British Army & Navy Clothes*/
 
 /obj/item/clothing/under/british_sailor1
 	name = "british sailor clothes"
@@ -451,13 +566,13 @@
 	icon_state = "chasseur_br"
 	item_state = "chasseur_br"
 
-/////////Portuguese/////////
+/* Colonial Portuguese Army & Navy Clothes*/
+
 /obj/item/clothing/head/tricorne_portuguese
 	name = "Portuguese Navy tricorne"
 	desc = "A green tricorne, used by the Portuguese Navy."
 	icon_state = "tricorne_portuguese"
 	item_state = "tricorne_portuguese"
-
 
 /obj/item/clothing/head/chasseur_portuguese
 	name = "Portuguese feathered hat"
@@ -514,7 +629,8 @@
 	worn_state = "portuguese_sailor4"
 
 
-/////////Spanish/////////
+/* Colonial Spanish Army & Navy Clothes*/
+
 /obj/item/clothing/head/tricorne_spanish
 	name = "Spanish Navy tricorne"
 	desc = "A yellow tricorne, used by the Spanish Navy."
@@ -562,8 +678,8 @@
 	item_state = "spanish_sailor3"
 	worn_state = "spanish_sailor3"
 
+/* Colonial French Army & Navy Clothes*/
 
-/////////French/////////
 /obj/item/clothing/head/tricorne_french
 	name = "French Navy tricorne"
 	desc = "A white and blue tricorne, used by the French Navy."
@@ -604,20 +720,6 @@
 	item_state = "baycona"
 	worn_state = "baycona"
 
-/obj/item/clothing/under/scavfit
-	name = "Ripped outfit"
-	desc = "A set of blue jeans and brown hoodie."
-	icon_state = "scavfit"
-	item_state = "scavfit"
-	worn_state = "scavfit"
-
-/obj/item/clothing/under/wastelander
-	name = "outfit"
-	desc = "A set of tan pants and a brown coat."
-	icon_state = "wastelander"
-	item_state = "wastelander"
-	worn_state = "wastelander"
-
 /obj/item/clothing/under/french_sailor1
 	name = "french sailor clothes"
 	desc = "A set of french navy sailor clothes, with light blue shirt and trousers."
@@ -650,7 +752,9 @@
 	desc = "A feathered black bicorne, used by the French Light Infantry."
 	icon_state = "chasseur_fr"
 	item_state = "chasseur_fr"
-/////////Dutch/////////
+
+/* Colonial Dutch Army & Navy Clothes*/
+
 /obj/item/clothing/head/tricorne_dutch
 	name = "United Provinces Navy tricorne"
 	desc = "An orange tricorne, used by the United Provinces Navy."
@@ -662,7 +766,6 @@
 	desc = "A feathered black bicorne, used by the United Provinces Light Infantry."
 	icon_state = "chasseur_nl"
 	item_state = "chasseur_nl"
-
 
 /obj/item/clothing/head/dutch_army
 	name = "United Provinces Army tricorne"
@@ -704,24 +807,9 @@
 	icon_state = "dutch_sailor3"
 	item_state = "dutch_sailor3"
 	worn_state = "dutch_sailor3"
-/////////GENERIC/////////
-/obj/item/clothing/head/red_beret
-	name = "red sailor beret"
-	desc = "A red beret."
-	icon_state = "redberet"
-	item_state = "redberet"
 
-/obj/item/clothing/head/blackberet
-	name = "black beret"
-	desc = "A black military beret."
-	icon_state = "blackberret"
-	item_state = "blackberret"
-
-/obj/item/clothing/head/blue_beret
-	name = "blue sailor beret"
-	desc = "A blue beret."
-	icon_state = "blueberet"
-	item_state = "blueberet"
+//* Colonial Army Clothes*/
+	/* Colonial Army Uniforms*/
 
 /obj/item/clothing/under/generic_officer
 	name = "officer clothes"
@@ -730,77 +818,6 @@
 	item_state = "officer"
 	worn_state = "officer"
 
-/obj/item/clothing/head/tarred_hat
-	name = "tarred hat"
-	desc = "A tarred hat, commonly used by sailors."
-	icon_state = "tarred_hat"
-	item_state = "tarred_hat"
-	flags_inv = BLOCKHEADHAIR
-
-/obj/item/clothing/head/strawhat
-	name = "straw hat"
-	icon_state = "boater_hat"
-	desc = "A straw hat, commonly used by sailors."
-	flags_inv = BLOCKHEADHAIR
-
-/obj/item/clothing/head/tricorne_black
-	name = "black tricorne"
-	desc = "A black tricorne. In fashion."
-	icon_state = "tricorne_black"
-	item_state = "tricorne_black"
-
-/obj/item/clothing/shoes/blackboots1
-	name = "black boots"
-	desc = "Classic black boots."
-	icon_state = "sailorboots1"
-	item_state = "sailorboots1"
-	worn_state = "sailorboots1"
-	force = WEAPON_FORCE_WEAK
-	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 30)
-	item_flags = NOSLIP
-	siemens_coefficient = 0.6
-	cold_protection = FEET
-	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
-/obj/item/clothing/shoes/leatherboots1
-	name = "leather boots"
-	desc = "Classic leather boots."
-	icon_state = "sailorboots2"
-	item_state = "sailorboots2"
-	worn_state = "sailorboots2"
-	force = WEAPON_FORCE_WEAK
-	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 30)
-	item_flags = NOSLIP
-	siemens_coefficient = 0.6
-	cold_protection = FEET
-	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
-
-/obj/item/clothing/shoes/winterboots
-	name = "winter boots"
-	desc = "Classic winter boots."
-	icon_state = "winterboots"
-	item_state = "winterboots"
-	worn_state = "winterboots"
-	force = WEAPON_FORCE_WEAK
-	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 40)
-	item_flags = NOSLIP
-	siemens_coefficient = 0.9
-	cold_protection = FEET
-	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
-
-/obj/item/clothing/shoes/usmc
-	name = "military boots"
-	desc = "Classic tan military boots."
-	icon_state = "usmc"
-	item_state = "usmc"
-	worn_state = "usmc"
-	force = WEAPON_FORCE_WEAK
-	armor = list(melee = 60, arrow = 20, gun = FALSE, energy = 25, bomb = 50, bio = 10, rad = 40)
-	item_flags = NOSLIP
-	siemens_coefficient = 0.7
-	cold_protection = FEET
-	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
-
-/////Army stuff
 /obj/item/clothing/suit/storage/jacket/dutch_officer_army
 	name = "United Provinces Army jacket"
 	desc = "A standard army jacket of the United Provinces Army. Orange with golden buttons."
@@ -857,23 +874,46 @@
 	item_state = "french_army"
 	worn_state = "french_army"
 
-///////////////
+/* Miscallaneous*/
 
-/obj/item/clothing/head/furhat
-	name = "fur hat"
-	desc = "A hat made of fur."
-	icon_state = "furhat_hat"
-	item_state = "furhat_hat"
+//These two seem misplaced, refer to be moved to modern or their own apparel, quiver is wierdly placed too.
+/obj/item/clothing/under/scavfit
+	name = "Ripped outfit"
+	desc = "A set of blue jeans and brown hoodie."
+	icon_state = "scavfit"
+	item_state = "scavfit"
+	worn_state = "scavfit"
 
-/obj/item/clothing/head/furcap
-	name = "fur cap"
-	desc = "A cap made of fur."
-	icon_state = "furcap_hat"
-	item_state = "furcap_hat"
+/obj/item/clothing/under/wastelander
+	name = "outfit"
+	desc = "A set of tan pants and a brown coat."
+	icon_state = "wastelander"
+	item_state = "wastelander"
+	worn_state = "wastelander"
+
+/obj/item/weapon/storage/backpack/quiver
+	name = "quiver"
+	desc = "The best way to carry a bow and arrows."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "quiver"
+	item_state = "quiver"
+
+/obj/item/weapon/storage/backpack/quiver/New()
+		..()
+		can_hold = list(/obj/item/ammo_casing/bolt, /obj/item/ammo_casing/arrow, /obj/item/weapon/gun/projectile/bow, /obj/item/weapon/material/pilum)
+
+/obj/item/weapon/storage/backpack/quiver/full/New()
+	..()
+	can_hold = list(/obj/item/ammo_casing/bolt, /obj/item/ammo_casing/arrow, /obj/item/weapon/gun/projectile/bow, /obj/item/weapon/material/pilum)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
+	new /obj/item/ammo_casing/arrow/bronze(src)
 
 
-/obj/item/clothing/head/roundcap
-	name = "roundcap"
-	desc = "A cap made of leather."
-	icon_state = "roundcap_hat"
-	item_state = "roundcap_hat"

--- a/code/modules/1713/apparel_medieval.dm
+++ b/code/modules/1713/apparel_medieval.dm
@@ -1,3 +1,29 @@
+/*Index*/
+/* * - 1 Medieval Shoes & Boots
+   * - 2 Medieval Gloves & Gauntlets
+   * - 3 Medieval Headpieces
+   * - 4 Medieval Suits
+   * - 5 Medieval Armor
+   * - 6 Medieval Armor Accessories
+   * - 7 Medieval Crowns
+   * - 8 Medieval Helmets
+   * - 9 Medieval Equipment Crates
+   /////////////////////////////////////
+   * - 10 Extra-Cultural Medieval Clothes
+   * - 10a Medieval Mayan
+   /////////////////////////////////////
+   * - 11 Medieval Japanese
+   * - 11a Medieval Japanese Armor
+   * - 11b Medieval Japanese Uniforms
+   * - 11c Medieval Japanese Shoes & Boots
+   * - 11d Medieval Japanese Headpieces & Helmets
+   * - 11e Medieval Japanese Masks
+   /////////////////////////////////////
+   * - Miscallenous Medieval Extra-Cultural Clothes
+   * - Sauron & Orc Cultural Clothes*/
+
+/* Medieval Shoes & Boots*/
+
 /obj/item/clothing/shoes/medieval
 	name = "leather shoes"
 	desc = "A pair of simple, thin leather shoes. Covers up to the ankle."
@@ -8,6 +34,7 @@
 	armor = list(melee = 15, arrow = 10, gun = FALSE, energy = 8, bomb = 15, bio = 10, rad = 10)
 	item_flags = NOSLIP
 	siemens_coefficient = 0.6
+
 /obj/item/clothing/shoes/medieval/arab
 	name = "arabic leather shoes"
 	desc = "A pair of simple, thin leather shoes. Loose at the tip."
@@ -18,7 +45,6 @@
 	armor = list(melee = 10, arrow = 8, gun = FALSE, energy = 6, bomb = 12, bio = 10, rad = 10)
 	item_flags = NOSLIP
 	siemens_coefficient = 0.6
-
 
 /obj/item/clothing/shoes/medieval/knight
 	name = "armored shoes"
@@ -33,6 +59,9 @@
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
 	slowdown = 0.1
 	health = 35
+
+/* Medieval Gloves & Gauntlets*/
+
 /obj/item/clothing/gloves/gauntlets
 	name = "armored gauntlets"
 	desc = "A pair of armored iron gauntlets."
@@ -46,6 +75,83 @@
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
 	slowdown = 0.1
 	health = 23
+
+/* Medieval Headpieces*/
+
+/obj/item/clothing/head/artisan
+	name = "artisan hat"
+	desc = "a large artisan hat."
+	icon_state = "artisan"
+	item_state = "artisan"
+	worn_state = "artisan"
+
+/obj/item/clothing/head/feathered_hat
+	name = "feathered hat"
+	desc = "a feathered hat."
+	icon_state = "feathered_hat"
+	item_state = "feathered_hat"
+	worn_state = "feathered_hat"
+
+/obj/item/clothing/head/noblehat1
+	name = "brown noble hat"
+	icon_state = "noblehat1"
+	item_state = "noblehat1"
+
+/obj/item/clothing/head/noblehat2
+	name = "black noble hat"
+	icon_state = "noblehat2"
+	item_state = "noblehat2"
+
+/obj/item/clothing/head/turban
+	name = "turban"
+	desc = "a colored, light fabric turban."
+	icon_state = "turban1"
+	item_state = "turban1"
+	worn_state = "turban1"
+	heat_protection = HEAD
+/obj/item/clothing/head/turban/New()
+	..()
+	var/pickcolor = pick("turban1", "turban2", "turban3", "turban4")
+	icon_state = pickcolor
+	item_state = pickcolor
+	worn_state = pickcolor
+
+/obj/item/clothing/head/turban/imam
+	name = "white turban"
+	desc = "a simple white turban."
+	icon_state = "turban_w"
+	item_state = "turban_w"
+	worn_state = "turban_w"
+/obj/item/clothing/head/turban/imam/New()
+	..()
+	icon_state = "turban_w"
+	item_state = "turban_w"
+	worn_state = "turban_w"
+
+/obj/item/clothing/head/keffiyeh
+	name = "keffiyeh"
+	desc = "A headdress fashioned from a scarf with a checkered pattern."
+	icon_state = "keffiyeh_black"
+	item_state = "keffiyeh_black"
+	worn_state = "keffiyeh_black"
+	heat_protection = HEAD
+
+/obj/item/clothing/head/keffiyeh/red
+	icon_state = "keffiyeh_red"
+	item_state = "keffiyeh_red"
+	worn_state = "keffiyeh_red"
+
+/*Medieval Suits*/
+
+/obj/item/clothing/suit/storage/jacket/arabic_robe
+	name = "arabic robe"
+	desc = "A light, loose fitting arabic robe."
+	icon_state = "arabw_robe"
+	item_state = "arabw_robe"
+	worn_state = "arabw_robe"
+	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+
+/* Medieval Uniforms*/
 
 /obj/item/clothing/under/medieval
 	name = "white tunic"
@@ -68,20 +174,6 @@
 	item_state = "pontifical"
 	worn_state = "pontifical"
 
-/obj/item/clothing/head/artisan
-	name = "artisan hat"
-	desc = "a large artisan hat."
-	icon_state = "artisan"
-	item_state = "artisan"
-	worn_state = "artisan"
-
-/obj/item/clothing/head/feathered_hat
-	name = "feathered hat"
-	desc = "a feathered hat."
-	icon_state = "feathered_hat"
-	item_state = "feathered_hat"
-	worn_state = "feathered_hat"
-
 /obj/item/clothing/under/medieval/crusader
 	name = "crusader tunic"
 	desc = "A white tunic with a red cross in the middle."
@@ -103,14 +195,12 @@
 	item_state = "yellow_tunic"
 	worn_state = "yellow_tunic"
 
-
 /obj/item/clothing/under/medieval/leather
 	name = "leather tunic"
 	desc = "A light leather tunic."
 	icon_state = "leather_tunic"
 	item_state = "leather_tunic"
 	worn_state = "leather_tunic"
-
 
 /obj/item/clothing/under/medieval/blue
 	name = "blue tunic"
@@ -119,14 +209,12 @@
 	item_state = "blue_tunic"
 	worn_state = "blue_tunic"
 
-
 /obj/item/clothing/under/medieval/blue2
 	name = "blue-white tunic"
 	desc = "A light blue and white tunic."
 	icon_state = "blue_tunic2"
 	item_state = "blue_tunic2"
 	worn_state = "blue_tunic2"
-
 
 /obj/item/clothing/under/medieval/green
 	name = "green tunic"
@@ -142,7 +230,6 @@
 	item_state = "red_tunic"
 	worn_state = "red_tunic"
 
-
 /obj/item/clothing/under/medieval/red2
 	name = "yellow-red tunic"
 	desc = "A light red and yellow tunic."
@@ -156,14 +243,6 @@
 	icon_state = "arabw_tunic"
 	item_state = "arabw_tunic"
 	worn_state = "arabw_tunic"
-	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-
-/obj/item/clothing/suit/storage/jacket/arabic_robe
-	name = "arabic robe"
-	desc = "A light, loose fitting arabic robe."
-	icon_state = "arabw_robe"
-	item_state = "arabw_robe"
-	worn_state = "arabw_robe"
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 
 /obj/item/clothing/under/medieval/lighttunic
@@ -198,28 +277,8 @@
 	worn_state = "arab3"
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 
-/obj/item/clothing/head/helmet/sauronhelm
-	name = "Sauron's Helmet"
-	desc = "The helmet to the armor of Sauron"
-	icon_state = "sauronhelmet"
-	item_state = "sauronhelmet"
-	worn_state = "sauronhelmet"
-	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 80, arrow = 90, gun = 30, energy = 20, bomb = 70, bio = 20, rad = 45)
-	value = 70
-	slowdown = 1
-	health = 90
-/obj/item/clothing/suit/armor/sauronarmor
-	name = "Sauron's Armor"
-	desc = "The armor of Sauron"
-	icon_state = "sauronarmor"
-	item_state = "sauronarmor"
-	worn_state = "sauronarmor"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 95, arrow = 90, gun = 30, energy = 20, bomb = 70, bio = 20, rad = 45)
-	value = 70
-	slowdown = 1
-	health = 90
+/* Medieval Armor*/
+
 /obj/item/clothing/suit/armor/medieval
 	name = "plated armor"
 	desc = "A thick, expensive iron armor, covering most of the body."
@@ -228,30 +287,6 @@
 	worn_state = "knight_simple"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list(melee = 85, arrow = 90, gun = 10, energy = 15, bomb = 60, bio = 20, rad = 45)
-	value = 50
-	slowdown = 1.5
-	health = 60
-
-/obj/item/clothing/suit/armor/darkplate
-	name = "plated armor"
-	desc = "A cheap dark iron armor."
-	icon_state = "ork_plate_elite"
-	item_state = "ork_plate_elite"
-	worn_state = "ork_plate_elite"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 70, arrow = 90, gun = 10, energy = 15, bomb = 60, bio = 20, rad = 45)
-	value = 50
-	slowdown = 1.5
-	health = 60
-
-/obj/item/clothing/suit/armor/darkplateelite
-	name = "plated armor"
-	desc = "A cheap dark iron armor."
-	icon_state = "ork_plate_commander"
-	item_state = "ork_plate_commander"
-	worn_state = "ork_plate_commander"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 80, arrow = 90, gun = 10, energy = 15, bomb = 60, bio = 20, rad = 45)
 	value = 50
 	slowdown = 1.5
 	health = 60
@@ -274,18 +309,21 @@
 	icon_state = "knight_blue"
 	item_state = "knight_blue"
 	worn_state = "knight_blue"
+
 /obj/item/clothing/suit/armor/medieval/red
 	name = "red plated armor"
 	desc = "A thick, expensive iron armor, covering most of the body."
 	icon_state = "knight_red"
 	item_state = "knight_red"
 	worn_state = "knight_red"
+
 /obj/item/clothing/suit/armor/medieval/yellow
 	name = "yellow plated armor"
 	desc = "A thick, expensive iron armor, covering most of the body."
 	icon_state = "knight_yellow"
 	item_state = "knight_yellow"
 	worn_state = "knight_yellow"
+
 /obj/item/clothing/suit/armor/medieval/green
 	name = "green plated armor"
 	desc = "A thick, expensive iron armor, covering most of the body."
@@ -311,6 +349,7 @@
 	value = 25
 	slowdown = 0.7
 	health = 48
+
 /obj/item/clothing/suit/armor/medieval/iron_chestplate
 	name = "iron chestplate"
 	desc = "An iron chestplate."
@@ -322,6 +361,7 @@
 	value = 32
 	slowdown = 0.8
 	health = 52
+
 /obj/item/clothing/suit/armor/medieval/iron_chestplate/red
 	icon_state = "iron_chestplater"
 	item_state = "iron_chestplater"
@@ -331,10 +371,12 @@
 	icon_state = "iron_chestplatec"
 	item_state = "iron_chestplatec"
 	worn_state = "iron_chestplatec"
+
 /obj/item/clothing/suit/armor/medieval/iron_chestplate/blue
 	icon_state = "iron_chestplateb"
 	item_state = "iron_chestplateb"
 	worn_state = "iron_chestplateb"
+
 /obj/item/clothing/suit/armor/medieval/leather
 	name = "leather armor"
 	desc = "Several pressed sheets of leather, making a reasonable armor plate."
@@ -347,6 +389,32 @@
 	flammable = TRUE
 	slowdown = 0.2
 	health = 33
+
+/obj/item/clothing/suit/armor/medieval/hauberk
+	name = "hauberk"
+	desc = "A longer version of the chainmail, worn as a coat. Offers greater protection."
+	icon_state = "hauberk"
+	item_state = "hauberk"
+	worn_state = "hauberk"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	armor = list(melee = 60, arrow = 55, gun = 10, energy = 20, bomb = 40, bio = 30, rad = 15)
+	value = 40
+	slowdown = 0.75
+	health = 60
+
+/obj/item/clothing/suit/armor/medieval/chainmail
+	name = "chainmail"
+	desc = "Wearable armor made of several small interlinked chains."
+	icon_state = "chainmail"
+	item_state = "chainmail"
+	worn_state = "chainmail"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
+	armor = list(melee = 50, arrow = 35, gun = 7, energy = 15, bomb = 30, bio = 20, rad = 10)
+	value = 30
+	slowdown = 0.6
+	health = 50
+
+/*Medieval Armor Accessories*/
 
 /obj/item/clothing/accessory/armor
 	icon = 'icons/obj/clothing/suits.dmi'
@@ -362,18 +430,6 @@
 			mob_overlay = image("icon" = 'icons/mob/suit.dmi', "icon_state" = "[tmp_icon_state]")
 	return mob_overlay
 
-/obj/item/clothing/suit/armor/medieval/chainmail
-	name = "chainmail"
-	desc = "Wearable armor made of several small interlinked chains."
-	icon_state = "chainmail"
-	item_state = "chainmail"
-	worn_state = "chainmail"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	armor = list(melee = 50, arrow = 35, gun = 7, energy = 15, bomb = 30, bio = 20, rad = 10)
-	value = 30
-	slowdown = 0.6
-	health = 50
-
 /obj/item/clothing/accessory/armor/chainmail
 	name = "chainmail"
 	desc = "Wearable armor made of several small interlinked chains."
@@ -386,17 +442,7 @@
 	slowdown = 0.6
 	health = 50
 
-/obj/item/clothing/suit/armor/medieval/hauberk
-	name = "hauberk"
-	desc = "A longer version of the chainmail, worn as a coat. Offers greater protection."
-	icon_state = "hauberk"
-	item_state = "hauberk"
-	worn_state = "hauberk"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 60, arrow = 55, gun = 10, energy = 20, bomb = 40, bio = 30, rad = 15)
-	value = 40
-	slowdown = 0.75
-	health = 60
+/* Medieval Crowns*/
 
 /obj/item/clothing/head/helmet/gold_crown
 	name = "gold crown"
@@ -460,6 +506,8 @@
 			W.amount = W.amount - 1
 			new/obj/item/clothing/head/helmet/gold_crown_diamond(user.loc)
 //continue
+
+/* Medieval Helmets*/
 
 /obj/item/clothing/head/helmet/medieval
 	name = "knight helmet"
@@ -577,6 +625,8 @@
 	item_state = pickcolor
 	worn_state = pickcolor
 
+/* Medieval Equipment Crates*/
+
 /obj/structure/closet/crate/equipment
 	name = "wood crate"
 	icon_state = "wood_crate"
@@ -592,59 +642,10 @@
 				/obj/item/weapon/material/sword/longsword/iron = 1,
 				/obj/item/weapon/shield/iron/semioval = 1,)
 
+/* Extra-Cultural Medieval Clothes*/
 
+	/* Medieval Mayan*/
 
-
-/obj/item/clothing/head/noblehat1
-	name = "brown noble hat"
-	icon_state = "noblehat1"
-	item_state = "noblehat1"
-
-/obj/item/clothing/head/noblehat2
-	name = "black noble hat"
-	icon_state = "noblehat2"
-	item_state = "noblehat2"
-
-/obj/item/clothing/head/turban
-	name = "turban"
-	desc = "a colored, light fabric turban."
-	icon_state = "turban1"
-	item_state = "turban1"
-	worn_state = "turban1"
-	heat_protection = HEAD
-
-/obj/item/clothing/head/turban/imam
-	name = "white turban"
-	desc = "a simple white turban."
-	icon_state = "turban_w"
-	item_state = "turban_w"
-	worn_state = "turban_w"
-/obj/item/clothing/head/turban/imam/New()
-	..()
-	icon_state = "turban_w"
-	item_state = "turban_w"
-	worn_state = "turban_w"
-/obj/item/clothing/head/turban/New()
-	..()
-	var/pickcolor = pick("turban1", "turban2", "turban3", "turban4")
-	icon_state = pickcolor
-	item_state = pickcolor
-	worn_state = pickcolor
-
-/obj/item/clothing/head/keffiyeh
-	name = "keffiyeh"
-	desc = "A headdress fashioned from a scarf with a checkered pattern."
-	icon_state = "keffiyeh_black"
-	item_state = "keffiyeh_black"
-	worn_state = "keffiyeh_black"
-	heat_protection = HEAD
-
-/obj/item/clothing/head/keffiyeh/red
-	icon_state = "keffiyeh_red"
-	item_state = "keffiyeh_red"
-	worn_state = "keffiyeh_red"
-
-//mesoamerican stuff
 /obj/item/clothing/head/mayan_headdress
 	name = "mayan headdress"
 	desc = "a mayan style headdress."
@@ -666,6 +667,9 @@
 	icon_state = "halfhuipil"
 	item_state = "halfhuipil"
 	worn_state = "halfhuipil"
+
+/* Medieval Japanese*/
+	/* Medieval Japanese*/
 
 /obj/item/clothing/suit/armor/samurai
 	name = "samurai armor"
@@ -731,6 +735,8 @@
 	icon_state = "samurai_lord4"
 	item_state = "samurai_lord4"
 	worn_state = "samurai_lord4"
+
+	/* Medieval Japanese Uniforms*/
 
 /obj/item/clothing/under/hanfu
 	name = "dark hanfu"
@@ -816,6 +822,8 @@
 	item_state = "haori_samurai3"
 	worn_state = "haori_samurai3"
 
+	/* Medieval Japanese Shoes & Boots*/
+
 /obj/item/clothing/shoes/geta
 	name = "geta sandals"
 	desc = "A pair of simple, wood sandals. Keeps you elevated off he ground slightly."
@@ -827,6 +835,7 @@
 	item_flags = NOSLIP
 	siemens_coefficient = 0.6
 
+	/* Medieval Japanese Headpieces & Helmets*/
 
 /obj/item/clothing/head/helmet/samurai
 	name = "samurai helmet"
@@ -930,6 +939,8 @@ obj/item/clothing/head/helmet/samurai/black
 	item_state = "samurai4"
 	worn_state = "samurai4"
 
+	/* Medieval Japanese Masks*/
+
 /obj/item/clothing/mask/samurai
 	name = "samurai mask"
 	desc = "A mask of metal, worn by lords to protect their face."
@@ -956,12 +967,64 @@ obj/item/clothing/head/helmet/samurai/black
 	item_state = "samurai3"
 	worn_state = "samurai3"
 
+/* Miscallenous Medieval Extra-Cultural Clothes*/
+
 /obj/item/clothing/head/gat
 	name = "gat hat"
 	desc = "A traditional Korean hat."
 	icon_state = "gat"
 	item_state = "gat"
 	worn_state = "gat"
+
+/* Sauron & Orc Cultural Clothes */
+
+/obj/item/clothing/head/helmet/sauronhelm
+	name = "Sauron's Helmet"
+	desc = "The helmet to the armor of Sauron"
+	icon_state = "sauronhelmet"
+	item_state = "sauronhelmet"
+	worn_state = "sauronhelmet"
+	body_parts_covered = HEAD|FACE|EYES
+	armor = list(melee = 80, arrow = 90, gun = 30, energy = 20, bomb = 70, bio = 20, rad = 45)
+	value = 70
+	slowdown = 1
+	health = 90
+
+/obj/item/clothing/suit/armor/sauronarmor
+	name = "Sauron's Armor"
+	desc = "The armor of Sauron"
+	icon_state = "sauronarmor"
+	item_state = "sauronarmor"
+	worn_state = "sauronarmor"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	armor = list(melee = 95, arrow = 90, gun = 30, energy = 20, bomb = 70, bio = 20, rad = 45)
+	value = 70
+	slowdown = 1
+	health = 90
+
+/obj/item/clothing/suit/armor/darkplate
+	name = "plated armor"
+	desc = "A cheap dark iron armor."
+	icon_state = "ork_plate_elite"
+	item_state = "ork_plate_elite"
+	worn_state = "ork_plate_elite"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	armor = list(melee = 70, arrow = 90, gun = 10, energy = 15, bomb = 60, bio = 20, rad = 45)
+	value = 50
+	slowdown = 1.5
+	health = 60
+
+/obj/item/clothing/suit/armor/darkplateelite
+	name = "plated armor"
+	desc = "A cheap dark iron armor."
+	icon_state = "ork_plate_commander"
+	item_state = "ork_plate_commander"
+	worn_state = "ork_plate_commander"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	armor = list(melee = 80, arrow = 90, gun = 10, energy = 15, bomb = 60, bio = 20, rad = 45)
+	value = 50
+	slowdown = 1.5
+	health = 60
 
 /obj/item/clothing/head/helmet/orc_beserker
 	name = "Orc Beserker Helm"
@@ -1002,6 +1065,7 @@ obj/item/clothing/head/helmet/samurai/black
 	body_parts_covered = HEAD|FACE|EYES
 	force = WEAPON_FORCE_PAINFUL
 	armor = list(melee = 55, arrow = 45, gun = 10, energy = 15, bomb = 60, bio = 30, rad = FALSE)
+
 /obj/item/clothing/head/helmet/orc_captain
 	name = "Orc Captain Helm"
 	desc = "Orc make good helmet!"
@@ -1011,6 +1075,7 @@ obj/item/clothing/head/helmet/samurai/black
 	body_parts_covered = HEAD|FACE|EYES
 	force = WEAPON_FORCE_PAINFUL
 	armor = list(melee = 55, arrow = 45, gun = 10, energy = 15, bomb = 60, bio = 30, rad = FALSE)
+
 /obj/item/clothing/head/helmet/orc_grunt
 	name = "Orc Grunt Helm"
 	desc = "Orc make good helmet!"
@@ -1020,6 +1085,7 @@ obj/item/clothing/head/helmet/samurai/black
 	body_parts_covered = HEAD|FACE
 	force = WEAPON_FORCE_PAINFUL
 	armor = list(melee = 50, arrow = 40, gun = 5, energy = 15, bomb = 50, bio = 20, rad = FALSE)
+
 /obj/item/clothing/suit/armor/ork_urukhai
 	name = "Ork Urukhai Armor"
 	desc = "Orc make good armor!"
@@ -1031,6 +1097,7 @@ obj/item/clothing/head/helmet/samurai/black
 	value = 50
 	slowdown = 1.7
 	health = 50
+
 /obj/item/clothing/suit/armor/ork_whitehand
 	name = "Ork Whitehand Armor"
 	desc = "Orc make good armor!"
@@ -1043,6 +1110,7 @@ obj/item/clothing/head/helmet/samurai/black
 	value = 50
 	slowdown = 1.7
 	health = 50
+
 /obj/item/clothing/suit/armor/ork_grunt
 	name = "Ork Grunt Armor"
 	desc = "Orc make good armor!"

--- a/code/modules/1713/apparel_stoneage.dm
+++ b/code/modules/1713/apparel_stoneage.dm
@@ -1,5 +1,13 @@
+/*Index*/
+/*  * - Stone-Age Uniforms
+    * - Indian-Carib Cultural Clothing
+    * - Indian-Carib Cultural Accessories
+    * - Bone Clothing, Armor & Accessories
+    * - Stone-Age Masks
+    * - Miscallaneous */
 
-/////////indian/prehistoric stuff/////////
+/* Stone-Age Uniforms*/
+
 /obj/item/clothing/under/loinleather
 	name = "leather loincloth"
 	desc = "A wrap of leather cloth, worn around the waist."
@@ -14,6 +22,13 @@
 	item_state = "leatherloincloth[randcloth]"
 	worn_state = "leatherloincloth[randcloth]"
 
+/obj/item/clothing/under/loincotton
+	name = "cotton loincloth"
+	desc = "An wrap of cotton loincloth, worn around the waist."
+	icon_state = "loincloth1"
+	item_state = "loincloth1"
+	worn_state = "loincloth1"
+
 /obj/item/clothing/under/leaves_skirt
 	name = "leaf skirt"
 	desc = "A wrap of leaves, worn around the waist."
@@ -26,6 +41,8 @@
 	icon_state = "leaves_skirt_long"
 	item_state = "leaves_skirt_long"
 	worn_state = "leaves_skirt_long"
+
+/* Indian-Carib Cultural Clothing*/
 
 /obj/item/clothing/under/indian1
 	name = "short leather loincloth"
@@ -48,13 +65,6 @@
 	item_state = "indian3"
 	worn_state = "indian3"
 
-/obj/item/clothing/under/loincotton
-	name = "cotton loincloth"
-	desc = "An wrap of cotton loincloth, worn around the waist."
-	icon_state = "loincloth1"
-	item_state = "loincloth1"
-	worn_state = "loincloth1"
-
 /obj/item/clothing/under/indianchief
 	name = "indian chief clothing"
 	desc = "An elaborate wrap of leather cloth, worn by tribal chiefs."
@@ -69,14 +79,6 @@
 	item_state = "indianshaman"
 	worn_state = "indianshaman"
 
-/obj/item/clothing/suit/storage/jacket/bonearmor
-	name = "bone armor"
-	desc = "A spooky armor, made of human bones."
-	icon_state = "bonearmor"
-	item_state = "bonearmor"
-	worn_state = "bonearmor"
-	armor = list(melee = 50, arrow = 15, gun = 0, energy = 0, bomb = 10, bio = 0, rad = FALSE)
-
 /obj/item/clothing/under/indianhuge
 	name = "big leopard pelt"
 	desc = "A massive leopard pelt."
@@ -84,13 +86,7 @@
 	item_state = "giant_leopard_pelt"
 	worn_state = "giant_leopard_pelt"
 
-/obj/item/clothing/accessory/armband/talisman
-	name = "bone talisman"
-	desc = "A bone talisman."
-	icon_state = "talisman"
-	item_state = "talisman"
-	slot = "decor"
-	var/religion = "none"
+	/* Indian-Carib Cultural Accessories*/
 
 /obj/item/clothing/accessory/armband/indian1
 	name = "indian acessories"
@@ -146,6 +142,34 @@
 	icon_state = "indianbl"
 	item_state = "indianbl"
 
+/* Bone Clothing, Armor & Accessories*/
+
+/obj/item/clothing/suit/storage/jacket/bonearmor
+	name = "bone armor"
+	desc = "A spooky armor, made of assorted bones."
+	icon_state = "bonearmor"
+	item_state = "bonearmor"
+	worn_state = "bonearmor"
+	armor = list(melee = 50, arrow = 15, gun = 0, energy = 0, bomb = 10, bio = 0, rad = FALSE)
+
+/obj/item/clothing/head/helmet/bone
+	name = "bone helmet"
+	desc = "A helmet made of bones."
+	icon_state = "bone_helmet"
+	item_state = "bone_helmet"
+	worn_state = "bone_helmet"
+	armor = list(melee = 25, arrow = 15, gun = 10, energy = 16, bomb = 16, bio = 16, rad = FALSE)
+
+/obj/item/clothing/accessory/armband/talisman
+	name = "bone talisman"
+	desc = "A bone talisman."
+	icon_state = "talisman"
+	item_state = "talisman"
+	slot = "decor"
+	var/religion = "none"
+
+/* Stone-Age Masks*/
+
 /obj/item/clothing/mask/skullmask
 	name = "skull mask"
 	desc = "A skull mask, used by shamans."
@@ -154,6 +178,17 @@
 	body_parts_covered = FACE|EYES
 	armor = list(melee = 25, arrow = 10, gun = 0, energy = 0, bomb = 15, bio = 0, rad = FALSE)
 
+/obj/item/clothing/mask/wooden
+	name = "wooden mask"
+	desc = "A tribal wooden mask."
+	icon_state = "woodenmask"
+	item_state = "woodenmask"
+	body_parts_covered = FACE|EYES
+	armor = list(melee = 15, arrow = 10, gun = 0, energy = 0, bomb = 10, bio = 0, rad = FALSE)
+
+/* Miscallaneous*/
+
+// These three seem misplaced, someone ought to revise the implementation & placement later.
 /obj/item/clothing/mask/iogplate
 	name = "face plate"
 	desc = "A bulletproof face plate. Used to protect your pretty face."
@@ -170,22 +205,6 @@
 	body_parts_covered = FACE|EYES
 	armor = list(melee = 5, arrow = 14, gun = 10, energy = 20, bomb = 10, bio = 10, rad = FALSE)
 
-/obj/item/clothing/head/helmet/bone
-	name = "bone helmet"
-	desc = "A helmet made of bones."
-	icon_state = "bone_helmet"
-	item_state = "bone_helmet"
-	worn_state = "bone_helmet"
-	armor = list(melee = 25, arrow = 15, gun = 10, energy = 16, bomb = 16, bio = 16, rad = FALSE)
-
-/obj/item/clothing/mask/wooden
-	name = "wooden mask"
-	desc = "A tribal wooden mask."
-	icon_state = "woodenmask"
-	item_state = "woodenmask"
-	body_parts_covered = FACE|EYES
-	armor = list(melee = 15, arrow = 10, gun = 0, energy = 0, bomb = 10, bio = 0, rad = FALSE)
-
 /obj/item/clothing/mask/clown
 	name = "clown mask"
 	desc = "A mask used around the world by clowns."
@@ -193,6 +212,8 @@
 	item_state = "clownmask"
 	body_parts_covered = FACE|EYES
 	armor = list(melee = 5, arrow = 5, gun = 1, energy = 0, bomb = 5, bio = 0, rad = FALSE)
+
+/////////////////////////////
 
 /obj/item/clothing/mask/chitinmask
 	name = "chitin mask"
@@ -202,9 +223,9 @@
 	body_parts_covered = FACE|EYES
 	armor = list(melee = 19, arrow = 9, gun = 0, energy = 0, bomb = 12, bio = 0, rad = FALSE)
 
-/obj/item/clothing/head/helmet/chitin
-	name = "gold crown"
-	desc = "A crown of gold. Fancy."
+/obj/item/clothing/head/helmet/chitin // name and description fixed & tidied up.
+	name = "chitin helmet"
+	desc = "A helmet made from insect chitin."
 	icon_state = "chitin_helmet"
 	item_state = "chitin_helmet"
 	worn_state = "chitin_helmet"


### PR DESCRIPTION
Towels now have lower body head protection & are a proper uniform rather than incorrect suit slot object. (A correction to crafting filepath may be in order to spawn them without admin perms)

Both fancy shendyt 1 & 2 have been renamed (pharoahic shendyt, nemes shendyt) and heat protect the upper & lower torso. Custom shendyt's only protect the lower body half. Egyptian headdresses in three colors have also been added, which protect the head, face & eyes from heat & the nemes headdress has also been changed to heat-protect similarly. (There is no Pharoahic headdress, maybe for another day)
>       * Chitin on stone-age apparel & bone armor had some minor description alterations.

>       * Lion pelts are spawnable to wear with perms, still no lions or crafting yet.

>       * No crafting for egyptian headdress such-yet for PR atomization sake.

All files in this PR now have a 'index' for easy readibility and reference to blocks of content, no code changes made to imperial or medieval. Swerved around touching and restructuring Industrial onwards though they do need desperate work to de-spaghettify.

Things are usually gathered together by commonality of culture or object type (like indian-carib unga clothes used in the 'Hunt' mode) or medieval armor/boots/helms etc. Everything compiled fine my end.

>        * Anything anomolous in file will have usually been moved to 'Miscallaneous'