### PR TITLE
Alligator Pelt Crafting & New Leather Recipies

### DIFF
--- a/code/game/objects/items/clothing/shoes/miscellaneous.dm
+++ b/code/game/objects/items/clothing/shoes/miscellaneous.dm
@@ -97,6 +97,11 @@
 	desc = "The height of fashion, and they're pre-polished!"
 	icon_state = "laceups"
 
+/obj/item/clothing/shoes/gator_laceup
+	name = "alligator scale laceup shoes"
+	desc = "The height of luxurious footwear, and they're pre-polished!"
+	icon_state = "gator_laceups"
+
 /obj/item/clothing/shoes/leather
 	name = "leather shoes"
 	desc = "A sturdy pair of leather shoes."

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -1,7 +1,5 @@
 
-/*
- * Backpack
- */
+/* backpack.dm*/
 
 /obj/item/weapon/storage/backpack
 	name = "backpack"
@@ -42,15 +40,21 @@
 	..(user)
 */
 
-/*
- * Satchel Types
- */
+/* Satchels*/
 
 /obj/item/weapon/storage/backpack/satchel
 	name = "leather satchel"
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel"
 	base_icon = "satchel"
+
+/obj/item/weapon/storage/backpack/satchel/gator_satchel
+	name = "alligator scale satchel"
+	desc = "A fashionable satchel lined with exotic alligator scales"
+	icon_state = "gator_satchel"
+	base_icon = "gator_satchel"
+
+/* Backpacks */
 
 /obj/item/weapon/storage/backpack/ww2/jap
 	name = "japanese backpack"
@@ -69,6 +73,13 @@
 	worn_state = "germanpack"
 	base_icon = "germanpack"
 	max_storage_space = 26
+
+/obj/item/weapon/storage/backpack/ww2/german/sapper
+	New()
+		..()
+		new /obj/item/weapon/storage/toolbox/emergency(src)
+		new /obj/item/weapon/storage/toolbox/mechanical(src)
+
 obj/item/weapon/storage/backpack/ww2/american
 	name = "american backpack"
 	desc = "It's a standard issue backpack for american military personel"
@@ -78,18 +89,11 @@ obj/item/weapon/storage/backpack/ww2/american
 	base_icon = "uspack"
 	max_storage_space = 26
 
-/obj/item/weapon/storage/backpack/ww2/german/sapper
-	New()
-		..()
-		new /obj/item/weapon/storage/toolbox/emergency(src)
-		new /obj/item/weapon/storage/toolbox/mechanical(src)
-
 /obj/item/weapon/storage/backpack/scavpack
 	name = "scavenger pack"
 	desc = "A makeshift backpack made of a mix of materials."
 	icon_state = "scavpack"
 	item_state = "scavpack"
-
 
 /obj/item/weapon/storage/backpack/rucksack
 	name = "rucksack"
@@ -102,10 +106,8 @@ obj/item/weapon/storage/backpack/ww2/american
 	max_w_class = 4
 	max_storage_space = 36
 
-
-
 /obj/item/weapon/storage/backpack/civbag
-	name = "Backpack"
+	name = "backpack"
 	desc = "A big backpack made for long walks."
 	icon_state = "civback"
 	item_state = "civback"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -47,6 +47,7 @@
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel"
 	base_icon = "satchel"
+	worn_state = "satchel-norm"
 
 /obj/item/weapon/storage/backpack/satchel/gator_satchel
 	name = "alligator scale satchel"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -116,6 +116,15 @@
 	new /obj/item/stack/farming/seeds/potato(src)
 	new /obj/item/stack/farming/seeds/hemp(src)
 
+/obj/item/weapon/storage/belt/gator_belt //doesn't hold anything
+	name = "alligator scale belt"
+	desc = "A purely decorative alligator scale thin belt. It has no pockets or attachments for items"
+	icon_state = "gator_belt"
+	item_state = "gator_belt"
+	storage_slots = 0
+	max_w_class = 1
+	max_storage_space = 0
+
 /obj/item/weapon/storage/belt/throwing
 	name = "throwing belt"
 	desc = "A belt made specifically to hold throwing weapons.."

