### PR TITLE
Disables Plague (Language Sanitized)

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/mouse
 	name = "mouse"
 	real_name = "mouse"
-	desc = "It's a small rodent."
+	desc = "It's a retarded ass mouse that doesnt give you the plague anymore, you are welcome"
 	icon_state = "mouse_gray"
 	item_state = "mouse_gray"
 	icon_living = "mouse_gray"
@@ -54,17 +54,17 @@
 	if(body_color == "black")
 		if(map && map.ordinal_age == 2 || map.ordinal_age == 3) //Approx epochs where black plague was a thing.
 			if(prob(50))
-				plaguemouse = TRUE
+				plaguemouse = FALSE
 		else
 			if(prob(25))
-				plaguemouse = TRUE
+				plaguemouse = FALSE
 	else
 		if(map && map.ordinal_age == 2 || map.ordinal_age == 3) //Approx epochs where black plague was a thing.
 			if(prob(10))
-				plaguemouse = TRUE
+				plaguemouse = FALSE
 		else
 			if(prob(5))
-				plaguemouse = TRUE
+				plaguemouse = FALSE
 
 /mob/living/simple_animal/mouse/proc/splat()
 	health = FALSE
@@ -96,16 +96,16 @@
 			stance = HOSTILE_STANCE_ATTACK
 			stance_step = 6
 			if(plaguemouse && prob(2*dmod))
-				M.disease = TRUE
+				M.disease = FALSE
 				M.disease_type = "plague"
 			else if((plaguemouse && prob(0.03*dmod)) && (map.ordinal_age == 2 || map.ordinal_age == 3)) //2 percent chance because of if-else logic,
-				M.disease = TRUE
+				M.disease = FALSE
 				M.disease_type = "plague"
 			else if(plaguemouse && body_color == "black" && prob(4*dmod)) //prob is 3 percent.
-				M.disease = TRUE
+				M.disease = FALSE
 				M.disease_type = "plague"
 			else if((plaguemouse && body_color == "black" && prob(5*dmod)) && (map.ordinal_age == 2 || map.ordinal_age == 3)) //four percent chance kinda
-				M.disease = TRUE
+				M.disease = FALSE
 				M.disease_type = "plague"
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/mouse
 	name = "mouse"
 	real_name = "mouse"
-	desc = "It's a retarded ass mouse that doesnt give you the plague anymore, you are welcome"
+	desc = "It's a retarded ass mouse that doesnt give you the plague"
 	icon_state = "mouse_gray"
 	item_state = "mouse_gray"
 	icon_living = "mouse_gray"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/mouse
 	name = "mouse"
 	real_name = "mouse"
-	desc = "It's a retarded ass mouse that doesnt give you the plague"
+	desc = "It's a rodent that doesnt give you the plague"
 	icon_state = "mouse_gray"
 	item_state = "mouse_gray"
 	icon_living = "mouse_gray"


### PR DESCRIPTION
WHY IS THIS CHANGE BEING MADE
The reason for this is because currently, Mice are really broken. They literally snipe people from a mile away, and just bite and scratch, causing the poor soul to roll the dice to see if he got the plague, which he probably will get

let us disable the plague for a bit, until the mice behavior has been fixed, this would give the community some breathing space so that they can live to fight battles and make the round more interesting, rather than watching a huge faction die off due to some dumb mouse walking in like, "HEEEEY GUYS, IMMA JUST BITE YA RANDOMLY"

Currently, the plague ruins the dynamic of the round, it literally destroyed a faction today that was going to RP a war with another huge faction.

Changes:

Changed: Changed mice description to something tasteful

Changed: Bunch of variables to false