### PR TITLE
Important Minor Fixes

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -1198,21 +1198,21 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 		else
 			if (istype(H.l_hand, /obj/item/stack/medical/advanced/herbs))
 				var/obj/item/stack/medical/advanced/herbs/NB = H.l_hand
-				if (NB.amount >= 1)
-					NB.amount -= 1
+				if (NB.amount >= 2)
+					NB.amount -= 2
 					if (NB.amount <= 0)
 						qdelHandReturn(H.l_hand, H)
 				else
-					user << "<span class = 'warning'>You need at least one medicinal herb in one of your hands in order to make this.</span>"
+					user << "<span class = 'warning'>You need at least a stack of two medicinal herbs in one of your hands in order to make this.</span>"
 					return
 			else if (istype(H.r_hand, /obj/item/stack/medical/advanced/herbs))
 				var/obj/item/stack/medical/advanced/herbs/NB = H.r_hand
-				if (NB.amount >= 1)
-					NB.amount -= 1
+				if (NB.amount >= 2)
+					NB.amount -= 2
 					if (NB.amount <= 0)
 						qdelHandReturn(H.r_hand, H)
 				else
-					user << "<span class = 'warning'>You need at least one medicinal herb in one of your hands in order to make this.</span>"
+					user << "<span class = 'warning'>You need at least a stack of two medicinal herbs in one of your hands in order to make this.</span>"
 					return
 
 	else if (findtext(recipe.title, "khepresh war crown"))

--- a/config/material_recipes.txt
+++ b/config/material_recipes.txt
@@ -2047,7 +2047,7 @@ RECIPE: /material/iron/,transport wagon,/obj/structure/trains/storage/closed,5,2
 
 RECIPE: /material/iron/,anvil,/obj/structure/anvil,25,150,1,1,production,25,0,0,8,null
 RECIPE: /material/iron/,armor repair bench,/obj/structure/repair/workbench,16,180,1,1,production,25,0,0,8,null
-RECIPE: /material/wood/,specialist armorbench,/obj/structure/anvil/armorbench/specialist,15,210,1,1,production,120,0,0,8,null
+RECIPE: /material/iron/,specialist armorbench,/obj/structure/anvil/armorbench/specialist,15,210,1,1,production,120,0,0,8,null
 
 RECIPE: /material/iron/,engine maker,/obj/item/weapon/enginemaker,5,80,0,1,tools,115,0,0,8,null
 


### PR DESCRIPTION
Specialist bench now correctly pathed to iron ((**important to progression**))

Bit more clarity on herbs being a stack material when used in hand to craft the plague doctor mask, now requires 2 herbs.