--- a/code/modules/1713/apparel_worldwars.dm
+++ b/code/modules/1713/apparel_worldwars.dm
@@ -1383,12 +1383,6 @@ obj/item/clothing/head/ww2/soviet_fieldcap
 	armor = list(melee = 10, arrow = 0, gun = FALSE, energy = 15, bomb = 5, bio = 30, rad = 30)
 	value = 100
 
-/obj/item/weapon/storage/belt/gator_belt //doesn't hold anything thus far.
-	name = "alligator scale belt"
-	desc = "A purely decorative alligator scale thin belt."
-	icon_state = "gator_belt"
-	item_state = "gator_belt"
-
 /obj/item/weapon/storage/belt/gulagguard
 	name = "GULAG guard belt"
 	desc = "A belt that can hold the standard issue gear of GULAG guards."

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -327,6 +327,16 @@
 	value = 2
 	w_class = 2.0
 	flammable = TRUE
+/*
+/obj/item/stack/material/scales/gator_scale  //placeholder for alternative scaly hide crafting
+	name = "alligator scales"
+	desc = "The fine scales of a alligator."
+	icon_state = "sheet-scales"
+	default_type = "alligator scales"
+	value = 2
+	w_class = 2.0
+	flammable = FALSE
+*/
 
 /obj/item/stack/material/pelt
 	name = "animal pelt"
@@ -345,7 +355,6 @@
 	value = 3
 	w_class = 2.0
 	flammable = TRUE
-
 /obj/item/stack/material/pelt/bearpelt/brown
 	name = "brown bear pelt"
 	desc = "A pelt from a skinned bear."
@@ -358,6 +367,7 @@
 	icon_state = "sheet-whitebearpelt"
 	default_type = "whitebearpelt"
 	value = 3
+
 /obj/item/stack/material/pelt/wolfpelt
 	name = "wolf pelt"
 	desc = "A pelt from a skinned wolf."
@@ -366,6 +376,7 @@
 	w_class = 2.0
 	flammable = TRUE
 	value = 3
+
 /obj/item/stack/material/pelt/catpelt
 	name = "cat pelt"
 	desc = "A pelt from a skinned cat."
@@ -391,14 +402,14 @@
 	flammable = TRUE
 	value = 3
 
-/* /obj/item/stack/material/pelt/gator_pelt  //reserved
+/obj/item/stack/material/pelt/gatorpelt
 	name = "gator pelt"
 	desc = "A pelt from a skinned alligator."
 	icon_state = "sheet-gatorpelt"
 	default_type = "gatorpelt"
 	w_class = 2.0
 	flammable = FALSE
-	value = 3 */
+	value = 3
 
 /obj/item/stack/material/pelt/monkeypelt
 	name = "monkey pelt"
@@ -408,6 +419,7 @@
 	w_class = 2.0
 	flammable = TRUE
 	value = 3
+
 /obj/item/stack/material/pelt/foxpelt
 	name = "fox pelt"
 	desc = "A pelt from a skinned fox."
@@ -424,6 +436,7 @@
 	w_class = 2.0
 	flammable = TRUE
 	value = 3
+
 /obj/item/stack/material/pelt/orcpelt
 	name = "Orc Pelt"
 	desc = "The skin of an Orc"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -579,16 +579,16 @@ var/list/name_to_material
 	ignition_point = T0C+300
 	melting_point = T0C+300
 	hardness = 25
-
-/*/material/gator_scale //In preparation, snakes and other reptiles have other sorts.
+/*
+/material/gatorscale // In preparation, snakes and other reptiles have other sorts.
 	name = "alligator scale"
 	icon_colour = "#443d36"
 
 	flags = MATERIAL_PADDING
 	ignition_point = T0C+300
 	melting_point = T0C+300
-	hardness = 25*/
-
+	hardness = 25
+*/
 /material/pelt
 	name = "pelt"
 	use_name = "pelt"
