### PR TITLE
M15 Adrian + Varients and M1 + Varients coded in

### DIFF
--- a/code/game/objects/structures/blacksmithing.dm
+++ b/code/game/objects/structures/blacksmithing.dm
@@ -860,9 +860,9 @@ obj/structure/anvil/New()
 			else if (map.ordinal_age == 8)
 				display4 = list("Scrap Armor (16)", "Scrap Helmet (15)", "Cancel")
 			else if (map.ordinal_age == 6)
-				display4 = list("Brodie (10)", "Stahlhelm (10)","Type 92 Helmet (10)", "Soviet Helmet (10)", "Cancel")
+				display4 = list("Brodie (10)", "Stahlhelm (10)","Type 92 Helmet (10)", "Soviet Helmet (10)", "M1 Helmet (10)", "Cancel")
 			else if (map.ordinal_age == 5)
-				display4 = list("Pickelhaube (7)","MesH Pickelhaube (7)", "Pith (7)", "Brodie (10)", "Stahlhelm (10)", "Cancel")
+				display4 = list("Pickelhaube (7)","MesH Pickelhaube (7)", "Pith (7)", "Brodie (10)", "Stahlhelm (10)", "M15 Adrian Helmet (10)", "Cancel")
 			else if (map.ordinal_age == 2)
 				if (H.orc)
 					display4 = list("Grunt Armor (10)", "Urukhai Armor (12)", "Grunt Helmet (10)", "Spearman Helmet (12)", "Berserker Helmet (15)", "Cancel")
@@ -1213,9 +1213,7 @@ obj/structure/anvil/New()
 							icon_state = "anvil1"
 						new/obj/item/clothing/head/helmet/modern/stahlhelm(user.loc)
 						return
-				else
-					user << "<span class='notice'>You need more iron to make this!</span>"
-					return
+
 
 			if (choice4 == "Type 92 Helmet (10)")
 				if (iron_amt >= 10)
@@ -1227,6 +1225,22 @@ obj/structure/anvil/New()
 						if (iron_amt <= 0)
 							icon_state = "anvil1"
 						new/obj/item/clothing/head/helmet/ww2/japhelm(user.loc)
+						return
+				else
+					user << "<span class='notice'>You need more iron to make this!</span>"
+					return
+
+
+			if (choice4 == "M1 Helmet (10)")
+				if (iron_amt >= 10)
+					user << "You begin crafting the M1..."
+					playsound(loc, 'sound/effects/clang.ogg', 100, TRUE)
+					if (do_after(user,150,src) && iron_amt >= 7)
+						user << "You craft the M1."
+						iron_amt -= 10
+						if (iron_amt <= 0)
+							icon_state = "anvil1"
+						new/obj/item/clothing/head/helmet/ww2/usm1(user.loc)
 						return
 				else
 					user << "<span class='notice'>You need more iron to make this!</span>"
@@ -1247,7 +1261,7 @@ obj/structure/anvil/New()
 					user << "<span class='notice'>You need more iron to make this!</span>"
 					return
 
-			if (choice4 == "Brodie (9)")
+			if (choice4 == "Brodie (10)")
 				if (iron_amt >= 9)
 					user << "You begin crafting the brodie..."
 					playsound(loc, 'sound/effects/clang.ogg', 100, TRUE)
@@ -1426,6 +1440,46 @@ obj/structure/anvil/New()
 				else
 					user << "<span class='notice'>You need more iron to make this!</span>"
 					return
+
+
+			if (choice4 == "M15 Adrian Helmet (10)")
+				var/list/display5 = list("Cancel")
+				if (iron_amt >= 10)
+					display5 = list("Standard M15 Adrian (10)", "Russian M15 Adrian (10)", "Cancel")
+				var/choice5 = WWinput(user, "Which varient?", "Blacksmith - [iron_amt] iron", "Cancel", display5)
+				if (choice5 == "Standard M15 Adrian (10)")
+					if (iron_amt >= 10)
+						user << "You begin crafting the M15 Adrian..."
+						playsound(loc, 'sound/effects/clang.ogg', 100, TRUE)
+						if (do_after(user,150,src) && iron_amt >= 7)
+							user << "You craft the M15 Adrian."
+							iron_amt -= 10
+							if (iron_amt <= 0)
+								icon_state = "anvil1"
+							new/obj/item/clothing/head/helmet/ww/adrian(user.loc)
+							return
+					else
+						user << "<span class='notice'>You need more iron to make this!</span>"
+						return
+
+				if (choice5 == "Russian M15 Adrian (10)")
+					if (iron_amt >= 10)
+						user << "You begin crafting the M15 Adrian..."
+						playsound(loc, 'sound/effects/clang.ogg', 100, TRUE)
+						if (do_after(user,150,src) && iron_amt >= 7)
+							user << "You craft the M15 Adrian."
+							iron_amt -= 10
+							if (iron_amt <= 0)
+								icon_state = "anvil1"
+							new/obj/item/clothing/head/helmet/ww/adriansoviet(user.loc)
+							return
+					else
+						user << "<span class='notice'>You need more iron to make this!</span>"
+						return
+
+					if (choice5 == "Cancel")
+						return
+
 
 	else if (iron_amt <= 0 || steel_amt <= 0)
 		user << "There is no hot iron or steel on top of this anvil. Smite some first."

