### PR TITLE
Bug fixes regarding auto-merge for stacks

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -19,13 +19,14 @@
 	var/build_type = null //used when directly applied to a turf
 	var/real_value = 1
 	value = 1
+	var/can_stack = FALSE //Determines if stacks should be auto-merged.
 	var/customcolor = "FFFFFF"
 	var/customcolor1 = "000000"
 	var/customcolor2 = "FFFFFF"
 	var/customcode = "0000"
 	var/customname = ""
 
-/obj/item/stack/New(var/loc, var/_amount=0, var/merge = TRUE)
+/obj/item/stack/New(var/loc, var/_amount=0, var/merge = can_stack)
 	..()
 	if (!stacktype)
 		stacktype = type
@@ -99,7 +100,7 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 
 //attempts to transfer amount to S, and returns the amount actually transferred
 /obj/item/stack/proc/transfer_to(obj/item/stack/S, var/_amount=null)
-	if ((stacktype != S.stacktype))
+	if (stacktype != S.stacktype)
 		return FALSE
 	if (isnull(_amount))
 		_amount = amount
@@ -154,8 +155,8 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 /obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, type))
 		var/obj/item/stack/S = W
-		merge(S)
-		W.update_icon()
+		src.transfer_to(S, 1)
+		S.update_icon()
 		src.update_icon()
 		spawn(0) //give the stacks a chance to delete themselves if necessary
 		if (S && usr.using_object == S)
@@ -1843,7 +1844,10 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 			build_override_vending.add_fingerprint(user)
 			qdel(O)
 			return
-
+		else if (istype(O, /obj/item/stack))
+			var/obj/item/stack/S = O
+			S.amount = produced
+			S.update_icon()
 		else if (recipe.result_type == /obj/item/weapon/clay/verysmallclaypot)
 			new/obj/item/weapon/clay/verysmallclaypot(get_turf(O))
 		else if (istype(O, /obj/item/ammo_casing/stone))

--- a/code/modules/1713/ores.dm
+++ b/code/modules/1713/ores.dm
@@ -6,6 +6,7 @@
 	w_class = 2
 	amount = 1
 	max_amount = 50
+	can_stack = TRUE
 	value = 1
 	var/radioactive = FALSE
 	var/radioactive_amt = 0

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -7,6 +7,7 @@
 	throw_speed = 3
 	throw_range = 3
 	max_amount = 50
+	can_stack = TRUE
 
 	var/default_type = DEFAULT_WALL_MATERIAL
 	var/material/material

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -838,12 +838,14 @@ default behaviour is:
 
 //Code to handle merging stacks when they are in mob's direct inventory.
 //Called when object enters the contents of a mob. Storage items not supported yet.
-/mob/living/Entered(var/obj/item/stack/O)
-	..()
-	if(istype(O, /obj/item/stack))
-		if(O.amount != O.max_amount)
-			for(var/obj/item/stack/S in contents)
-				if(S.stacktype == O.stacktype)
-					if(O.amount == O.max_amount)
-						break
-					S.merge(O)
+//Not used because people don't like it. Might be useful for merging in containers.
+/* /mob/living/Entered(var/obj/item/stack/O)
+ * 	..()
+ * 	if(istype(O, /obj/item/stack))
+ * 		if(O.amount != O.max_amount)
+ * 			for(var/obj/item/stack/S in contents)
+ * 				if(S.stacktype == O.stacktype && S.amount != S.max_amount)
+ * 					if(O.amount == O.max_amount)
+ * 						break
+ * 					S.merge(O)
+ */


### PR DESCRIPTION
Changes done:
- Stacks inside inventory no longer auto-merge.
- When a stack is used on another stack, they no longer merge and instead transfer 1 unit at a time.
- Fixed the issue with crafted stacks not producing right amount when crafted on top of another stack.
- Only materials and ores auto-merge now.