@@ -677,8 +677,8 @@ var/list/name_to_material
 	sheet_plural_name = "pelts"
 	stack_type = /obj/item/stack/material/pelt/lionpelt
 
-/* /material/gatorpelt
-	name = "alligatorpelt"
+/material/gatorpelt
+	name = "alligator pelt"
 	use_name = "alligator"
 	icon_colour = "#443d36"
 	ignition_point = T0C+400
@@ -686,7 +686,7 @@ var/list/name_to_material
 	hardness = 30
 	sheet_singular_name = "pelt"
 	sheet_plural_name = "pelts"
-	stack_type = /obj/item/stack/material/pelt/gatorpelt */
+	stack_type = /obj/item/stack/material/pelt/gatorpelt
 
 /material/monkeypelt
 	name = "monkeypelt"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -610,6 +610,9 @@
 				else if (istype(src, /mob/living/simple_animal/hostile/sabertooth/lion) && !istype(src, /mob/living/simple_animal/hostile/sabertooth/lion/gladiator))
 					var/obj/item/stack/material/pelt/lionpelt/NP = new/obj/item/stack/material/pelt/lionpelt(get_turf(src))
 					NP.amount = 3
+				else if (istype(src, /mob/living/simple_animal/hostile/alligator))
+					var/obj/item/stack/material/pelt/gatorpelt/NP = new/obj/item/stack/material/pelt/gatorpelt(get_turf(src))
+					NP.amount = 3
 				if (istype(user, /mob/living/carbon/human))
 					var/mob/living/carbon/human/HM = user
 					HM.adaptStat("medical", amt/3)

--- a/config/material_recipes.txt
+++ b/config/material_recipes.txt
@@ -23,7 +23,8 @@ RECIPE: /material/leather/,sling,/obj/item/weapon/gun/projectile/bow/sling,3,60,
 RECIPE: /material/leather/,comfy chair,/obj/structure/bed/chair/comfy/brown,6,100,1,1,furniture,25,0,25,8,null
 RECIPE: /material/leather/,bug swatter,/obj/item/weapon/swatter,3,90,0,1,tools,0,0,0,8,null
 RECIPE: /material/leather/,quiver,/obj/item/weapon/storage/backpack/quiver,3,60,0,1,storage,0,0,0,8,null
-RECIPE: /material/leather/,leather satchel,/obj/item/weapon/storage/belt/leather,3,60,0,1,storage,0,0,0,8,null
+RECIPE: /material/leather/,leather belt satchel,/obj/item/weapon/storage/belt/leather,3,60,0,1,storage,0,0,0,8,null
+RECIPE: /material/leather/,leather satchel,/obj/item/weapon/storage/backpack/satchel,3,100,0,1,storage,120,0,125,8,null
 RECIPE: /material/leather/,leather bedroll,/obj/item/weapon/bedroll,4,100,0,1,furniture,0,0,0,8,null
 RECIPE: /material/leather/,leather waterskin,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/waterskin,3,90,0,1,storage,0,0,0,8,null
 RECIPE: /material/leather/,ore collector,/obj/item/weapon/storage/ore_collector,5,100,0,1,storage,0,0,0,8,null
@@ -83,6 +84,11 @@ RECIPE: /material/leather/,riding boots,/obj/item/clothing/shoes/riding2,3,50,0,
 RECIPE: /material/leather/,black leather shoes,/obj/item/clothing/shoes/soldiershoes,2,60,0,1,foot wear,55,0,25,8,null
 RECIPE: /material/leather/,black leather boots,/obj/item/clothing/shoes/blackboots1,3,80,0,1,foot wear,55,0,25,8,null
 RECIPE: /material/leather/,leather boots,/obj/item/clothing/shoes/leatherboots1,3,80,0,1,foot wear,55,0,25,8,null