--- a/code/modules/1713/apparel_worldwars.dm
+++ b/code/modules/1713/apparel_worldwars.dm
@@ -67,14 +67,78 @@
 	armor = list(melee = 45, arrow = 35, gun = 10, energy = 15, bomb = 45, bio = 20, rad = FALSE)
 
 /obj/item/clothing/head/helmet/ww/adrian
-	name = "Adrian helmet"
+	name = "M15 Adrian helmet"
 	desc = "A typical french adrian helmet."
-	icon_state = "adrian"
-	item_state = "adrian"
-	worn_state = "adrian"
+	icon_state = "adrian_standard"
+	item_state = "adrian_standard"
+	worn_state = "adrian_standard"
 	body_parts_covered = HEAD
 	flags_inv = BLOCKHEADHAIR
 	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
+	var/strap = FALSE
+
+/obj/item/clothing/head/helmet/ww/adrian/verb/toggle_strap()
+	set category = null
+	set src in usr
+	set name = "Toggle Strap"
+	if (strap)
+		icon_state = "adrian_standard"
+		item_state = "adrian_standard"
+		worn_state = "adrian_standard"
+		body_parts_covered = HEAD
+		item_state_slots["slot_wear_head"] = "adrian_standard"
+		usr << "<span class = 'danger'>You put down your helmets strap.</span>"
+		update_icon()
+		strap = FALSE
+		usr.update_inv_head(1)
+	else if (!strap)
+		icon_state = "adrian_standard_strap"
+		item_state = "adrian_standard_strap"
+		worn_state = "adrian_standard_strap"
+		body_parts_covered = HEAD
+		item_state_slots["slot_wear_head"] = "adrian_standard_strap"
+		usr << "<span class = 'danger'>You put up your helmets strap.</span>"
+		update_icon()
+		strap = TRUE
+		usr.update_inv_head(1)
+
+/obj/item/clothing/head/helmet/ww/adriansoviet
+	name = "Russian M15 Adrian helmet"
+	desc = "The adrian helmet but soviet, used by the red army"
+	icon_state = "adrian_russian"
+	item_state = "adrian_russian"
+	worn_state = "adrian_russian"
+	body_parts_covered = HEAD
+	flags_inv = BLOCKHEADHAIR
+	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
+	var/strap = FALSE
+
+/obj/item/clothing/head/helmet/ww/adriansoviet/verb/toggle_strap()
+	set category = null
+	set src in usr
+	set name = "Toggle Strap"
+	if (strap)
+		icon_state = "adrian_russian"
+		item_state = "adrian_russian"
+		worn_state = "adrian_russian"
+		body_parts_covered = HEAD
+		item_state_slots["slot_wear_head"] = "adrian_standard"
+		usr << "<span class = 'danger'>You put down your helmets strap.</span>"
+		update_icon()
+		strap = FALSE
+		usr.update_inv_head(1)
+	else if (!strap)
+		icon_state = "adrian_russian_strap"
+		item_state = "adrian_russian_strap"
+		worn_state = "adrian_russian_strap"
+		body_parts_covered = HEAD
+		item_state_slots["slot_wear_head"] = "adrian_standard_strap"
+		usr << "<span class = 'danger'>You put up your helmets strap.</span>"
+		update_icon()
+		strap = TRUE
+		usr.update_inv_head(1)
 
 /obj/item/clothing/head/helmet/ww/brodie
 	name = "Brodie helmet"
@@ -1166,52 +1230,138 @@ obj/item/clothing/head/ww2/soviet_fieldcap
 		item_state_slots["sovhelm_winter"] = "sovhelm_winter"
 
 
-/obj/item/clothing/head/helmet/ww2/us
-	name = "american helmet"
+/obj/item/clothing/head/helmet/ww2/usm1
+	name = "M1 Helmet"
 	desc = "The typical rounded steel helmet of the US Army."
-	icon_state = "ushelmet"
-	item_state = "ushelmet"
-	worn_state = "ushelmet"
+	icon_state = "m1_standard"
+	item_state = "m1_standard"
+	worn_state = "m1_standard"
 	body_parts_covered = HEAD
 	flags_inv = BLOCKHEADHAIR
 	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
