### PR TITLE
de-chad europe + mapstart swap to four_colonies

### DIFF
--- a/civ13.dme
+++ b/civ13.dme
@@ -967,5 +967,5 @@
 #include "code\processes\zoom\zoom_scopes.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\nomads\nomads_europe.dmm"
+#include "maps\1713\four_colonies.dmm"
 // END_INCLUDE

--- a/code/game/objects/map_metadata/nomads_europe.dm
+++ b/code/game/objects/map_metadata/nomads_europe.dm
@@ -7,7 +7,6 @@
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall/)
 	respawn_delay = 6000 // 10 minutes!
 	has_hunger = TRUE
-	chad_mode_plus = TRUE
 	faction_organization = list(
 		CIVILIAN,)
 


### PR DESCRIPTION
removes the line of code that makes Nomads_europe chadmode+ and changes the starting map for the server to four_colonies clearing the last event and sidestepping the mapswap issue for the current event.