+RECIPE: /material/leather/,work boots,/obj/item/clothing/shoes/workboots,4,80,0,1,foot wear,120,0,112,8,null
+RECIPE: /material/leather/,laceup shoes,/obj/item/clothing/shoes/laceup,3,60,0,1,foot wear,112,0,112,8,null
+RECIPE: /material/leather/,plain leather shoes,/obj/item/clothing/shoes/leather,3,60,0,1,foot wear,112,0,112,8,null
+RECIPE: /material/leather/,biker jacket,/obj/item/clothing/suit/storage/coat/ww2/biker,6,110,0,1,jackets & vests,150,0,175,8,null
+RECIPE: /material/leather/,80's jacket,/obj/item/clothing/suit/storage/coat/oldyjacket,6,110,0,1,jackets & vests,185,0,175,7,null
 RECIPE: /material/leather/,whip,/obj/item/weapon/melee/classic_baton/whip,4,100,0,1,weapons,0,38,0,8,null
 RECIPE: /material/leather/,leather curtain,/obj/structure/curtain/leather,1,80,1,1,furniture,0,0,0,8,null
 
@@ -179,7 +185,6 @@ RECIPE: /material/woolcloth/,brown bomber's jacket,/obj/item/clothing/suit/stora
 RECIPE: /material/woolcloth/,black bomber's jacket,/obj/item/clothing/suit/storage/coat/ww2/bomberjacketblack,4,70,0,1,jackets & vests,0,0,109,8,null
 RECIPE: /material/woolcloth/,service jacket,/obj/item/clothing/suit/storage/coat/ww2/servicejacket,3,70,0,1,jackets & vests,0,0,109,8,null
 RECIPE: /material/woolcloth/,modern coat,/obj/item/clothing/suit/storage/coat/ww2/moderncoat,4,70,0,1,jackets & vests,0,0,109,8,null
-
 
 RECIPE: /material/cloth/,customizable armband,/obj/item/clothing/accessory/custom/armband,1,30,0,1,accessories,0,0,0,8,null
 RECIPE: /material/cloth/,customizable sash,/obj/item/clothing/accessory/custom/sash,1,30,0,1,accessories,0,0,0,8,null
@@ -433,6 +438,15 @@ RECIPE: /material/catpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather,3,
 RECIPE: /material/pantherpelt/,panther pelt headcover,/obj/item/clothing/head/pantherpelt,3,150,0,1,none,0,0,0,8,null
 
 RECIPE: /material/lionpelt/,lion pelt headcover,/obj/item/clothing/head/lionpelt,3,150,0,1,none,0,0,0,8,null
+
+RECIPE: /material/pelt/gatorpelt/,alligator pelt headcover,/obj/item/clothing/head/gatorpelt,3,150,0,1,none,0,0,0,8,null
+RECIPE: /material/pelt/gatorpelt/,alligator scale armor,/obj/item/clothing/suit/armor/ancient/gator_scale_armor,9,100,0,1,none,0,18,18,2,null
+RECIPE: /material/pelt/gatorpelt/,alligator scale belt,/obj/item/weapon/storage/belt/gator_belt,3,80,0,1,none,0,0,98,7,null
+RECIPE: /material/pelt/gatorpelt/,alliator scale wallet,/obj/item/clothing/accessory/storage/coinpouch/gator_wallet,2,60,0,1,storage,87,0,0,8,null
+RECIPE: /material/pelt/gatorpelt/,alligator scale satchel,/obj/item/weapon/storage/backpack/satchel/gator_satchel,3,100,0,1,storage,120,0,125,8,null
+RECIPE: /material/pelt/gatorpelt/,alligator scale riding boots,/obj/item/clothing/shoes/riding1/gator_cowboy,3,60,0,1,foot wear,0,0,98,4,null
+RECIPE: /material/pelt/gatorpelt/,alligator scale ankle boots,/obj/item/clothing/shoes/gator_ankleboots,3,60,0,1,foot wear,0,0,98,7,null
+RECIPE: /material/pelt/gatorpelt/,alligator scale laceup shoes,/obj/item/clothing/shoes/gator_laceup,3,60,0,1,foot wear,112,0,112,8,null
 
 RECIPE: /material/monkeypelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
 RECIPE: /material/monkeypelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null