+/obj/item/clothing/head/helmet/ww2/usm1/attackby(obj/item/W as obj, mob/user as mob)
+	if (!istype(W)) return//I really don't understand why this check is needed
+	if (istype(W, /obj/item/stack/material/rope))
+		playsound(loc, 'sound/machines/click.ogg', 75, TRUE)
+		user << "<span class='notice'>You put netting on the helmet.</span>"
+		new/obj/item/clothing/head/helmet/ww2/ustannet(user.loc)
+		qdel(src)
+		qdel(W)
+
+/obj/item/clothing/head/helmet/ww2/ustannet/verb/toggle_color()
+	set category = null
+	set src in usr
+	set name = "Toggle Color"
+	if (color)
+		icon_state = "m1_tan_netting"
+		item_state = "m1_tan_netting"
+		worn_state = "m1_tan_netting"
+		body_parts_covered = HEAD
+		item_state_slots["slot_wear_head"] = "m1_tan_netting"
+		usr << "<span class = 'danger'>You switch out your tan netting for green netting.</span>"
+		update_icon()
+		color = FALSE
+		usr.update_inv_head(1)
+	else if (!color)
+		icon_state = "m1_green_netting"
+		item_state = "m1_green_netting"
+		worn_state = "m1_green_netting"
+		body_parts_covered = HEAD
+		item_state_slots["slot_wear_head"] = "m1_green_netting"
+		usr << "<span class = 'danger'>You switch out your green netting for tan netting.</span>"
+		update_icon()
+		color = TRUE
+		usr.update_inv_head(1)
+
+/obj/item/clothing/head/helmet/ww2/usgreennet
+	name = "M1 Helmet with green netting"
+	desc = "The typical rounded steel helmet of the US Army, with green netting."
+	icon_state = "m1_green_netting"
+	item_state = "m1_green_netting"
+	worn_state = "m1_green_netting"
+	body_parts_covered = HEAD
+	flags_inv = BLOCKHEADHAIR
+	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
+/obj/item/clothing/head/helmet/ww2/ustannet
+	name = "M1 Helmet with netting"
+	desc = "The typical rounded steel helmet of the US Army, with tan netting."
+	icon_state = "m1_tan_netting"
+	item_state = "m1_tan_netting"
+	worn_state = "m1_tan_netting"
+	body_parts_covered = HEAD
+	flags_inv = BLOCKHEADHAIR
+	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
+/obj/item/clothing/head/helmet/ww2/us_chaplain
+	name = "M1 Chaplain Helmet"
+	desc = "The typical rounded steel helmet of the US Army, this one brandishing a cross."
+	icon_state = "m1_chaplain"
+	item_state = "m1_chaplain"
+	worn_state = "m1_chaplain"
+	body_parts_covered = HEAD
+	flags_inv = BLOCKHEADHAIR
+	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
+
+/obj/item/clothing/head/helmet/ww2/usm1mpblack
+	name = "Black M1 MP Helmet"
+	desc = "The typical rounded steel helmet of the US Army, this one for Military Police."
+	icon_state = "m1_mp_black"
+	item_state = "m1_mp_black"
+	worn_state = "m1_mp_black"
+	body_parts_covered = HEAD
+	flags_inv = BLOCKHEADHAIR
+	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
+/obj/item/clothing/head/helmet/ww2/usm1mpgreen
+	name = "M1 MP Helmet"
+	desc = "The typical rounded steel helmet of the US Army, this one for Military Police."
+	icon_state = "m1_mp_green"
+	item_state = "m1_mp_green"
+	worn_state = "m1_mp_green"
+	body_parts_covered = HEAD
+	flags_inv = BLOCKHEADHAIR
+	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
+
 
 /obj/item/clothing/head/helmet/ww2/us_medic
-	name = "american medic helmet"
-	desc = "The typical rounded steel helmet of the US Army, this one bearing a medic symbol."
-	icon_state = "ushelmet_medical"
-	item_state = "ushelmet_medical"
-	worn_state = "ushelmet_medical"
+	name = "M1 Medic Helmet"
+	desc = "The typical rounded steel helmet of the US Army, this one for medics"
+	icon_state = "m1_medic"
+	item_state = "m1_medic"
+	worn_state = "m1_medic"
 	body_parts_covered = HEAD
 	flags_inv = BLOCKHEADHAIR
 	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
 
