### PR TITLE
Allows improper bears to drop leather

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -599,6 +599,9 @@
 					var/obj/item/stack/material/bone/bone = new/obj/item/stack/material/bone(get_turf(src))
 					bone.name = "[name] bone"
 					bone.amount = amt
+				if (istype(src, /mob/living/simple_animal/hostile/bear)) //all bears on the inheritance path drop leather to compensate for improper types.
+					var/obj/item/stack/material/leather/leather = new/obj/item/stack/material/leather(get_turf(src))
+					NP.amount = 1.5
 				if (istype(src, /mob/living/simple_animal/hostile/bear/boar/black))
 					var/obj/item/stack/material/pelt/bearpelt/black/NP = new/obj/item/stack/material/pelt/bearpelt/black(get_turf(src))
 					NP.amount = 6

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -600,7 +600,7 @@
 					bone.name = "[name] bone"
 					bone.amount = amt
 				if (istype(src, /mob/living/simple_animal/hostile/bear)) //all bears on the inheritance path drop leather to compensate for improper types.
-					var/obj/item/stack/material/leather/leather = new/obj/item/stack/material/leather(get_turf(src))
+					var/obj/item/stack/material/leather/NP = new/obj/item/stack/material/leather(get_turf(src))
 					NP.amount = 1.5
 				if (istype(src, /mob/living/simple_animal/hostile/bear/boar/black))
 					var/obj/item/stack/material/pelt/bearpelt/black/NP = new/obj/item/stack/material/pelt/bearpelt/black(get_turf(src))


### PR DESCRIPTION
## little band-aid fix

``1.5`` leather a small quantity, which in turn is imparted on all other bears through inheritance as a small bonus on the side.

You can harvest more from improper bears should you encounter one with the butcher intent which differs to skinning in that it prioritizes meat and makes leather appropriate to the size appear; in client testing showed that adding more pelts further up the path of the code that makes bears drop pelts simply made duplications of usually the wrong type.