### PR TITLE
Stone brick & Ornate Marble fixes.

### DIFF
--- a/code/game/objects/covers.dm
+++ b/code/game/objects/covers.dm
@@ -199,7 +199,7 @@
 	buildstack = /obj/item/stack/material/stone
 
 /obj/covers/ornatemarblefloor
-	name = "marble floor"
+	name = "ornate marble floor"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "ornate_marble"
 	passable = TRUE
@@ -1759,10 +1759,11 @@
 /obj/covers/stone_wall/brick
 	name = "stone brick wall"
 	desc = "A stone brick wall."
-	icon_state = "stone_brickwall0"
-	base_icon_state = "stone_brickwall"
+	icon_state = "new_stonebrick0"
+	base_icon_state = "new_stonebrick"
 	adjusts = TRUE
 	health = 550
+	buildstack = /obj/item/stack/material/stonebrick
 
 /obj/covers/stone_wall/fortress
 	name = "fortress brick wall"
@@ -1772,3 +1773,4 @@
 	adjusts = TRUE
 	health = 650
 	explosion_resistance = 7
+	buildstack = /obj/item/stack/material/stonebrick

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -409,7 +409,8 @@ var/list/name_to_material
 	door_icon_base = "stone"
 
 /material/stonebrick
-	name = "stone brick"
+	name = "stonebrick"
+	display_name = "stone brick"
 	hardness = 50
 	weight = 11
 	integrity = 450

--- a/config/material_recipes.txt
+++ b/config/material_recipes.txt
@@ -539,7 +539,7 @@ RECIPE: /material/stone/,cobblestone floor,/obj/covers/cobblestone,1,25,1,1,floo
 RECIPE: /material/stone/,slate floor,/obj/covers/slatefloor,1,25,1,1,floors,25,0,0,8,null
 RECIPE: /material/stone/,roman road,/obj/covers/romanroad,1,25,1,1,floors,20,0,0,8,null
 RECIPE: /material/stone/,marble floor,/obj/covers/marblefloor,1,25,1,1,floors,32,0,0,8,null
-RECIPE: /material/stone/,ornate marble tile,/obj/covers/marblefloor,1,25,1,1,floors,32,0,0,8,null
+RECIPE: /material/stone/,ornate marble tile,/obj/covers/ornatemarblefloor,1,25,1,1,floors,32,0,0,8,null
 RECIPE: /material/stone/,road,/obj/covers/road,1,25,1,1,floors,100,0,0,8,null
 RECIPE: /material/stone/,sidewalk,/obj/covers/sidewalk,1,25,1,1,floors,100,0,0,8,null
 
@@ -568,7 +568,7 @@ RECIPE: /material/stone/,stone projectile (x2),/obj/item/stack/ammopart/stonebal
 
 RECIPE: /material/stone/,stone bricks,/obj/item/stack/material/stonebrick,1,25,1,1,none,35,0,0,8,null
 RECIPE: /material/stonebrick/,stone brick wall,/obj/covers/stone_wall/brick,6,140,1,1,none,35,0,0,8,null
-RECIPE: /material/stonebrick/,stone brick floor,/obj/covers/stonebrickfloor,1,25,1,1,none,18,0,0,8,null
+RECIPE: /material/stonebrick/,stone brick floor,/obj/covers/stonebrickfloor,1,25,1,1,none,35,0,0,8,null
 
 RECIPE: /material/stone/,stone wall,/obj/covers/stone_wall,8,140,1,1,construction,0,0,0,2,null
 RECIPE: /material/stone/,stone block wall,/obj/covers/stone_wall/classic,8,140,1,1,construction,0,0,0,2,null


### PR DESCRIPTION
>          Ornate Marble
- Fixes ornate marble - now actually places down and distinguishes itself from regular marble.

>       Stone bricks
- Through some code changes and fixes, stone bricks are now confirmed to be working and have the correct stone brick wall & stone brick floor sprites & related turfs/objects.
- Stone bricks are now the sole repair item for stone brick walls, & fortress walls.
- To clarify stone bricks are availible by medieval era, under no category, playtesting suggests the typical place would be above 'fortifications'. You would still need to use stone bricks if you were going to construct (by using stone first and bricks in the other hand) and keep up maintenance on midgame fortress walls.