### PR TITLE
Stack duplication fix, minor improvements and grammatical fixes

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -24,6 +24,7 @@
 	var/customcolor2 = "FFFFFF"
 	var/customcode = "0000"
 	var/customname = ""
+
 /obj/item/stack/New(var/loc, var/_amount=0, var/merge = TRUE)
 	..()
 	if (!stacktype)
@@ -132,18 +133,6 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 			qdel(src)
 		return S
 	return FALSE
-
-/obj/item/stack/proc/add_to_stacks(mob/user as mob)
-	for (var/obj/item/stack/item in user.loc)
-		if (item==src)
-			continue
-		var/transfer = transfer_to(item)
-		if (transfer)
-			user << "<span class='notice'>You add a new [item.singular_name] to the stack. It now contains [item.amount] [item.singular_name]\s.</span>"
-			item.update_icon()
-			src.update_icon() //funcionou
-		if (!amount)
-			break
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
@@ -1855,11 +1844,6 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 			qdel(O)
 			return
 
-		else if (istype(O, /obj/item/stack))
-			var/obj/item/stack/S = O
-			S.amount = produced
-			S.add_to_stacks(user)
-			S.update_icon()
 		else if (recipe.result_type == /obj/item/weapon/clay/verysmallclaypot)
 			new/obj/item/weapon/clay/verysmallclaypot(get_turf(O))
 		else if (istype(O, /obj/item/ammo_casing/stone))

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -86,7 +86,7 @@
 		return
 
 /obj/item/weapon/material/sword/training
-	name = "Training Sword"
+	name = "training sword"
 	desc = "A wood sword used for nonlethal practice."
 	icon_state = "wood_sword"
 	item_state = "wood_sword"

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -36,7 +36,7 @@
 	//If the user is holding dummy armor, equips the dummy(not target) with it and increases it's health.
 	if (istype(W, /obj/item/weapon/dummy_armor))
 		if(src.humanoid)
-			visible_message("<span class='notice'>[user] put [W] on the [src]!</span>","<span class='notice'>You put [W] on the [src]!</span>")
+			visible_message("<span class='notice'>[user] put [W] on \the [src]!</span>","<span class='notice'>You put [W] on \the [src]!</span>")
 			src.icon_state = icon_state + "_armor"
 			src.health += 200
 			qdel(W)
@@ -46,9 +46,9 @@
 	if (istype(W, /obj/item/weapon/material))
 		user.setClickCooldown(W.cooldownw)
 		if (W.attack_verb.len)
-			visible_message("<span class='notice'>[user] [pick(W.attack_verb)] the training dummy with the [W]!</span>","<span class='notice'>You have [pick(W.attack_verb)] the training dummy with the [W]!</span>")
+			visible_message("<span class='notice'>[user] [pick(W.attack_verb)] \the [src] with \the [W]!</span>","<span class='notice'>You have [pick(W.attack_verb)] \the [src] with \the [W]!</span>")
 		else
-			visible_message("<span class='notice'>[user] hit the training dummy with the [W]!</span>","<span class='notice'>You have hit the training dummy with the [W]!</span>")
+			visible_message("<span class='notice'>[user] hit \the [src] with \the [W]!</span>","<span class='notice'>You have hit \the [src] with \the [W]!</span>")
 
 		playsound(get_turf(src), W.hitsound, 100)
 		user.do_attack_animation(src)
@@ -72,9 +72,9 @@
 	if (user.a_intent == I_HARM)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if (prob(67))
-			visible_message("<span class='notice'>[user] punches the training dummy!</span>","<span class='notice'>You punch the training dummy!</span>")
+			visible_message("<span class='notice'>[user] punches \the [src]!</span>","<span class='notice'>You punch \the [src]!</span>")
 		else
-			visible_message("<span class='notice'>[user] kicks the training dummy!</span>","<span class='notice'>You kick the training dummy!</span>")
+			visible_message("<span class='notice'>[user] kicks \the [src]!</span>","<span class='notice'>You kick \the [src]!</span>")
 		playsound(get_turf(src), pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg'), 100)
 		user.do_attack_animation(src)
 		health -= 2
@@ -109,7 +109,7 @@
 				if (GUN_TYPE_BOW)
 					if(ranged)
 						H.adaptStat("bows", 1)
-		visible_message("<span class='notice'>[H] hits the target with the [proj]!</span>","<span class='notice'>You hit the target with the [proj]!</span>")
+		visible_message("<span class='notice'>[H] hits \the [src] with \the [proj]!</span>","<span class='notice'>You hit \the [src] with \the [proj]!</span>")
 		//If the user shoots at a target, check if it's an arrow or a bolt and have a chance of dropping the arrow/bolt.
 		if(istype(src, /obj/structure/practice_dummy/target))
 			if (istype(proj, /obj/item/projectile/arrow/arrow))
@@ -163,12 +163,11 @@
 //Checks the dummy health, if it drops to 0 or below, turns it into a wreckage.
 /obj/structure/practice_dummy/proc/check_health()
 	if (health <= 0)
-		visible_message("<span class='notice'>The dummy is broken apart!</span>")
+		visible_message("<span class='notice'>The training [target_type] is broken apart!</span>")
 		var/obj/structure/practice_dummy/wreckage/JUNK = new /obj/structure/practice_dummy/wreckage(src.loc)
 		JUNK.target_type = src.target_type //Determines what it was before turning into wreckage and stores it in the variable.
-		if(JUNK.target_type == "target") //If wreckage was produced from a target, apply different name/desc to distinguish from dummy.
-			JUNK.name = "target wreckage"
-			JUNK.desc = "The wreckage of a training target. Can be fixed with wood."
+		JUNK.name = "[target_type] wreckage"
+		JUNK.desc = "The wreckage of a training [target_type]. Can be fixed with wood."
 		qdel(src)
 		return
 	else

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -125,7 +125,9 @@ var/list/name_to_material
 	target_stack.use(1)
 	var/obj/item/stack/S = new rod_product(get_turf(user))
 	S.add_fingerprint(user)
-	S.add_to_stacks(user)
+	for(var/obj/item/stack/T in get_turf(user))
+		if(T == src)
+			T.merge(src)
 
 /material/proc/build_wired_product(var/mob/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
 	if (!wire_product)


### PR DESCRIPTION
Changes done to code:
- Removed obsolete crafted stack merging proc that conflicted with new merging logic, causing duplication of produced stacks.
- Minor code clean-up in training_stake.dm and grammatical fixes.
- Changed the name of 'Training Sword' to 'training sword' as it should be.