--- a/config/material_recipes.txt
+++ b/config/material_recipes.txt
@@ -442,8 +442,9 @@ RECIPE: /material/lionpelt/,lion pelt headcover,/obj/item/clothing/head/lionpelt
 RECIPE: /material/pelt/gatorpelt/,alligator pelt headcover,/obj/item/clothing/head/gatorpelt,3,150,0,1,none,0,0,0,8,null
 RECIPE: /material/pelt/gatorpelt/,alligator scale armor,/obj/item/clothing/suit/armor/ancient/gator_scale_armor,9,100,0,1,none,0,18,18,2,null
 RECIPE: /material/pelt/gatorpelt/,alligator scale belt,/obj/item/weapon/storage/belt/gator_belt,3,80,0,1,none,0,0,98,7,null
+RECIPE: /material/leather/,biker jacket,/obj/item/clothing/suit/storage/coat/ww2/biker/gator_jacket,6,110,0,1,jackets & vests,150,0,175,8,null
 RECIPE: /material/pelt/gatorpelt/,alliator scale wallet,/obj/item/clothing/accessory/storage/coinpouch/gator_wallet,2,60,0,1,storage,87,0,0,8,null
-RECIPE: /material/pelt/gatorpelt/,alligator scale satchel,/obj/item/weapon/storage/backpack/satchel/gator_satchel,3,100,0,1,storage,120,0,125,8,null
+RECIPE: /material/pelt/gatorpelt/,alligator scale satchel,/obj/item/weapon/storage/backpack/satchel/gator_satchel,5,100,0,1,storage,120,0,125,8,null
 RECIPE: /material/pelt/gatorpelt/,alligator scale riding boots,/obj/item/clothing/shoes/riding1/gator_cowboy,3,60,0,1,foot wear,0,0,98,4,null
 RECIPE: /material/pelt/gatorpelt/,alligator scale ankle boots,/obj/item/clothing/shoes/gator_ankleboots,3,60,0,1,foot wear,0,0,98,7,null
 RECIPE: /material/pelt/gatorpelt/,alligator scale laceup shoes,/obj/item/clothing/shoes/gator_laceup,3,60,0,1,foot wear,112,0,112,8,null

--- a/config/recipes_info.txt
+++ b/config/recipes_info.txt
@@ -17,6 +17,12 @@
 format:
 material, name, path, cost, building time, only one per turf?, on the floor?, category, research 1 needed, research 2 needed, research 3 needed, max ordinal age (inclusive), material name (optional - use null if not necessary)
 
+// Research //
+
+1 - Industrial
+2 - Military
+3 - Medicine
+
 // HERES THE GODDAMN ORDINAL AGES//
 0 stone age
 1 bronze


### PR DESCRIPTION
The objects previously added are now craftable, including some new additions to later eras for leather objects.  Alligators drop 3 gator pelts when skinned.

>                 New leather items
- Biker Jackets: availible by the time of WW2, always remains cool and craftable even to modern times
- 80's jackets: these jackets are now craftable during the cold war period, and go out of fashion before modern. Gives people IC justification to call you a ``boomer``
- Work boots: early modern attire for protecting your feet onwards through time
- Laceup shoes:  late industrial shoes for all modern periods afterwards
- Leather shoes (plain contempoary shoes) similar to laceup
- Satchel: a modern and civilized earlymodern storage space, mechanically no different to a leather backpack
>                Gator Items
- Gator scale armor: a armor accessible in the copper age, becomes redundant by medieval, requires three whole dead alligators to craft so you were most certainly tough enough anyway.
- Gator wallet: a scaly wallet for keeping your belongings in... fashionably
- Gator jacket: a scaly version of the biker jacket
- Gator laceup shoes: comfortable & stylish
- Gator riding boots: fashionable boots for industrial varmints
- Gator ankle boots: these stood the test of time and dont go out of style until the cold war
- Gator belt: purely for decoration, has no storage slots
- Gator headdress: toothy!
- Gator satchel: for making a statement about your disdain for contempoary wildlife conservation efforts.