-/obj/item/clothing/head/helmet/ww2/us_sgt
-	name = "american sergeant helmet"
-	desc = "The typical rounded steel helmet of the US Army, this one bearing the rank of Sergeant."
-	icon_state = "ushelmet_sgt"
-	item_state = "ushelmet_sgt"
-	worn_state = "ushelmet_sgt"
+/obj/item/clothing/head/helmet/ww2/us_2lt
+	name = "M1 2nd LT Helmet"
+	desc = "The typical rounded steel helmet of the US Army, this one bearing the rank of 2nd Lieutenant."
+	icon_state = "m1_2nd_lt"
+	item_state = "m1_2nd_lt"
+	worn_state = "m1_2nd_lt"
 	body_parts_covered = HEAD
 	flags_inv = BLOCKHEADHAIR
 	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
 
-/obj/item/clothing/head/helmet/ww2/us_lt
-	name = "american lieutenant helmet"
-	desc = "The typical rounded steel helmet of the US Army, this one bearing the rank of Lieutenant."
-	icon_state = "ushelmet_lt"
-	item_state = "ushelmet_lt"
-	worn_state = "ushelmet_lt"
+/obj/item/clothing/head/helmet/ww2/us_1lt
+	name = "M1 1st LT Helmet"
+	desc = "The typical rounded steel helmet of the US Army, this one bearing the rank of 1st Lieutenant."
+	icon_state = "m1_1st_lt"
+	item_state = "m1_1st_lt"
+	worn_state = "m1_1st_lt"
 	body_parts_covered = HEAD
 	flags_inv = BLOCKHEADHAIR
 	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)
 
 /obj/item/clothing/head/helmet/ww2/us_cap
-	name = "american captain helmet"
+	name = "M1 Captain Helmet"
 	desc = "The typical rounded steel helmet of the US Army, this one bearing the rank of Captain."
-	icon_state = "ushelmet_cap"
-	item_state = "ushelmet_cap"
-	worn_state = "ushelmet_cap"
+	icon_state = "m1_cpt"
+	item_state = "m1_cpt"
+	worn_state = "m1_cpt"
 	body_parts_covered = HEAD
 	flags_inv = BLOCKHEADHAIR
 	armor = list(melee = 40, arrow = 30, gun = 10, energy = 15, bomb = 40, bio = 20, rad = FALSE)

--- a/code/modules/1713/jobs/american.dm
+++ b/code/modules/1713/jobs/american.dm
@@ -63,7 +63,7 @@
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/us(H), slot_w_uniform)
 //head
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/us_lt(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/us_1lt(H), slot_head)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/thompson(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/m1911(H), slot_l_hand)
 	var/obj/item/clothing/under/uniform = H.w_uniform
@@ -105,7 +105,7 @@
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/us(H), slot_w_uniform)
 //head
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/us_sgt(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/us_2lt(H), slot_head)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/thompson(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/us_ww2_sgt(H), slot_belt)
@@ -232,7 +232,7 @@
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/us(H), slot_w_uniform)
 //head
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/us(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/usm1(H), slot_head)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/springfield/sniper, slot_shoulder)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/us_ww2_sniper(H), slot_belt)
@@ -271,7 +271,7 @@
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/us(H), slot_w_uniform)
 //head
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/us(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/usm1(H), slot_head)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/bar(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/us_ww2_gunner(H), slot_belt)
@@ -312,7 +312,7 @@
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/us(H), slot_w_uniform)
 //head
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/us(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/usm1(H), slot_head)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/m1garand(H), slot_shoulder)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/us_ww2(H), slot_belt)

--- a/code/modules/1713/vending.dm
+++ b/code/modules/1713/vending.dm
@@ -184,7 +184,7 @@
 		/obj/item/clothing/shoes/jackboots = 15,
 		/obj/item/clothing/under/ww2/us = 15,
 		/obj/item/clothing/under/ww2/us_shirtless = 15,
-		/obj/item/clothing/head/helmet/ww2/us = 15,
+		/obj/item/clothing/head/helmet/ww2/usm1 = 15,
 		/obj/item/stack/medical/bruise_pack/bint = 10,
 		/obj/item/weapon/shovel/trench = 10,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen/full = 30,


### PR DESCRIPTION
Coded in M1 Helmet varients
-M1 Standard
-M1 Netted (tan and green)
-M1 Military Police (black and green)
-M1 with rank (1st Lt, 2nd Lt, Captain)
-M1 Medic
-M1 Chaplain

*M1 Standard and M1 Netted available
 to player
-M1 Helmet in anvil
-Netted M1 made when adding rope to regular M1 (Color switch by right click)

*Rest of M1 Helmets admin spawn only (subject to change)

Coded in Adrian Helmet varients
-M15 Adrian (strap up and strap down)
-Russian M15 Adrian (strap up strap down)

*Both craftable in anvil
*Toggle strap by right click

-Replaced Adrian and M1 Helmets in apparel vendors for respective nations