### PR TITLE
Refines & trims carib crafting list, properly implements primitive armor.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -297,14 +297,6 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 	if (istype(get_turf(H), /turf/floor/beach/water/deep))
 		H << "<span class = 'danger'>You can't build here!</span>"
 		return
-	if (findtext(recipe.title, "gunpowder pouch") || findtext(recipe.title, "bandolier") || findtext(recipe.title, "lantern") || findtext(recipe.title, "oven") || findtext(recipe.title, "keychain") || findtext(recipe.title, "anvil") || findtext(recipe.title, "armorbench") ||  findtext(recipe.title, "musket ball") || findtext(recipe.title, "small musket ball") || findtext(recipe.title, "blunderbuss ball") || findtext(recipe.title, "cannon ball") || findtext(recipe.title, "pen") || findtext(recipe.title, "paper sheet") || findtext(recipe.title, "small glass bottle") || findtext(recipe.title, "drinking glass") || findtext(recipe.title, "teapot") || findtext(recipe.title, "teacup") || findtext(recipe.title, "wine glass") || findtext(recipe.title, "black leather shoes") || findtext(recipe.title, "black leather boots") || findtext(recipe.title, "leather boots"))
-		if (H.faction_text == INDIANS)
-			H << "<span class = 'danger'>You don't know how to make this.</span>"
-			return
-	if (findtext(recipe.title, "leather samurai helmet") || findtext(recipe.title, "red leather samurai helmet") || findtext(recipe.title, "blue leather samurai helmet") || findtext(recipe.title, "black leather samurai") || findtext(recipe.title, "leather samurai armor") || findtext(recipe.title, "red leather samurai armor") || findtext(recipe.title, "blue leather samurai armor") ||  findtext(recipe.title, "black leather samurai armor") || findtext(recipe.title, "hatchigane headband"))
-		if (H.faction_text == INDIANS)
-			H << "<span class = 'danger'>You don't know how to make this.</span>"
-			return
 	if (findtext(recipe.title, "talisman"))
 		if (H.religion == "none")
 			H << "<span class = 'danger'>You cannot make a [recipe.title] as you have no religion.</span>"
@@ -1004,6 +996,54 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 						qdelHandReturn(H.r_hand, H)
 				else
 					user << "<span class = 'warning'>You need at least 0.2 parts of a leather sheet in one of your hands in order to make this.</span>"
+					return
+
+	else if (findtext(recipe.title, "primitive wood armor"))
+		if (!istype(H.l_hand, /obj/item/stack/material/wood) && !istype(H.r_hand, /obj/item/stack/material/wood))
+			user << "<span class = 'warning'>You need at least 15 units of wood in one of your hands in order to make this.</span>"
+			return
+		else
+			if (istype(H.l_hand, /obj/item/stack/material/rope))
+				var/obj/item/stack/material/rope/NB = H.l_hand
+				if (NB.amount >= 3)
+					NB.amount -= 3
+					if (NB.amount <= 0)
+						qdelHandReturn(H.l_hand, H)
+				else
+					user << "<span class = 'warning'>You need at least 3 lengths of rope in one of your hands in order to make this.</span>"
+					return
+			else if (istype(H.r_hand, /obj/item/stack/material/rope))
+				var/obj/item/stack/material/rope/NB = H.r_hand
+				if (NB.amount >= 3)
+					NB.amount -= 3
+					if (NB.amount <= 0)
+						qdelHandReturn(H.r_hand, H)
+				else
+					user << "<span class = 'warning'>You need at least 3 lengths of rope in one of your hands in order to make this.</span>"
+					return
+
+	else if (findtext(recipe.title, "primitive bone hair-pipe armor"))
+		if (!istype(H.l_hand, /obj/item/stack/material/bone) && !istype(H.r_hand, /obj/item/stack/material/bone))
+			user << "<span class = 'warning'>You need at least 5 pieces of bone in one of your hands in order to make this.</span>"
+			return
+		else
+			if (istype(H.l_hand, /obj/item/stack/material/rope))
+				var/obj/item/stack/material/rope/NB = H.l_hand
+				if (NB.amount >= 3)
+					NB.amount -= 3
+					if (NB.amount <= 0)
+						qdelHandReturn(H.l_hand, H)
+				else
+					user << "<span class = 'warning'>You need at least 3 lengths of rope in one of your hands in order to make this.</span>"
+					return
+			else if (istype(H.r_hand, /obj/item/stack/material/rope))
+				var/obj/item/stack/material/rope/NB = H.r_hand
+				if (NB.amount >= 3)
+					NB.amount -= 3
+					if (NB.amount <= 0)
+						qdelHandReturn(H.r_hand, H)
+				else
+					user << "<span class = 'warning'>You need at least 3 lengths of rope in one of your hands in order to make this.</span>"
 					return
 
 	else if (findtext(recipe.title, "doge hat"))

--- a/code/modules/1713/apparel_stoneage.dm
+++ b/code/modules/1713/apparel_stoneage.dm
@@ -218,22 +218,21 @@
 
 /obj/item/clothing/suit/woodarmor
 	name = "primitive wood armor"
-	desc = "A wooden set of armor made of small planks held together by hemp."
+	desc = "A wooden set of armor made of small planks held together by plant fiber ropes."
 	icon_state = "wooden_chestarmor"
 	item_state = "wooden_chestarmor"
 	worn_state = "wooden_chestarmor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	armor = list(melee = 15, arrow = 18, gun = FALSE, energy = 10, bomb = 4, bio = 20, rad = 15)
 
-/obj/item/clothing/suit/nativebonearmor
+/obj/item/clothing/suit/hairbonearmor
 	name = "primitive bone hair-pipe armor"
-	desc = "A bone set of chest armor made of small bones and shells held together by hemp."
+	desc = "A bone set of chest armor made of tightly packed small bones held together by plant fiber ropes."
 	icon_state = "native_bonearmor"
 	item_state = "native_bonearmor"
 	worn_state = "native_bonearmor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	armor = list(melee = 21, arrow = 13, gun = FALSE, energy = 8, bomb = 6, bio = 10, rad = 18)
-
 
 /obj/item/clothing/accessory/armband/talisman
 	name = "bone talisman"
@@ -323,7 +322,7 @@
 
 /obj/item/clothing/head/chief_hat
 	name = "chief hat"
-	desc = "A hat made with withe feathers. Worn by tribal leaders."
+	desc = "A hat made with with feathers. Worn by tribal leaders."
 	icon_state = "chief_hat"
 	item_state = "chief_hat"
 	flags_inv = BLOCKHEADHAIR

--- a/code/modules/1713/weapons/guns/flintlock.dm
+++ b/code/modules/1713/weapons/guns/flintlock.dm
@@ -91,9 +91,6 @@
 
 /obj/item/weapon/gun/projectile/flintlock/attack_self(mob/user)
 	var/mob/living/human/H = user
-	if (istype(H) && H.faction_text == "INDIANS")
-		user << "<span class = 'danger'>You have no idea how this thing works.</span>"
-		return FALSE
 	if (!check_cocked)//Keeps people from spamming the bolt
 		check_cocked++
 		if (!do_after(user, 2, src, FALSE, TRUE, INCAPACITATION_DEFAULT, TRUE))//Delays the bolt
@@ -114,9 +111,6 @@
 
 /obj/item/weapon/gun/projectile/flintlock/special_check(mob/user)
 	var/mob/living/human/H = user
-	if (istype(H) && (H.faction_text == "INDIANS"))
-		user << "<span class = 'danger'>You have no idea how this thing works.</span>"
-		return FALSE
 	if (!cocked)
 		user << "<span class='warning'>You can't fire \the [src] while the weapon is uncocked!</span>"
 		return FALSE
@@ -127,9 +121,6 @@
 
 /obj/item/weapon/gun/projectile/flintlock/load_ammo(var/obj/item/A, mob/user)
 	var/mob/living/human/H = user
-	if (istype(H) && (H.faction_text == "INDIANS"))
-		user << "<span class = 'danger'>You have no idea how this thing works.</span>"
-		return FALSE
 	if (cocked)
 		return
 	..()

--- a/code/modules/1713/weapons/guns/flintlock.dm
+++ b/code/modules/1713/weapons/guns/flintlock.dm
@@ -90,7 +90,7 @@
 	var/last_fire = -1
 
 /obj/item/weapon/gun/projectile/flintlock/attack_self(mob/user)
-	var/mob/living/human/H = user
+//	var/mob/living/human/H = user
 	if (!check_cocked)//Keeps people from spamming the bolt
 		check_cocked++
 		if (!do_after(user, 2, src, FALSE, TRUE, INCAPACITATION_DEFAULT, TRUE))//Delays the bolt
@@ -110,7 +110,7 @@
 	check_cocked--
 
 /obj/item/weapon/gun/projectile/flintlock/special_check(mob/user)
-	var/mob/living/human/H = user
+//	var/mob/living/human/H = user
 	if (!cocked)
 		user << "<span class='warning'>You can't fire \the [src] while the weapon is uncocked!</span>"
 		return FALSE
@@ -120,7 +120,7 @@
 	return ..()
 
 /obj/item/weapon/gun/projectile/flintlock/load_ammo(var/obj/item/A, mob/user)
-	var/mob/living/human/H = user
+//	var/mob/living/human/H = user
 	if (cocked)
 		return
 	..()

--- a/code/modules/1713/weapons/guns/lever_action.dm
+++ b/code/modules/1713/weapons/guns/lever_action.dm
@@ -107,10 +107,7 @@
 		cocked = TRUE
 */
 /obj/item/weapon/gun/projectile/leveraction/special_check(mob/user)
-	var/mob/living/human/H = user
-	if (istype(H) && (H.faction_text == "INDIANS"))
-		user << "<span class = 'danger'>You have no idea how this thing works.</span>"
-		return FALSE
+//	var/mob/living/human/H = user
 	if (gun_safety && safetyon)
 		user << "<span class='warning'>You can't fire \the [src] while the safety is on!</span>"
 		return FALSE

--- a/code/modules/1713/weapons/guns/revolvers.dm
+++ b/code/modules/1713/weapons/guns/revolvers.dm
@@ -127,12 +127,9 @@
 			update_icon()
 
 /obj/item/weapon/gun/projectile/revolver/special_check(mob/user)
-	var/mob/living/human/H = user
+//	var/mob/living/human/H = user
 	if (gun_safety && safetyon)
 		user << "<span class='warning'>You can't fire \the [src] while the safety is on!</span>"
-		return FALSE
-	if (istype(H) && (H.faction_text == "INDIANS"))
-		user << "<span class = 'danger'>You have no idea how this thing works.</span>"
 		return FALSE
 	if (!cocked && single_action)
 		user << "<span class='warning'>You can't fire \the [src] while the weapon is uncocked!</span>"
@@ -750,10 +747,7 @@
 			cocked = FALSE
 
 /obj/item/weapon/gun/projectile/revolving/special_check(mob/user)
-	var/mob/living/human/H = user
-	if (istype(H) && (H.faction_text == "INDIANS"))
-		user << "<span class = 'danger'>You have no idea how this thing works.</span>"
-		return FALSE
+//	var/mob/living/human/H = user
 	if (!cocked && single_action)
 		user << "<span class='warning'>You can't fire \the [src] while the weapon is uncocked!</span>"
 		return FALSE
@@ -942,10 +936,7 @@
 			update_icon()
 
 /obj/item/weapon/gun/projectile/capnball/special_check(mob/user)
-	var/mob/living/human/H = user
-	if (istype(H) && (H.faction_text == "INDIANS"))
-		user << "<span class = 'danger'>You have no idea how this thing works.</span>"
-		return FALSE
+//	var/mob/living/human/H = user
 	if (!cocked && single_action)
 		user << "<span class='warning'>You can't fire \the [src] while the weapon is uncocked!</span>"
 		return FALSE

--- a/config/material_recipes.txt
+++ b/config/material_recipes.txt
@@ -131,9 +131,9 @@
 
 //**| WOOD |**| WOOD VEHICLES & LOCOMOTIVES |**| WOOD PRODUCTION & ECONOMY |**| WOOD CONSTRUCTIONS |**| WOOD BARRICADES |**| WOOD HYGIENE |**| WOOD WEAPONS |**| WOOD PROJECTILES & SHAFTS |*******
 //*************************************************************************************************************************************************************************************************
-//**| WOOD TOOLS |**| WOOD FURNITURE |**| WOOD DECORATION & MONUMENTS |**| WOOD CLOTHING |**| WOOD KITCHEN |**| WOOD ENTERTAINMENT |**| WOOD RESEARCH & PAPER |**| WOOD SIEGE WEAPONS |**| WOOD HEALTHCARE |**
+//**| WOOD TOOLS |**| WOOD FURNITURE |**| WOOD DECORATION & MONUMENTS |**| WOOD CLOTHING |**| WOOD ARMOR |**| WOOD KITCHEN |**| WOOD ENTERTAINMENT |**| WOOD RESEARCH & PAPER |********************
 //*************************************************************************************************************************************************************************************************
-//**| WOOD PAINTINGS |**| WOOD PUNISHMENTS |*******************************************************************************************************************************************************
+//**| WOOD SIEGE WEAPONS |**| WOOD HEALTHCARE |**| WOOD PAINTINGS |**| WOOD PUNISHMENTS |**********************************************************************************************************
 //*************************************************************************************************************************************************************************************************
 
 /**| BAMBOO |**| BAMBOO DECORATION & RELIGION | BAMBOO CONSTRUCTIONS |**| BAMBOO RESEARCH & PAPER |**| BAMBOO CLOTHING |**| BAMBOO WEAPONS |
@@ -1150,6 +1150,7 @@ RECIPE: /material/bone/,bone talisman,/obj/item/clothing/accessory/armband/talis
 RECIPE: /material/bone/,skull mask,/obj/item/clothing/mask/skullmask,5,100,0,1,none,0,0,0,2,null
 RECIPE: /material/bone/,bone helmet,/obj/item/clothing/head/helmet/bone,10,100,0,1,none,0,0,0,2,null
 RECIPE: /material/bone/,bone armor,/obj/item/clothing/suit/storage/jacket/bonearmor,10,170,0,2,none,0,0,0,1,null
+RECIPE: /material/bone/,primitive bone hair-pipe armor,/obj/item/clothing/suit/hairbonearmor,5,100,0,1,none,0,0,0,2,null
 RECIPE: /material/bone/,bone hatchet,/obj/item/weapon/material/hatchet/tribal/bone,2,35,0,1,none,0,0,0,8,bone
 RECIPE: /material/bone/,battle axe,/obj/item/weapon/material/hatchet/bone_battleaxe,10,70,0,1,none,0,0,0,4,bone
 RECIPE: /material/bone/,tribal bone knife,/obj/item/weapon/material/kitchen/utensil/knife/bone,4,90,0,1,none,0,0,0,4,bone
@@ -1907,6 +1908,10 @@ RECIPE: /material/wood/,geta sandals,/obj/item/clothing/shoes/geta,1,40,0,1,shoe
 
 RECIPE: /material/wood/,wearable wood mask,/obj/item/clothing/mask/wooden,2,50,0,1,shoes & clothing,0,0,0,2,null
 RECIPE: /material/wood/,expressive wearable wood mask,/obj/item/clothing/mask/wooden/expressive,3,50,0,1,shoes & clothing,0,0,0,2,null
+
+//*********************| WOOD ARMOR |**************************
+
+/material/wood/,primitive wood armor,/obj/item/clothing/suit/woodarmor,15,150,0,1,none,0,0,0,2,null
 
 //*********************| WOOD KITCHEN |**************************
 

--- a/config/material_recipes_carib.txt
+++ b/config/material_recipes_carib.txt
@@ -710,7 +710,6 @@ RECIPE: /material/stone/,stone anvil,/obj/structure/anvil/stone,25,150,1,1,produ
 
 RECIPE: /material/stone/,sling projectile (x5),/obj/item/ammo_casing/stone,1,25,0,1,projectiles,0,0,0,8,null
 RECIPE: /material/stone/,stone arrowhead (x4),/obj/item/stack/arrowhead/stone,1,10,0,1,projectiles,0,14,0,8,null
-RECIPE: /material/stone/,catapult projectile,/obj/item/catapult_ball,5,75,0,1,projectiles,24,33,0,4,null
 RECIPE: /material/stone/,stone projectile (x2),/obj/item/stack/ammopart/stoneball,1,25,0,1,projectiles,24,49,0,8,null
 
 //*************| STONE BRICKS & CONSTRUCTIONS |***************
@@ -1158,8 +1157,6 @@ RECIPE: /material/wood/,work propaganda poster,/obj/item/weapon/poster/faction/w
 RECIPE: /material/wood/,leader propaganda poster,/obj/item/weapon/poster/faction/lead,1,25,0,1,paper & printing,19,0,0,8,null
 
 //*********************| WOOD SIEGE WEAPONS |**************************
-
-RECIPE: /material/wood/,catapult,/obj/structure/catapult,50,450,1,1,siege weapons,24,33,0,8,null
 
 RECIPE: /material/wood/,siege ladder,/obj/item/weapon/siegeladder,8,100,0,1,siege weapons,24,33,0,8,null
 

--- a/config/material_recipes_carib.txt
+++ b/config/material_recipes_carib.txt
@@ -131,9 +131,9 @@
 
 //**| WOOD |**| WOOD VEHICLES & LOCOMOTIVES |**| WOOD PRODUCTION & ECONOMY |**| WOOD CONSTRUCTIONS |**| WOOD BARRICADES |**| WOOD HYGIENE |**| WOOD WEAPONS |**| WOOD PROJECTILES & SHAFTS |*******
 //*************************************************************************************************************************************************************************************************
-//**| WOOD TOOLS |**| WOOD FURNITURE |**| WOOD DECORATION & MONUMENTS |**| WOOD CLOTHING |**| WOOD KITCHEN |**| WOOD ENTERTAINMENT |**| WOOD RESEARCH & PAPER |**| WOOD SIEGE WEAPONS |**| WOOD HEALTHCARE |**
+//**| WOOD TOOLS |**| WOOD FURNITURE |**| WOOD DECORATION & MONUMENTS |**| WOOD CLOTHING |**| WOOD ARMOR |**| WOOD KITCHEN |**| WOOD ENTERTAINMENT |**| WOOD RESEARCH & PAPER |********************
 //*************************************************************************************************************************************************************************************************
-//**| WOOD PAINTINGS |**| WOOD PUNISHMENTS |*******************************************************************************************************************************************************
+//**| WOOD SIEGE WEAPONS |**| WOOD HEALTHCARE |**| WOOD PAINTINGS |**| WOOD PUNISHMENTS |**********************************************************************************************************
 //*************************************************************************************************************************************************************************************************
 
 /**| BAMBOO |**| BAMBOO DECORATION & RELIGION | BAMBOO CONSTRUCTIONS |**| BAMBOO RESEARCH & PAPER |**| BAMBOO CLOTHING |**| BAMBOO WEAPONS |
@@ -176,15 +176,9 @@ RECIPE: /material/clay/,unfired large clay pitcher,/obj/item/weapon/clay/largecl
 //*****************| CLAY BUILDING MATERIALS, FLOORS & STRUCTURES |***************************
 
 RECIPE: /material/clay/,unfired clay blocks,/obj/item/weapon/clay/claybricks,0.5,50,0,1,none,0,0,0,8,null
-RECIPE: /material/clay/,unfired clay bricks,/obj/item/weapon/clay/advclaybricks,0.5,50,0,1,none,82,0,0,8,null
-RECIPE: /material/clay/,unfired cement bricks,/obj/item/weapon/clay/advclaybricks/cement,4,50,0,1,none,82,0,0,8,null
-
-RECIPE: /material/clay/,concrete floor,/obj/covers/concretefloor,0.5,15,1,1,none,103,0,0,8,null
 
 RECIPE: /material/clay/,clay brick bloomery,/obj/structure/furnace,10,150,1,1,none,26,0,0,8,null
 RECIPE: /material/clay/,clay kiln,/obj/structure/furnace/kiln,10,150,1,1,none,26,0,0,8,null
-
-RECIPE: /material/clay/,concrete pillar,/obj/structure/mine_support/stone/concrete,2,20,0,1,none,103,0,0,8,null
 
 RECIPE: /material/clay/,unfired ingot mold,/obj/item/weapon/clay/mold,1.5,40,0,1,molds,0,0,0,8,null
 RECIPE: /material/clay/,unfired axehead mold,/obj/item/weapon/clay/mold/axehead,1.5,40,0,1,molds,0,0,0,8,null
@@ -198,10 +192,6 @@ RECIPE: /material/clay/,unfired blacksmith clay pot,/obj/item/weapon/clay/mold/c
 RECIPE: /material/clay/,unfired blacksmith clay jug,/obj/item/weapon/clay/mold/clayjug,5,40,0,1,molds,0,0,0,8,null
 
 //*****************| CLAY STUCCO |***************************
-
-RECIPE: /material/clay/,raw stucco,/obj/item/weapon/stucco/generic,1.5,25,0,1,wall coverings & stucco,18,0,0,8,null
-RECIPE: /material/clay/,raw greek stucco,/obj/item/weapon/stucco/greek,1.5,25,0,1,wall coverings & stucco,18,0,0,2,null
-RECIPE: /material/clay/,raw roman stucco,/obj/item/weapon/stucco/roman,1.5,25,0,1,wall coverings & stucco,18,0,0,2,null
 
 //*****************| CLAY PLANT POTS |***************************
 
@@ -236,9 +226,6 @@ RECIPE: /material/leather/,quiver,/obj/item/weapon/storage/backpack/quiver,3,60,
 RECIPE: /material/leather/,leather belt satchel,/obj/item/weapon/storage/belt/leather,3,60,0,1,storage,0,0,0,8,null
 RECIPE: /material/leather/,leather backpack,/obj/item/weapon/storage/backpack,6,100,0,1,storage,18,0,0,8,null
 RECIPE: /material/leather/,leather waterskin,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/waterskin,3,90,0,1,storage,0,0,0,8,null
-RECIPE: /material/leather/,leather satchel,/obj/item/weapon/storage/backpack/satchel,3,100,0,1,storage,120,0,125,8,null
-RECIPE: /material/leather/,leather briefcase,/obj/item/weapon/storage/briefcase,2,80,0,1,storage,100,0,100,8,null
-RECIPE: /material/leather/,duffel bag,/obj/item/weapon/storage/backpack/duffel,4,80,0,1,storage,180,0,180,8,null
 
 //*****************| LEATHER HEALTHCARE |***************************
 
@@ -246,69 +233,27 @@ RECIPE: /material/leather/,leather bandages,/obj/item/stack/medical/bruise_pack/
 
 //*****************| LEATHER UNIFORMS & JACKETS |***************************
 
-RECIPE: /material/leather/,leather loincloth,/obj/item/clothing/under/loinleather,2,50,0,1,clothing,0,0,0,0,null
-RECIPE: /material/leather/,aztec loincloth,/obj/item/clothing/under/aztec_loincloth,2,50,0,1,clothing,0,0,0,3,null
-RECIPE: /material/leather/,small customizable loincloth,/obj/item/clothing/under/custom/spartan,3,50,0,1,clothing,0,0,0,1,null
-RECIPE: /material/leather/,long celtic braccae,/obj/item/clothing/under/celtic_long_braccae,3,55,0,1,clothing,0,19,0,1,null
-RECIPE: /material/leather/,short celtic braccae,/obj/item/clothing/under/celtic_short_braccae,2,55,0,1,clothing,0,19,0,1,null
+RECIPE: /material/leather/,leather loincloth,/obj/item/clothing/under/loinleather,2,50,0,1,clothing,0,0,0,8,null
+RECIPE: /material/leather/,aztec loincloth,/obj/item/clothing/under/aztec_loincloth,2,50,0,1,clothing,0,0,0,8,null
+RECIPE: /material/leather/,small customizable loincloth,/obj/item/clothing/under/custom/spartan,3,50,0,1,clothing,0,0,0,8,null
 
-RECIPE: /material/leather/,leather overcoat,/obj/item/clothing/suit/storage/jacket/leatherovercoat1,6,120,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/leather/,black leather overcoat,/obj/item/clothing/suit/storage/jacket/leatherovercoat2,6,120,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/leather/,biker jacket,/obj/item/clothing/suit/storage/coat/ww2/biker,6,110,0,1,jackets & vests,150,0,175,8,null
-RECIPE: /material/leather/,80's jacket,/obj/item/clothing/suit/storage/coat/oldyjacket,6,110,0,1,jackets & vests,185,0,175,7,null
-RECIPE: /material/leather/,punk jacket,/obj/item/clothing/suit/storage/jacket/punk,5,110,0,1,jackets & vests,175,0,180,8,null
+RECIPE: /material/leather/,short leather loincloth,/obj/item/clothing/under/indian1,3,50,0,1,clothing,0,0,0,8,null
+RECIPE: /material/leather/,long leather loincloth,/obj/item/clothing/under/indian2,3,50,0,1,clothing,0,0,0,8,null
+RECIPE: /material/leather/,covering leather loincloth,/obj/item/clothing/under/indian3,3,50,0,1,clothing,0,0,0,8,null
+
+RECIPE: /material/leather/,indian chief clothing,/obj/item/clothing/under/indianchief,5,50,0,1,clothing,0,0,0,8,null
+RECIPE: /material/leather/,big leopard pelt,/obj/item/clothing/under/indianhuge,8,100,0,1,clothing,0,0,0,8,null
 
 //*****************| LEATHER HATS |***************************
 
-RECIPE: /material/leather/,cavalier hat,/obj/item/clothing/head/cavalier,3,55,0,1,hats,0,0,52,3,null
-RECIPE: /material/leather/,cowboy hat,/obj/item/clothing/head/cowboyhat,3,55,0,1,hats,0,0,98,8,null
-RECIPE: /material/leather/,dark cowboy hat,/obj/item/clothing/head/cowboyhat2,3,55,0,1,hats,0,0,98,8,null
+RECIPE: /material/leather/,chief hat,/obj/item/clothing/head/chief_hat,5,70,0,1,hats,0,0,0,8,null
 
 //*****************| LEATHER SHOES |***************************
 
-RECIPE: /material/leather/,roman-style sandals,/obj/item/clothing/shoes/roman,2,60,0,1,foot wear,0,19,0,1,null
-RECIPE: /material/leather/,aztec-style sandals,/obj/item/clothing/shoes/aztec_sandals,2,60,0,1,foot wear,0,19,0,3,null
-RECIPE: /material/leather/,medieval shoes,/obj/item/clothing/shoes/medieval,3,80,0,1,foot wear,0,39,0,2,null
-RECIPE: /material/leather/,arabic-style shoes,/obj/item/clothing/shoes/medieval/arab,2,60,0,1,foot wear,0,39,0,2,null
-RECIPE: /material/leather/,emirate shoes,/obj/item/clothing/shoes/medieval/emirate,4,60,0,1,foot wear,0,39,0,2,null
-RECIPE: /material/leather/,black leather shoes,/obj/item/clothing/shoes/soldiershoes,2,60,0,1,foot wear,55,0,25,8,null
-RECIPE: /material/leather/,black leather boots,/obj/item/clothing/shoes/blackboots1,3,80,0,1,foot wear,55,0,25,8,null
-RECIPE: /material/leather/,leather boots,/obj/item/clothing/shoes/leatherboots1,3,80,0,1,foot wear,55,0,25,8,null
-RECIPE: /material/leather/,black riding boots,/obj/item/clothing/shoes/riding1,3,50,0,1,foot wear,0,0,98,4,null
-RECIPE: /material/leather/,riding boots,/obj/item/clothing/shoes/riding2,3,50,0,1,foot wear,0,0,98,4,null
-RECIPE: /material/leather/,work boots,/obj/item/clothing/shoes/workboots,4,80,0,1,foot wear,120,0,112,8,null
-RECIPE: /material/leather/,laceup shoes,/obj/item/clothing/shoes/laceup,3,60,0,1,foot wear,112,0,112,8,null
-RECIPE: /material/leather/,plain leather shoes,/obj/item/clothing/shoes/leather,3,60,0,1,foot wear,112,0,112,8,null
-RECIPE: /material/leather/,punk boots,/obj/item/clothing/shoes/punk,4,110,0,1,foot wear,175,0,180,8,null
-
 //*****************| LEATHER ARMOR |***************************
 
-RECIPE: /material/leather/,leather armor,/obj/item/clothing/suit/armor/medieval/leather,6,130,0,1,armor,0,16,21,3,null
-RECIPE: /material/leather/,leather helmet,/obj/item/clothing/head/helmet/leather,3,90,0,1,armor,0,16,21,3,null
-
-RECIPE: /material/leather/,hatchigane headband,/obj/item/clothing/head/helmet/hatchigane,3,90,0,1,armor,0,16,21,3,null
-
-RECIPE: /material/leather/,leather samurai helmet,/obj/item/clothing/head/helmet/samurai/guard,7,90,0,1,armor,0,16,21,3,null
-RECIPE: /material/leather/,red leather samurai helmet,/obj/item/clothing/head/helmet/samurai/guard/red,7,90,0,1,armor,0,16,21,3,null
-RECIPE: /material/leather/,blue leather samurai helmet,/obj/item/clothing/head/helmet/samurai/guard/blue,7,90,0,1,armor,0,16,21,3,null
-RECIPE: /material/leather/,black leather samurai helmet,/obj/item/clothing/head/helmet/samurai/guard/black,7,90,0,1,armor,0,16,21,3,null
-
-RECIPE: /material/leather/,leather samurai armor,/obj/item/clothing/suit/armor/samurai,10,130,0,1,armor,0,16,21,3,null
-RECIPE: /material/leather/,red leather samurai armor,/obj/item/clothing/suit/armor/samurai/red,10,130,0,1,armor,0,16,21,3,null
-RECIPE: /material/leather/,blue leather samurai armor,/obj/item/clothing/suit/armor/samurai/blue,10,130,0,1,armor,0,16,21,3,null
-RECIPE: /material/leather/,black leather samurai armor,/obj/item/clothing/suit/armor/samurai/black,10,130,0,1,armor,0,16,21,3,null
-
-RECIPE: /material/leather/,khepresh war crown,/obj/item/clothing/head/helmet/khepresh,3,90,0,1,armor,0,16,22,2,null
-
-RECIPE: /material/leather/,leather skullcap helmet,/obj/item/clothing/head/helmet/leather_skullcap,3,100,0,1,armor,0,27,27,3,null
-
-RECIPE: /material/leather/,steppe leather armor,/obj/item/clothing/suit/armor/medieval/steppe_leather,5,140,0,1,armor,0,33,28,3,null
-RECIPE: /material/leather/,leather roundcap,/obj/item/clothing/head/roundcap,2,100,0,1,hats & masks,65,0,0,4,null
-
-RECIPE: /material/leather/,leather infantry cap,/obj/item/clothing/head/helmet/leather_infantry,3,90,0,1,armor,0,88,92,4,null
-RECIPE: /material/leather/,brown leather infantry cap,/obj/item/clothing/head/helmet/leather_infantry/brown,3,90,0,1,armor,0,88,92,4,null
-RECIPE: /material/leather/,blue leather infantry cap,/obj/item/clothing/head/helmet/leather_infantry/blue,3,90,0,1,armor,0,88,92,4,null
-RECIPE: /material/leather/,red leather infantry cap,/obj/item/clothing/head/helmet/leather_infantry/red,3,90,0,1,armor,0,88,92,4,null
+RECIPE: /material/leather/,leather armor,/obj/item/clothing/suit/armor/medieval/leather,6,130,0,1,armor,0,0,0,8,null
+RECIPE: /material/leather/,leather helmet,/obj/item/clothing/head/helmet/leather,3,90,0,1,armor,0,0,0,8,null
 
 //*****************| LEATHER ACCESSORIES |***************************
 
@@ -316,20 +261,8 @@ RECIPE: /material/leather/,coin pouch,/obj/item/clothing/accessory/storage/coinp
 RECIPE: /material/leather/,wallet,/obj/item/clothing/accessory/storage/coinpouch/wallet,2,60,0,1,accessories,87,0,0,8,null
 
 RECIPE: /material/leather/,customizable armband,/obj/item/clothing/accessory/custom/armband,1,30,0,1,accessories,0,0,0,8,null
-RECIPE: /material/leather/,suspenders,/obj/item/clothing/accessory/suspenders,1,60,0,1,accessories,0,0,85,8,null
-RECIPE: /material/leather/,dark suspenders,/obj/item/clothing/accessory/suspenders/dark,1,70,0,1,accessories,0,0,85,8,null
-RECIPE: /material/leather/,khaki webbing,/obj/item/clothing/accessory/storage/webbing/khaki_webbing,2,60,0,1,storage,0,0,99,8,null
-RECIPE: /material/leather/,green webbing,/obj/item/clothing/accessory/storage/webbing/green_webbing,2,60,0,1,storage,0,0,99,8,null
-RECIPE: /material/leather/,light webbing,/obj/item/clothing/accessory/storage/webbing/light,1,50,0,1,storage,0,0,99,8,null
-RECIPE: /material/leather/,pilot goggles,/obj/item/clothing/glasses/pilot,2,60,0,1,accessories,0,0,107,8,null
 
 //*****************| LEATHER WEAPON ACCESSORIES |***************************
-
-RECIPE: /material/leather/,sword sheath,/obj/item/clothing/accessory/storage/sheath,3,80,0,1,weapon accessories,0,39,0,2,null
-RECIPE: /material/leather/,longer sword sheath,/obj/item/clothing/accessory/storage/sheath/longer,3,80,0,1,weapon accessories,0,39,0,2,null
-RECIPE: /material/leather/,longsword sheath,/obj/item/clothing/accessory/storage/sheath/longsword,4,80,0,1,weapon accessories,0,39,0,2,null
-RECIPE: /material/leather/,katana sheath,/obj/item/clothing/accessory/storage/sheath/katana,3,80,0,1,weapon accessories,0,39,0,2,null
-RECIPE: /material/leather/,daisho sheath,/obj/item/clothing/accessory/storage/sheath/daisho,6,80,0,1,weapon accessories,0,39,0,2,null
 
 RECIPE: /material/leather/,sword sheath,/obj/item/clothing/accessory/storage/sheath,3,80,0,1,weapon accessories,0,54,0,8,null
 RECIPE: /material/leather/,longer sword sheath,/obj/item/clothing/accessory/storage/sheath/longer,3,80,0,1,weapon accessories,0,54,0,8,null
@@ -337,146 +270,47 @@ RECIPE: /material/leather/,longsword sheath,/obj/item/clothing/accessory/storage
 RECIPE: /material/leather/,katana sheath,/obj/item/clothing/accessory/storage/sheath/katana,3,80,0,1,weapon accessories,0,54,0,8,null
 RECIPE: /material/leather/,daisho sheath,/obj/item/clothing/accessory/storage/sheath/daisho,6,80,0,1,weapon accessories,0,54,0,8,null
 
-RECIPE: /material/leather/,bullet pouch,/obj/item/ammo_magazine/emptypouch,3,70,0,1,weapon accessories,0,0,85,8,null
-RECIPE: /material/leather/,hip holster,/obj/item/clothing/accessory/holster/hip,2,50,0,1,weapon accessories,0,0,85,8,null
-RECIPE: /material/leather/,double hip holster,/obj/item/clothing/accessory/holster/hip/double,3,70,0,1,weapon accessories,0,0,85,8,null
-
 //**************************************************************
 //*********************| ELECTRONICS ***************************
 //**************************************************************
 
-RECIPE: /material/electronics/,pill maker,/obj/structure/chem_master,20,120,1,1,none,100,0,0,8,null
-RECIPE: /material/electronics/,geiger counter,/obj/item/weapon/geiger_counter,5,120,0,1,none,110,0,0,8,null
-RECIPE: /material/electronics/,component analyser,/obj/item/weapon/analyser,18,100,0,1,none,218,0,0,8,null
-
 //*****************| ELECTRONICS RADIO & COMMUNICATION |***************************
-
-RECIPE: /material/electronics/,telephone,/obj/item/weapon/telephone,2,120,1,1,none,100,0,0,8,null
-RECIPE: /material/electronics/,radio transmitter,/obj/structure/radio/transmitter,6,150,1,1,none,105,0,0,8,null
-RECIPE: /material/electronics/,radio receiver,/obj/structure/radio,3,80,1,1,none,105,0,0,8,null
-RECIPE: /material/electronics/,2-way radio,/obj/structure/radio/transmitter_receiver,10,150,1,1,none,137,0,0,8,null
-RECIPE: /material/electronics/,portable radio,/obj/item/weapon/radio,12,100,0,1,none,141,0,0,8,null
-RECIPE: /material/electronics/,walkie-talkie radio,/obj/item/weapon/radio/walkietalkie,16,100,0,1,none,178,0,0,8,null
-RECIPE: /material/electronics/,mobile phone,/obj/item/weapon/telephone/mobile,20,100,0,1,none,212,0,0,8,null
 
 //*****************| ELECTRONICS CAMERAS |***************************
 
-RECIPE: /material/electronics/,early camera,/obj/item/camera/early,5,150,1,1,none,95,0,0,5,null
-RECIPE: /material/electronics/,black and white camera,/obj/item/camera/earlymodern,6,150,1,1,none,115,0,0,7,null
-RECIPE: /material/electronics/,early color camera,/obj/item/camera/coldwar,7,150,1,1,none,160,0,0,7,null
-RECIPE: /material/electronics/,modern camera,/obj/item/camera,7,150,1,1,none,205,0,0,8,null
-
 //*****************| ELECTRONICS FURNITURE |***************************
-
-RECIPE: /material/electronics/,television,/obj/structure/TV/television,3,80,1,1,none,160,0,0,8,null
 
 //**************************************************************
 //*********************| WOOLCLOTH |****************************
 //**************************************************************
 
 RECIPE: /material/woolcloth/,wool gloves,/obj/item/clothing/gloves/thick/leather/white,3,80,0,1,gloves,0,0,0,8,null
-RECIPE: /material/woolcloth/,wool coat,/obj/item/clothing/suit/storage/coat/fur/white,6,150,0,1,jackets & vests,0,0,20,8,null
-RECIPE: /material/woolcloth/,oven mittens,/obj/item/clothing/gloves/oven,3,80,0,1,gloves,45,0,8,8,null
-RECIPE: /material/woolcloth/,motorist gloves,/obj/item/clothing/gloves/motorist,3,80,0,1,gloves,0,0,180,8,null
+RECIPE: /material/woolcloth/,wool primitive coat,/obj/item/clothing/suit/prehistoricfurcoat/white,6,150,0,1,jackets & vests,0,0,20,8,null
 
 RECIPE: /material/woolcloth/,wool boots,/obj/item/clothing/shoes/fur/white,3,80,0,1,foot wear,0,0,0,8,null
-RECIPE: /material/woolcloth/,steppe wool shoes,/obj/item/clothing/shoes/steppe_shoes,3,80,0,1,foot wear,0,0,33,3,null
-RECIPE: /material/woolcloth/,courier sneakers,/obj/item/clothing/shoes/sneakers/courier,3,80,0,1,foot wear,0,0,180,8,null
+RECIPE: /material/woolcloth/,steppe wool shoes,/obj/item/clothing/shoes/steppe_shoes,3,80,0,1,foot wear,0,0,0,8,null
 
 //*****************| WOOLCLOTH HATS |***************************
 
-RECIPE: /material/woolcloth/,colored turban,/obj/item/clothing/head/turban,2,55,0,1,hats,0,0,18,8,null
-RECIPE: /material/woolcloth/,white turban,/obj/item/clothing/head/turban/imam,2,55,0,1,hats,0,18,0,8,null
-RECIPE: /material/woolcloth/,custom wool hood,/obj/item/clothing/head/custom/customhood,2,40,0,1,hats,0,0,26,8,null
-RECIPE: /material/woolcloth/,ainu bandana,/obj/item/clothing/head/ainu_bandana,4,70,0,1,hats,0,0,28,5,null
-RECIPE: /material/woolcloth/,steppe shaman hat,/obj/item/clothing/head/steppe_shaman,4,70,0,1,hats,0,0,33,3,null
-RECIPE: /material/woolcloth/,nun hood,/obj/item/clothing/head/nun_hood,4,65,0,1,hats,0,0,38,3,null
-RECIPE: /material/woolcloth/,brown padded head-cap,/obj/item/clothing/head/helmet/brown_eisenbruck,4,55,0,1,hats,0,32,42,2,null
-RECIPE: /material/woolcloth/,grey padded head-cap,/obj/item/clothing/head/helmet/grey_eisenbruck,4,55,0,1,hats,0,32,42,2,null
-RECIPE: /material/woolcloth/,ratty old padded head-cap,/obj/item/clothing/head/helmet/aged_eisenbruck,4,55,0,1,hats,0,32,42,2,null
-RECIPE: /material/woolcloth/,custom hennin,/obj/item/clothing/head/custom_hennin,2,40,0,1,hats,0,0,38,3,null
-RECIPE: /material/woolcloth/,artisan hat,/obj/item/clothing/head/artisan,2,55,0,1,hats,0,0,52,3,null
-RECIPE: /material/woolcloth/,red beret,/obj/item/clothing/head/red_beret,2,55,0,1,hats,0,0,62,8,null
-RECIPE: /material/woolcloth/,custom beret,/obj/item/clothing/head/custom/customberet,2,55,0,1,hats,0,0,62,8,null
-RECIPE: /material/woolcloth/,blue beret,/obj/item/clothing/head/blue_beret,2,55,0,1,hats,0,0,62,8,null
-RECIPE: /material/woolcloth/,brown flatcap,/obj/item/clothing/head/flatcap1,2,55,0,1,hats,0,0,109,8,null
-RECIPE: /material/woolcloth/,blue flatcap,/obj/item/clothing/head/flatcap2,2,55,0,1,hats,0,0,109,8,null
-RECIPE: /material/woolcloth/,grey flatcap,/obj/item/clothing/head/flatcap3,2,55,0,1,hats,0,0,109,8,null
-RECIPE: /material/woolcloth/,custom officer cap,/obj/item/clothing/head/custom_off_cap,4,95,0,1,hats,0,0,109,8,null
-RECIPE: /material/woolcloth/,custom field cap,/obj/item/clothing/head/custom/fieldcap,3,70,0,1,hats,0,0,109,8,null
-RECIPE: /material/woolcloth/,customizable beanie,/obj/item/clothing/head/custom/custom_beanie,2,130,0,1,hats,0,0,109,8,null
-RECIPE: /material/woolcloth/,count hat,/obj/item/clothing/head/count_hat,5,130,0,1,hats,0,0,35,8,null
+RECIPE: /material/woolcloth/,colored turban,/obj/item/clothing/head/turban,2,55,0,1,hats,0,0,0,8,null
+RECIPE: /material/woolcloth/,white turban,/obj/item/clothing/head/turban/imam,2,55,0,1,hats,0,0,0,8,null
+RECIPE: /material/woolcloth/,custom wool hood,/obj/item/clothing/head/custom/customhood,2,40,0,1,hats,0,0,0,8,null
+RECIPE: /material/woolcloth/,ainu bandana,/obj/item/clothing/head/ainu_bandana,4,70,0,1,hats,0,0,0,8,null
+RECIPE: /material/woolcloth/,steppe shaman hat,/obj/item/clothing/head/steppe_shaman,4,70,0,1,hats,0,0,0,8,null
 
 //*****************| WOOLCLOTH MASKS & EYEWEAR |***************************
 
-RECIPE: /material/woolcloth/,shemagh,/obj/item/clothing/mask/shemagh,2,55,0,1,masks & eyewear,0,0,33,8,null
-RECIPE: /material/woolcloth/,bandana,/obj/item/clothing/head/piratebandana1,2,55,0,1,masks & eyewear,0,0,62,3,null
-RECIPE: /material/woolcloth/,red kerchief,/obj/item/clothing/mask/shemagh/redkerchief,2,45,0,1,masks & eyewear,0,0,98,8,null
-RECIPE: /material/woolcloth/,grey kerchief,/obj/item/clothing/mask/shemagh/greykerchief,2,45,0,1,masks & eyewear,0,0,98,8,null
-
 //*****************| WOOLCLOTH UNIFORMS |***************************
 
-RECIPE: /material/woolcloth/,blue ainu robes,/obj/item/clothing/under/ainu,3,100,0,1,clothing,0,0,28,5,null
-RECIPE: /material/woolcloth/,brown ainu robes,/obj/item/clothing/under/ainu2,3,100,0,1,clothing,0,0,28,5,null
-RECIPE: /material/woolcloth/,steppe wool tunic,/obj/item/clothing/under/medieval/steppe_tunic,3,100,0,1,clothing,0,0,33,3,null
-RECIPE: /material/woolcloth/,kilt,/obj/item/clothing/under/medieval/kilt,2,100,0,1,clothing,0,0,38,8,null
-RECIPE: /material/woolcloth/,beggar clothing,/obj/item/clothing/under/medieval/beggar_clothing,2,100,0,1,clothing,0,0,38,8,null
-RECIPE: /material/woolcloth/,black haori,/obj/item/clothing/under/haori,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,blue haori,/obj/item/clothing/under/haori/blue,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,red haori,/obj/item/clothing/under/haori/red,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,customizable haori,/obj/item/clothing/under/haori,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,light hanfu,/obj/item/clothing/under/hanfu/light,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,dark hanfu,/obj/item/clothing/under/hanfu,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,green hanfu,/obj/item/clothing/under/hanfu/green,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,merchant outfit,/obj/item/clothing/under/merchant_suit,5,85,0,1,clothing,0,0,75,8,null
-RECIPE: /material/woolcloth/,count outfit,/obj/item/clothing/under/count_outfit,6,85,0,1,clothing,0,0,35,8,null
-RECIPE: /material/woolcloth/,artisan clothing,/obj/item/clothing/under/artisan,3,100,0,1,clothing,0,0,38,3,null
-RECIPE: /material/woolcloth/,dark artisan clothing,/obj/item/clothing/under/artisan/dark,3,100,0,1,clothing,0,0,38,3,null
-RECIPE: /material/woolcloth/,light artisan clothing,/obj/item/clothing/under/artisan/light,3,100,0,1,clothing,0,0,38,3,null
-RECIPE: /material/woolcloth/,customizable renaissance clothing,/obj/item/clothing/under/customren,6,105,0,1,clothing,0,0,59,3,null
-RECIPE: /material/woolcloth/,baggy renaissance clothing,/obj/item/clothing/under/renaissance,6,105,0,1,clothing,0,0,59,3,null
-RECIPE: /material/woolcloth/,pontifical renaissance clothing,/obj/item/clothing/under/renaissance_pontifical,6,105,0,1,clothing,0,0,59,3,null
-RECIPE: /material/woolcloth/,pilgrim uniform,/obj/item/clothing/under/pilgrim,4,75,0,1,clothing,0,0,80,4,null
-RECIPE: /material/woolcloth/,lederhosen,/obj/item/clothing/under/lederhosen,4,75,0,1,clothing,0,0,80,8,null
-RECIPE: /material/woolcloth/,custom victorian uniform,/obj/item/clothing/under/customvicuniform,3,75,0,1,clothing,0,0,98,8,null
-RECIPE: /material/woolcloth/,custom modern outfit,/obj/item/clothing/under/customuniform,4,75,0,1,clothing,0,0,120,8,null
-RECIPE: /material/woolcloth/,custom baggy modern outfit,/obj/item/clothing/under/customuniform/baggy,4,75,0,1,clothing,0,0,120,8,null
-RECIPE: /material/woolcloth/,custom short modern outfit,/obj/item/clothing/under/customuniform/short,4,75,0,1,clothing,0,0,120,8,null
-RECIPE: /material/woolcloth/,custom colonial outfit,/obj/item/clothing/under/customuniform/colonial,4,75,0,1,clothing,0,0,70,8,null
-RECIPE: /material/woolcloth/,custom short colonial outfit,/obj/item/clothing/under/customuniform/colonial/short,4,75,0,1,clothing,0,0,70,8,null
-RECIPE: /material/woolcloth/,motorist outfit,/obj/item/clothing/under/motorist,4,75,0,1,clothing,0,0,180,8,null
-RECIPE: /material/woolcloth/,punk outfit,/obj/item/clothing/under/punk,3,75,0,1,clothing,0,0,180,8,null
-RECIPE: /material/woolcloth/,waistcoat,/obj/item/clothing/under/waistcoat,5,110,0,1,clothing,0,0,105,8,null
-RECIPE: /material/woolcloth/,nun dress,/obj/item/clothing/under/nun,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/woolcloth/,plain black dress,/obj/item/clothing/under/blackdress,4,85,0,1,feminine clothing,0,0,38,6,null
-RECIPE: /material/woolcloth/,customizable dress,/obj/item/clothing/under/customdress,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/woolcloth/,customizable buttoned dress,/obj/item/clothing/under/customdress2,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/woolcloth/,short black dress,/obj/item/clothing/under/blackdress/short,4,75,0,1,feminine clothing,0,0,98,6,null
-RECIPE: /material/woolcloth/,proper black dress,/obj/item/clothing/under/victorian_prim,4,75,0,1,feminine clothing,0,0,105,8,null
+RECIPE: /material/woolcloth/,blue ainu robes,/obj/item/clothing/under/ainu,3,100,0,1,clothing,0,0,0,8,null
+RECIPE: /material/woolcloth/,brown ainu robes,/obj/item/clothing/under/ainu2,3,100,0,1,clothing,0,0,0,8,null
+RECIPE: /material/woolcloth/,steppe wool tunic,/obj/item/clothing/under/medieval/steppe_tunic,3,100,0,1,clothing,0,0,0,8,null
+RECIPE: /material/woolcloth/,indian shaman clothing,/obj/item/clothing/under/indianshaman,4,100,0,1,clothing,0,0,0,8,null
+
 //*****************| WOOLCLOTH SUITS & COATS |***************************
 
-RECIPE: /material/woolcloth/,steppe shaman wool coat,/obj/item/clothing/suit/storage/jacket/steppe_shaman,6,140,0,1,jackets & vests,0,0,33,3,null
-RECIPE: /material/woolcloth/,black jacket,/obj/item/clothing/suit/storage/jacket/piratejacket1,6,110,0,1,jackets & vests,0,0,57,3,null
-RECIPE: /material/woolcloth/,fancy brown jacket,/obj/item/clothing/suit/storage/jacket/piratejacket2,10,180,0,1,jackets & vests,0,0,57,3,null
-RECIPE: /material/woolcloth/,fancy red jacket,/obj/item/clothing/suit/storage/jacket/piratejacket5,10,180,0,1,jackets & vests,0,0,57,3,null
-RECIPE: /material/woolcloth/,blue vest,/obj/item/clothing/suit/storage/jacket/piratejacket3,4,75,0,1,jackets & vests,0,0,57,8,null
-RECIPE: /material/woolcloth/,black vest,/obj/item/clothing/suit/storage/jacket/piratejacket4,4,75,0,1,jackets & vests,0,0,57,8,null
-RECIPE: /material/woolcloth/,olive vest,/obj/item/clothing/suit/storage/jacket/olivevest,4,80,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/woolcloth/,brown winter coat,/obj/item/clothing/suit/storage/coat/japcoat2/brown,10,200,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/woolcloth/,grey winter coat,/obj/item/clothing/suit/storage/coat/ruscoat/grey,10,200,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/woolcloth/,brown bomber's jacket,/obj/item/clothing/suit/storage/coat/ww2/bomberjacketbrown,4,70,0,1,jackets & vests,0,0,109,8,null
-RECIPE: /material/woolcloth/,black bomber's jacket,/obj/item/clothing/suit/storage/coat/ww2/bomberjacketblack,4,70,0,1,jackets & vests,0,0,109,8,null
-RECIPE: /material/woolcloth/,service jacket,/obj/item/clothing/suit/storage/coat/ww2/servicejacket,3,70,0,1,jackets & vests,0,0,109,8,null
-RECIPE: /material/woolcloth/,modern coat,/obj/item/clothing/suit/storage/coat/ww2/moderncoat,4,70,0,1,jackets & vests,0,0,109,8,null
-RECIPE: /material/woolcloth/,charcoal suit,/obj/item/clothing/suit/storage/jacket/charcoal_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/woolcloth/,black suit,/obj/item/clothing/suit/storage/jacket/black_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/woolcloth/,dark black suit,/obj/item/clothing/suit/storage/jacket/really_black_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/woolcloth/,burgundy suit,/obj/item/clothing/suit/storage/jacket/burgundy_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/woolcloth/,checkered suit,/obj/item/clothing/suit/storage/jacket/checkered_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/woolcloth/,navy suit,/obj/item/clothing/suit/storage/jacket/navy_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/woolcloth/,grey parka,/obj/item/clothing/suit/storage/coat/ww2/german/civ,8,100,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/woolcloth/,motorist jacket,/obj/item/clothing/suit/storage/jacket/motorist,6,110,0,1,jackets & vests,180,0,0,8,null
-RECIPE: /material/woolcloth/,victorian peacoat,/obj/item/clothing/suit/storage/coat/victorian_peacoat,7,110,0,1,jackets & vests,0,0,105,8,null
+RECIPE: /material/woolcloth/,steppe shaman wool coat,/obj/item/clothing/suit/storage/jacket/steppe_shaman,6,140,0,1,jackets & vests,0,0,0,8,null
+
 //*****************| WOOLCLOTH ACCESSORIES |***************************
 
 RECIPE: /material/woolcloth/,customizable armband,/obj/item/clothing/accessory/custom/armband,1,30,0,1,accessories,0,0,0,8,null
@@ -486,9 +320,6 @@ RECIPE: /material/woolcloth/,customizable tabard,/obj/item/clothing/accessory/cu
 RECIPE: /material/woolcloth/,customizable apron,/obj/item/clothing/accessory/custom/apron,2,30,0,1,accessories,0,0,0,8,null
 RECIPE: /material/woolcloth/,customizable priest band,/obj/item/clothing/accessory/custom/priest_band,1.5,50,0,1,accessories,0,0,28,8,null
 RECIPE: /material/woolcloth/,customizable scarf,/obj/item/clothing/accessory/custom/scarf,2,30,0,1,accessories,0,0,70,8,null
-RECIPE: /material/woolcloth/,neck ruffle,/obj/item/clothing/accessory/ruffle/neck,2,30,0,1,accessories,0,0,70,3,null
-RECIPE: /material/woolcloth/,customizable tie,/obj/item/clothing/accessory/custom/tie,2,50,0,1,accessories,0,0,95,8,null
-RECIPE: /material/woolcloth/,customizable bowtie,/obj/item/clothing/accessory/custom/bowtie,2,50,0,1,accessories,0,0,95,8,null
 
 //*****************| WOOLCLOTH BEDSHEETS |***************************
 
@@ -504,12 +335,6 @@ RECIPE: /material/woolcloth/,red bedsheet,/obj/item/weapon/bedsheet/red,2,75,0,1
 //**************************************************************
 
 RECIPE: /material/cloth/,small sail,/obj/item/sail,15,125,0,1,none,0,0,22,8,null
-RECIPE: /material/cloth/,cigarette pack,/obj/item/weapon/storage/fancy/cigarettes,1,20,0,1,none,90,0,0,8,null
-RECIPE: /material/cloth/,sandbag,/obj/item/weapon/barrier/sandbag/empty,1,105,0,1,none,0,0,90,8,null
-
-RECIPE: /material/cloth/,courier sneakers,/obj/item/clothing/shoes/sneakers/courier,3,80,0,1,foot wear,0,0,180,8,null
-RECIPE: /material/cloth/,oven mittens,/obj/item/clothing/gloves/oven,3,80,0,1,gloves,45,0,8,8,null
-RECIPE: /material/cloth/,motorist gloves,/obj/item/clothing/gloves/motorist,3,80,0,1,gloves,0,0,180,8,null
 
 //*****************| CLOTH ACCESSORIES |***************************
 
@@ -520,9 +345,6 @@ RECIPE: /material/cloth/,customizable tabard,/obj/item/clothing/accessory/custom
 RECIPE: /material/cloth/,customizable apron,/obj/item/clothing/accessory/custom/apron,2,30,0,1,accessories,0,0,0,8,null
 RECIPE: /material/cloth/,customizable priest band,/obj/item/clothing/accessory/custom/priest_band,1.5,50,0,1,accessories,0,0,28,8,null
 RECIPE: /material/cloth/,customizable scarf,/obj/item/clothing/accessory/custom/scarf,2,30,0,1,accessories,0,0,70,8,null
-RECIPE: /material/cloth/,neck ruffle,/obj/item/clothing/accessory/ruffle/neck,2,30,0,1,accessories,0,0,70,3,null
-RECIPE: /material/cloth/,customizable tie,/obj/item/clothing/accessory/custom/tie,2,50,0,1,accessories,0,0,95,8,null
-RECIPE: /material/cloth/,customizable bowtie,/obj/item/clothing/accessory/custom/bowtie,2,50,0,1,accessories,0,0,95,8,null
 
 //*****************| CLOTH BEDSHEETS |***************************
 
@@ -546,7 +368,6 @@ RECIPE: /material/cloth/,bandages,/obj/item/stack/medical/bruise_pack/bint,1,75,
 RECIPE: /material/cloth/,surgery kit,/obj/item/weapon/storage/firstaid/surgery_empty,6,90,0,1,healthcare,18,0,26,8,null
 RECIPE: /material/cloth/,burn kit,/obj/item/stack/medical/advanced/ointment,1,90,0,1,healthcare,0,0,43,8,null
 RECIPE: /material/cloth/,trauma kit,/obj/item/stack/medical/advanced/bruise_pack,2,105,0,1,healthcare,0,0,56,8,null
-RECIPE: /material/cloth/,surgical mask,/obj/item/clothing/mask/sterile,1,140,0,1,healthcare,0,0,108,8,null
 
 //*****************| CLOTH CARPETS |***************************
 
@@ -570,401 +391,108 @@ RECIPE: /material/cloth/,sofa (right),/obj/structure/bed/sofa/right,8,140,1,1,fu
 
 ***************************| CLOTH SUITS, VESTS, COATS, JACKETS |***************************
 
-RECIPE: /material/cloth/,plague doctor suit,/obj/item/clothing/suit/storage/jacket/plaguedoctor,5,120,0,1,jackets & vests,0,0,38,3,null
-RECIPE: /material/cloth/,custom haori jacket,/obj/item/clothing/suit/storage/jacket/custom/haori_jacket,4,75,0,1,jackets & vests,0,0,38,8,null
-RECIPE: /material/cloth/,black haori jacket,/obj/item/clothing/suit/storage/jacket/custom/haori_jacket,4,75,0,1,jackets & vests,0,0,38,8,null
-RECIPE: /material/cloth/,custom colonial jacket,/obj/item/clothing/suit/storage/jacket/customcolonial,5,90,0,1,jackets & vests,0,0,57,3,null
-RECIPE: /material/cloth/,custom colonial coat,/obj/item/clothing/suit/storage/jacket/customcolonialcoat,7,120,0,1,jackets & vests,0,0,57,3,null
-RECIPE: /material/cloth/,black jacket,/obj/item/clothing/suit/storage/jacket/piratejacket1,6,110,0,1,jackets & vests,0,0,57,4,null
-RECIPE: /material/cloth/,fancy brown jacket,/obj/item/clothing/suit/storage/jacket/piratejacket2,10,180,0,1,jackets & vests,0,0,57,3,null
-RECIPE: /material/cloth/,fancy red jacket,/obj/item/clothing/suit/storage/jacket/piratejacket5,10,180,0,1,jackets & vests,0,0,57,3,null
-RECIPE: /material/cloth/,blue vest,/obj/item/clothing/suit/storage/jacket/piratejacket3,4,75,0,1,jackets & vests,0,0,57,8,null
-RECIPE: /material/cloth/,black vest,/obj/item/clothing/suit/storage/jacket/piratejacket4,4,75,0,1,jackets & vests,0,0,57,8,null
 RECIPE: /material/cloth/,customizable poncho,/obj/item/clothing/suit/storage/jacket/custom/poncho,2,100,0,1,jackets & vests,0,0,57,8,null
-RECIPE: /material/cloth/,black vest,/obj/item/clothing/suit/storage/jacket/blackvest,4,80,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/cloth/,blue vest,/obj/item/clothing/suit/storage/jacket/bluevest,4,80,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/cloth/,olive vest,/obj/item/clothing/suit/storage/jacket/olivevest,4,80,0,1,jackets & vests,0,0,89,8,null
-RECIPE: /material/cloth/,brown winter coat,/obj/item/clothing/suit/storage/coat/japcoat2/brown,10,200,0,1,jackets & vests,0,0,99,8,null
-RECIPE: /material/cloth/,grey winter coat,/obj/item/clothing/suit/storage/coat/ruscoat/grey,10,200,0,1,jackets & vests,0,0,99,8,null
-RECIPE: /material/cloth/,charcoal suit,/obj/item/clothing/suit/storage/jacket/charcoal_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,black suit,/obj/item/clothing/suit/storage/jacket/black_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,dark black suit,/obj/item/clothing/suit/storage/jacket/really_black_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,burgundy suit,/obj/item/clothing/suit/storage/jacket/burgundy_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,checkered suit,/obj/item/clothing/suit/storage/jacket/checkered_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,victorian tailcoat,/obj/item/clothing/suit/storage/jacket/vict_tailcoat,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,cream short jacket,/obj/item/clothing/suit/storage/jacket/texan,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,navy suit,/obj/item/clothing/suit/storage/jacket/navy_suit,15,200,0,1,jackets & vests,0,0,112,8,null
-RECIPE: /material/cloth/,olive drab NBC suit,/obj/item/clothing/suit/nbc/olive,12,200,0,1,jackets & vests,0,0,145,8,null
-RECIPE: /material/cloth/,olive drab NBC hood,/obj/item/clothing/head/nbc/olive,3,100,0,1,jackets & vests,0,0,145,8,null
-RECIPE: /material/cloth/,yellow NBC suit,/obj/item/clothing/suit/nbc,12,200,0,1,jackets & vests,0,0,145,8,null
-RECIPE: /material/cloth/,yellow NBC hood,/obj/item/clothing/head/nbc,3,100,0,1,jackets & vests,0,0,145,8,null
-RECIPE: /material/cloth/,grey parka,/obj/item/clothing/suit/storage/coat/ww2/german/civ,8,100,0,1,jackets & vests,0,0,145,8,null
-RECIPE: /material/cloth/,blue hawaiian shirt,/obj/item/clothing/suit/hawaiian,3,100,0,1,jackets & vests,0,0,165,8,null
-RECIPE: /material/cloth/,orange hawaiian shirt,/obj/item/clothing/suit/hawaiian/orange,3,100,0,1,jackets & vests,0,0,165,8,null
-RECIPE: /material/cloth/,purple hawaiian shirt,/obj/item/clothing/suit/hawaiian/purple,3,100,0,1,jackets & vests,0,0,165,8,null
-RECIPE: /material/cloth/,green hawaiian shirt,/obj/item/clothing/suit/hawaiian/green,3,100,0,1,jackets & vests,0,0,165,8,null
-RECIPE: /material/cloth/,motorist jacket,/obj/item/clothing/under/motorist,6,110,0,1,jackets & vests,0,0,180,8,null
-RECIPE: /material/cloth/,chest length apron,/obj/item/clothing/suit/storage/closechest_apron_f,4,100,0,1,jackets & vests,0,0,105,8,null
-RECIPE: /material/cloth/,waist length apron,/obj/item/clothing/suit/storage/openchest_apron_f,4,100,0,1,jackets & vests,0,0,105,8,null
-
 
 //*****************| CLOTH ARMOR |***************************
 
-RECIPE: /material/cloth/,linothorax armor,/obj/item/clothing/suit/armor/ancient/linen,8,100,0,1,armor,0,20,23,3,null
-
-RECIPE: /material/cloth/,purple arabic turban helmet,/obj/item/clothing/head/helmet/medieval/nomads/arab,5,75,0,1,armor,0,0,38,3,null
-RECIPE: /material/cloth/,red arabic turban helmet,/obj/item/clothing/head/helmet/medieval/nomads/arab2,5,75,0,1,armor,0,0,38,3,null
-RECIPE: /material/cloth/,green arabic turban helmet,/obj/item/clothing/head/helmet/medieval/nomads/arab3,5,75,0,1,armor,0,0,38,3,null
-RECIPE: /material/cloth/,blue arabic turban helmet,/obj/item/clothing/head/helmet/medieval/nomads/arab4,5,75,0,1,armor,0,0,38,3,null
-RECIPE: /material/cloth/,emirate turban,/obj/item/clothing/head/helmet/medieval/emirate,7,90,0,1,armor,0,0,38,3,null
-
 //*****************| CLOTH HATS |***************************
 
-RECIPE: /material/cloth/,fiendish headdress,/obj/item/clothing/head/fiendish,4,55,0,1,hats,0,0,18,4,null
-RECIPE: /material/cloth/,semitic cap,/obj/item/clothing/head/semitic_cap,4,55,0,1,hats,0,0,18,3,null
-RECIPE: /material/cloth/,mayan headdress,/obj/item/clothing/head/mayan_headdress,4,55,0,1,hats,0,0,18,3,null
-RECIPE: /material/cloth/,pharoah headdress,/obj/item/clothing/head/pharoah,6,55,0,1,hats,0,0,18,1,null
-RECIPE: /material/cloth/,nemes headdress,/obj/item/clothing/head/nemes,6,55,0,1,hats,0,0,18,1,null
-RECIPE: /material/cloth/,black egyptian headdress,/obj/item/clothing/head/egyptian_headdress_black,4,55,0,1,hats,0,0,18,1,null
-RECIPE: /material/cloth/,blue egyptian headdress,/obj/item/clothing/head/egyptian_headdress_blue,4,55,0,1,hats,0,0,18,1,null
-RECIPE: /material/cloth/,red egyptian headdress,/obj/item/clothing/head/egyptian_headdress_red,4,55,0,1,hats,0,0,18,1,null
-RECIPE: /material/cloth/,hedjet crown,/obj/item/clothing/head/hedjet,5,65,0,1,hats,0,0,18,1,null
-RECIPE: /material/cloth/,deshret crown,/obj/item/clothing/head/deshret,5,65,0,1,hats,0,0,18,1,null
-RECIPE: /material/cloth/,straw hat,/obj/item/clothing/head/strawhat,3,55,0,1,hats,0,0,18,8,null
-RECIPE: /material/cloth/,pschent crown,/obj/item/clothing/head/pschent,5,65,0,1,hats,0,0,24,1,null
-RECIPE: /material/cloth/,ainu bandana,/obj/item/clothing/head/ainu_bandana,4,70,0,1,hats,0,0,28,5,null
-RECIPE: /material/cloth/,brown padded head-cap,/obj/item/clothing/head/helmet/brown_eisenbruck,4,55,0,1,hats,0,32,42,2,null
-RECIPE: /material/cloth/,grey padded head-cap,/obj/item/clothing/head/helmet/grey_eisenbruck,4,55,0,1,hats,0,32,42,2,null
-RECIPE: /material/cloth/,ratty old padded head-cap,/obj/item/clothing/head/helmet/aged_eisenbruck,4,55,0,1,hats,0,32,42,2,null
-RECIPE: /material/cloth/,hooded cape,/obj/item/clothing/head/hooded_cape,6,100,0,1,hats,0,0,35,3,null
-RECIPE: /material/cloth/,colored turban,/obj/item/clothing/head/turban,2,55,0,1,hats,0,0,38,8,null
-RECIPE: /material/cloth/,white turban,/obj/item/clothing/head/turban/imam,2,55,0,1,hats,0,0,38,8,null
-RECIPE: /material/cloth/,grand turban,/obj/item/clothing/head/turban/sultan,5,110,0,1,hats,0,0,38,8,null
-RECIPE: /material/cloth/,custom keffiyeh,/obj/item/clothing/head/custom_keffiyeh,2,55,0,1,hats,0,0,38,8,null
-RECIPE: /material/cloth/,phrigian hat,/obj/item/clothing/head/phrigian_hat,4,55,0,1,hats,0,0,38,2,null
-RECIPE: /material/cloth/,red phrigian hat,/obj/item/clothing/head/phrigian_hat/red,4,55,0,1,hats,0,0,38,2,null
-RECIPE: /material/cloth/,blue phrigian hat,/obj/item/clothing/head/phrigian_hat/blue,4,55,0,1,hats,0,0,38,2,null
-RECIPE: /material/cloth/,doge hat,/obj/item/clothing/head/phrigian_hat/doge,4,104,0,1,hats,0,0,38,3,null
-RECIPE: /material/cloth/,plague doctor hat,/obj/item/clothing/head/plaguedoctor,4,65,0,1,hats,0,0,38,3,null
-RECIPE: /material/cloth/,nun hood,/obj/item/clothing/head/nun_hood,4,65,0,1,hats,0,0,38,3,null
-RECIPE: /material/cloth/,customizable hennin,/obj/item/clothing/head/custom_hennin,2,55,0,1,hats,0,0,38,3,null
-RECIPE: /material/cloth/,custom noble hat,/obj/item/clothing/head/custom/customnoblehat,4,55,0,1,hats,0,0,38,3,null
-RECIPE: /material/cloth/,feathered hat,/obj/item/clothing/head/feathered_hat,3,55,0,1,hats,0,0,52,8,null
-RECIPE: /material/cloth/,custom feather cap,/obj/item/clothing/head/custom_feathered_hat,4,55,0,1,hats,0,0,52,8,null
-RECIPE: /material/cloth/,kasa hat,/obj/item/clothing/head/helmet/kasa,3,75,0,1,hats,0,0,40,8,null
-RECIPE: /material/cloth/,jingasa hat,/obj/item/clothing/head/helmet/jingasa,5,75,0,1,hats,0,0,40,8,null
-RECIPE: /material/cloth/,gat hat,/obj/item/clothing/head/gat,2,55,0,1,hats,0,0,52,8,null
-RECIPE: /material/cloth/,artisan hat,/obj/item/clothing/head/artisan,2,55,0,1,hats,0,0,52,3,null
-RECIPE: /material/cloth/,red beret,/obj/item/clothing/head/red_beret,2,55,0,1,hats,0,0,62,8,null
-RECIPE: /material/cloth/,blue beret,/obj/item/clothing/head/blue_beret,2,55,0,1,hats,0,0,62,8,null
-RECIPE: /material/cloth/,custom beret,/obj/item/clothing/head/custom/customberet,2,55,0,1,hats,0,0,62,8,null
-RECIPE: /material/cloth/,black bicorne,/obj/item/clothing/head/bicorne_british_soldier,2,95,0,1,hats,0,0,78,4,null
-RECIPE: /material/cloth/,black tricorne,/obj/item/clothing/head/tricorne_black,3,75,0,1,hats,0,0,78,4,null
-RECIPE: /material/cloth/,tarred hat,/obj/item/clothing/head/tarred_hat,3,75,0,1,hats,0,0,78,5,null
-RECIPE: /material/cloth/,capotain,/obj/item/clothing/head/capotain,4,75,0,1,hats,0,0,80,4,null
-RECIPE: /material/cloth/,pilgrim hat,/obj/item/clothing/head/capotain/pilgrim,4,75,0,1,hats,0,0,80,4,null
-RECIPE: /material/cloth/,nurse hat,/obj/item/clothing/head/nurse,2,50,0,1,hats,0,0,88,8,null
-RECIPE: /material/cloth/,bowler hat,/obj/item/clothing/head/bowler_hat,2,55,0,1,hats,0,0,98,5,null
-RECIPE: /material/cloth/,sombrero,/obj/item/clothing/head/sombrero,4,75,0,1,hats,0,0,98,8,null
-RECIPE: /material/cloth/,vaquero hat,/obj/item/clothing/head/vaquerohat,4,75,0,1,hats,0,0,98,4,null
-RECIPE: /material/cloth/,bandit hat,/obj/item/clothing/head/bandit,4,75,0,1,hats,0,0,98,4,null
-RECIPE: /material/cloth/,tophat,/obj/item/clothing/head/top_hat,5,95,0,1,hats,0,0,109,5,null
-RECIPE: /material/cloth/,ten gallon hat,/obj/item/clothing/head/ten_gallon,5,95,0,1,hats,0,0,109,5,null
-RECIPE: /material/cloth/,brown flatcap,/obj/item/clothing/head/flatcap1,2,55,0,1,hats,0,0,109,8,null
-RECIPE: /material/cloth/,blue flatcap,/obj/item/clothing/head/flatcap2,2,55,0,1,hats,0,0,109,8,null
-RECIPE: /material/cloth/,grey flatcap,/obj/item/clothing/head/flatcap3,2,55,0,1,hats,0,0,109,8,null
-RECIPE: /material/cloth/,custom officer cap,/obj/item/clothing/head/custom_off_cap,4,95,0,1,hats,0,0,109,8,null
-RECIPE: /material/cloth/,custom field cap,/obj/item/clothing/head/custom/fieldcap,3,70,0,1,hats,0,0,109,8,null
-RECIPE: /material/cloth/,black balaclava,/obj/item/clothing/mask/balaclava,2,130,0,1,hats,0,0,109,8,null
-RECIPE: /material/cloth/,customizable beanie,/obj/item/clothing/head/custom/custom_beanie,2,130,0,1,hats,0,0,109,8,null
-RECIPE: /material/cloth/,count hat,/obj/item/clothing/head/count_hat,5,130,0,1,hats,0,0,35,8,null
-RECIPE: /material/cloth/,police cap,/obj/item/clothing/head/traffic_police,4,75,0,1,military & law enforcement clothes,0,0,160,8,null
+RECIPE: /material/cloth/,fiendish headdress,/obj/item/clothing/head/fiendish,4,55,0,1,hats,0,0,0,8,null
+RECIPE: /material/cloth/,straw hat,/obj/item/clothing/head/strawhat,3,55,0,1,hats,0,0,0,8,null
+RECIPE: /material/cloth/,ainu bandana,/obj/item/clothing/head/ainu_bandana,4,70,0,1,hats,0,0,0,8,null
+RECIPE: /material/cloth/,hooded cape,/obj/item/clothing/head/hooded_cape,6,100,0,1,hats,0,0,0,8,null
+RECIPE: /material/cloth/,colored turban,/obj/item/clothing/head/turban,2,55,0,1,hats,0,0,0,8,null
+RECIPE: /material/cloth/,white turban,/obj/item/clothing/head/turban/imam,2,55,0,1,hats,0,0,0,8,null
+RECIPE: /material/cloth/,grand turban,/obj/item/clothing/head/turban/sultan,5,110,0,1,hats,0,0,0,8,null
 
 //*****************| CLOTH MASKS & EYEWEAR |***************************
 
 RECIPE: /material/cloth/,eyepatch,/obj/item/clothing/glasses/eyepatch,2,55,0,1,masks & eyewear,0,0,18,8,null
 RECIPE: /material/cloth/,blindfold,/obj/item/clothing/glasses/sunglasses/blindfold,2,55,0,1,masks & eyewear,0,0,18,8,null
-RECIPE: /material/cloth/,plague doctor mask,/obj/item/clothing/mask/plaguedoctor,4,90,0,1,masks & eyewear,0,0,38,3,null
-RECIPE: /material/cloth/,shemagh,/obj/item/clothing/mask/shemagh,2,55,0,1,masks & eyewear,0,0,38,8,null
-RECIPE: /material/cloth/,kerchief,/obj/item/clothing/head/kerchief,2,75,0,1,masks & eyewear,0,0,38,8,null
-RECIPE: /material/cloth/,bandana,/obj/item/clothing/head/piratebandana1,2,55,0,1,masks & eyewear,0,0,52,8,null
-RECIPE: /material/cloth/,custom bandana,/obj/item/clothing/head/custom/custombandana,2,55,0,1,masks & eyewear,0,0,52,8,null
-RECIPE: /material/cloth/,red kerchief,/obj/item/clothing/mask/shemagh/redkerchief,2,45,0,1,masks & eyewear,0,0,98,8,null
-RECIPE: /material/cloth/,grey kerchief,/obj/item/clothing/mask/shemagh/greykerchief,2,45,0,1,masks & eyewear,0,0,98,8,null
-RECIPE: /material/cloth/,sterile mask,/obj/item/clothing/mask/sterile,2,130,0,1,masks & eyewear,0,0,140,8,null
 
 //*****************| CLOTH UNIFORMS |***************************
 
-RECIPE: /material/cloth/,cotton loincloth,/obj/item/clothing/under/loincotton,2,45,0,1,clothing,0,0,0,0,null
-RECIPE: /material/cloth/,mayan loincloth,/obj/item/clothing/under/mayan_loincloth,2,55,0,1,clothing,0,0,6,3,null
+RECIPE: /material/cloth/,cotton loincloth,/obj/item/clothing/under/loincotton,2,45,0,1,clothing,0,0,0,8,null
 RECIPE: /material/cloth/,towl,/obj/item/clothing/under/towl,1,25,0,1,clothing,0,0,12,8,null
-RECIPE: /material/cloth/,huipil,/obj/item/clothing/under/huipil,3,55,0,1,clothing,0,0,18,4,null
-RECIPE: /material/cloth/,half huipil,/obj/item/clothing/under/halfhuipil,2,45,0,1,clothing,0,0,18,4,null
-RECIPE: /material/cloth/,white kimono,/obj/item/clothing/under/kimono,4,85,0,1,clothing,0,0,18,8,null
-RECIPE: /material/cloth/,customizable tunic,/obj/item/clothing/under/custom/roman,4,85,0,1,clothing,0,0,18,8,null
-RECIPE: /material/cloth/,customizable toga,/obj/item/clothing/under/custom/toga,3,65,0,1,clothing,0,0,18,2,null
-RECIPE: /material/cloth/,customizable shendyt,/obj/item/clothing/under/custom/shendyt,2,45,0,1,clothing,0,0,18,2,null
-RECIPE: /material/cloth/,customizable celtic trousers,/obj/item/clothing/under/custom/celtic,2,55,0,1,clothing,0,0,18,1,null
-RECIPE: /material/cloth/,customizable tribal robe,/obj/item/clothing/under/customtribalrobe,3,100,0,1,clothing,0,0,18,3,null
-RECIPE: /material/cloth/,fancy shendyt,/obj/item/clothing/under/pharaoh,8,145,0,1,clothing,0,0,21,2,null
-RECIPE: /material/cloth/,great shendyt,/obj/item/clothing/under/pharaoh2,10,185,0,1,clothing,0,0,21,2,null
-RECIPE: /material/cloth/,blue ainu robes,/obj/item/clothing/under/ainu,3,100,0,1,clothing,0,0,28,5,null
-RECIPE: /material/cloth/,brown ainu robes,/obj/item/clothing/under/ainu2,3,100,0,1,clothing,0,0,28,5,null
-RECIPE: /material/cloth/,black haori,/obj/item/clothing/under/haori,3,100,0,1,clothing,0,0,38,8,null
-RECIPE: /material/cloth/,blue haori,/obj/item/clothing/under/haori/blue,3,100,0,1,clothing,0,0,38,8,null
-RECIPE: /material/cloth/,red haori,/obj/item/clothing/under/haori/red,3,100,0,1,clothing,0,0,38,8,null
-RECIPE: /material/cloth/,customizable haori,/obj/item/clothing/under/haori,3,100,0,1,clothing,0,0,38,8,null
-RECIPE: /material/cloth/,beggar clothing,/obj/item/clothing/under/medieval/beggar_clothing,2,100,0,1,clothing,0,0,38,8,null
-RECIPE: /material/cloth/,black priest outfit,/obj/item/clothing/under/christian_priest,4,85,0,1,clothing,0,0,38,8,null
-RECIPE: /material/cloth/,merchant outfit,/obj/item/clothing/under/merchant_suit,5,85,0,1,clothing,0,0,75,8,null
-RECIPE: /material/cloth/,count outfit,/obj/item/clothing/under/count_outfit,6,85,0,1,clothing,0,0,35,8,null
-RECIPE: /material/cloth/,customizable tunic,/obj/item/clothing/under/custom/tunic,4,85,0,1,clothing,0,0,38,5,null
-RECIPE: /material/cloth/,customizable crinoline dress,/obj/item/clothing/under/crinoline_dress,4,85,0,1,clothing,0,0,38,5,null
-RECIPE: /material/cloth/,customizable arabic tunic,/obj/item/clothing/under/custom/arabictunic,4,85,0,1,clothing,0,0,38,5,null
-RECIPE: /material/cloth/,light brown arabic tunic,/obj/item/clothing/under/medieval/arab1,3,85,0,1,clothing,0,0,38,5,null
-RECIPE: /material/cloth/,light white arabic tunic,/obj/item/clothing/under/medieval/arab2,3,85,0,1,clothing,0,0,38,5,null
-RECIPE: /material/cloth/,emirate tunic,/obj/item/clothing/under/medieval/emirate,4,85,0,1,clothing,0,0,38,5,null
-RECIPE: /material/cloth/,light hanfu,/obj/item/clothing/under/hanfu/light,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/cloth/,dark hanfu,/obj/item/clothing/under/hanfu,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/cloth/,green hanfu,/obj/item/clothing/under/hanfu/green,3,100,0,1,clothing,0,0,38,6,null
-RECIPE: /material/cloth/,doge outfit,/obj/item/clothing/under/renaissance/doge,8,147,0,1,clothing,0,0,38,3,null
-RECIPE: /material/cloth/,customizable renaissance clothing,/obj/item/clothing/under/customren,6,105,0,1,clothing,0,0,59,3,null
-RECIPE: /material/cloth/,customizable pontifical clothing,/obj/item/clothing/under/custompontifical,6,105,0,1,clothing,0,0,59,8,null
-RECIPE: /material/cloth/,baggy renaissance clothing,/obj/item/clothing/under/renaissance,6,105,0,1,clothing,0,0,59,3,null
-RECIPE: /material/cloth/,pontifical renaissance clothing,/obj/item/clothing/under/renaissance_pontifical,6,105,0,1,clothing,0,0,59,3,null
-RECIPE: /material/cloth/,artisan clothing,/obj/item/clothing/under/artisan,3,100,0,1,clothing,0,0,59,3,null
-RECIPE: /material/cloth/,dark artisan clothing,/obj/item/clothing/under/artisan/dark,3,100,0,1,clothing,0,0,59,3,null
-RECIPE: /material/cloth/,light artisan clothing,/obj/item/clothing/under/artisan/light,3,100,0,1,clothing,0,0,59,3,null
-RECIPE: /material/cloth/,blue colonial clothing,/obj/item/clothing/under/civ1,3,75,0,1,clothing,0,0,78,4,null
-RECIPE: /material/cloth/,white colonial clothing,/obj/item/clothing/under/civ2,3,75,0,1,clothing,0,0,78,4,null
-RECIPE: /material/cloth/,short-sleeved colonial clothing,/obj/item/clothing/under/civ3,2,55,0,1,clothing,0,0,78,4,null
-RECIPE: /material/cloth/,fancy colonial clothing,/obj/item/clothing/under/civ4,5,105,0,1,clothing,0,0,78,4,null
-RECIPE: /material/cloth/,green colonial clothing,/obj/item/clothing/under/civ5,3,75,0,1,clothing,0,0,78,4,null
-RECIPE: /material/cloth/,pink colonial clothing,/obj/item/clothing/under/civ6,3,75,0,1,clothing,0,0,78,4,null
-RECIPE: /material/cloth/,black stripes clothing,/obj/item/clothing/under/pirate1,3,75,0,1,clothing,0,0,78,3,null
-RECIPE: /material/cloth/,red stripes clothing,/obj/item/clothing/under/pirate2,3,75,0,1,clothing,0,0,78,3,null
-RECIPE: /material/cloth/,blue stripes clothing,/obj/item/clothing/under/pirate3,3,75,0,1,clothing,0,0,78,3,null
-RECIPE: /material/cloth/,customizable pyjamas,/obj/item/clothing/under/custompyjamas,3,100,0,1,clothing,0,0,78,8,null
-RECIPE: /material/cloth/,pilgrim uniform,/obj/item/clothing/under/pilgrim,4,75,0,1,clothing,0,0,80,4,null
-RECIPE: /material/cloth/,lederhosen,/obj/item/clothing/under/lederhosen,4,75,0,1,clothing,0,0,80,8,null
-RECIPE: /material/cloth/,pioneer outfit,/obj/item/clothing/under/industrial1,3,75,0,1,clothing,0,0,98,5,null
-RECIPE: /material/cloth/,rancher outfit,/obj/item/clothing/under/industrial2,3,75,0,1,clothing,0,0,98,6,null
-RECIPE: /material/cloth/,cowboy outfit,/obj/item/clothing/under/industrial3,3,75,0,1,clothing,0,0,98,8,null
-RECIPE: /material/cloth/,customizable pyjamas,/obj/item/clothing/under/custompyjamas,3,100,0,1,clothing,0,0,98,8,null
-RECIPE: /material/cloth/,checkered outfit,/obj/item/clothing/under/industrial4,3,75,0,1,clothing,0,0,112,8,null
-RECIPE: /material/cloth/,light brown outfit,/obj/item/clothing/under/modern1,4,75,0,1,clothing,112,0,0,8,null
-RECIPE: /material/cloth/,black outfit,/obj/item/clothing/under/modern2,4,75,0,1,clothing,112,0,0,8,null
-RECIPE: /material/cloth/,grey outfit,/obj/item/clothing/under/modern3,4,75,0,1,clothing,112,0,0,8,null
-RECIPE: /material/cloth/,brown outfit,/obj/item/clothing/under/modern4,4,75,0,1,clothing,112,0,0,8,null
-RECIPE: /material/cloth/,farmer outfit,/obj/item/clothing/under/farmer_outfit,4,75,0,1,clothing,112,0,0,8,null
-RECIPE: /material/cloth/,mechanic outfit,/obj/item/clothing/under/mechanic_outfit,4,75,0,1,clothing,112,0,0,8,null
-RECIPE: /material/cloth/,custom victorian uniform,/obj/item/clothing/under/customvicuniform,3,75,0,1,clothing,0,0,112,8,null
-RECIPE: /material/cloth/,worker outfit,/obj/item/clothing/under/industrial5,3,75,0,1,clothing,0,0,112,6,null
-RECIPE: /material/cloth/,texan shirt outfit,/obj/item/clothing/under/texan,5,75,0,1,clothing,0,0,112,8,null
-RECIPE: /material/cloth/,black victorian shirt and vest,/obj/item/clothing/under/victorian_vest,5,75,0,1,clothing & vests,0,0,112,6,null
-RECIPE: /material/cloth/,black victorian shirt and red vest,/obj/item/clothing/under/victorian_vest/redvest,5,75,0,1,clothing,0,0,112,6,null
-RECIPE: /material/cloth/,red victorian shirt and black vest,/obj/item/clothing/under/victorian_vest/redshirt,5,75,0,1,clothing,0,0,112,6,null
-RECIPE: /material/cloth/,custom modern outfit,/obj/item/clothing/under/customuniform,4,75,0,1,clothing,0,0,120,8,null
-RECIPE: /material/cloth/,custom baggy modern outfit,/obj/item/clothing/under/customuniform/baggy,4,75,0,1,clothing,0,0,120,8,null
-RECIPE: /material/cloth/,custom short modern outfit,/obj/item/clothing/under/customuniform/short,4,75,0,1,clothing,0,0,120,8,null
-RECIPE: /material/cloth/,custom colonial outfit,/obj/item/clothing/under/customuniform/colonial,4,75,0,1,clothing,0,0,70,8,null
-RECIPE: /material/cloth/,custom short colonial outfit,/obj/item/clothing/under/customuniform/colonial/short,4,75,0,1,clothing,0,0,70,8,null
-RECIPE: /material/cloth/,motorist outfit,/obj/item/clothing/under/motorist,4,75,0,1,clothing,0,0,180,8,null
-RECIPE: /material/cloth/,punk outfit,/obj/item/clothing/under/punk,3,75,0,1,clothing,0,0,180,8,null
+RECIPE: /material/cloth/,customizable tribal robe,/obj/item/clothing/under/customtribalrobe,3,100,0,1,clothing,0,0,18,8,null
+RECIPE: /material/cloth/,blue ainu robes,/obj/item/clothing/under/ainu,3,100,0,1,clothing,0,0,0,8,null
+RECIPE: /material/cloth/,brown ainu robes,/obj/item/clothing/under/ainu2,3,100,0,1,clothing,0,0,0,8,null
 
-RECIPE: /material/cloth/,nun dress,/obj/item/clothing/under/nun,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/cloth/,plain black dress,/obj/item/clothing/under/blackdress,4,85,0,1,feminine clothing,0,0,38,6,null
-RECIPE: /material/cloth/,blue sari,/obj/item/clothing/under/sari/blue,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/cloth/,red sari,/obj/item/clothing/under/sari/red,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/cloth/,customizable dress,/obj/item/clothing/under/customdress,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/cloth/,customizable buttoned dress,/obj/item/clothing/under/customdress2,4,85,0,1,feminine clothing,0,0,38,8,null
-RECIPE: /material/cloth/,dark dress,/obj/item/clothing/under/civf1,3,75,0,1,feminine clothing,0,0,78,4,null
-RECIPE: /material/cloth/,blue dress,/obj/item/clothing/under/civf2,3,75,0,1,feminine clothing,0,0,78,4,null
-RECIPE: /material/cloth/,brown dress,/obj/item/clothing/under/civf3,3,75,0,1,feminine clothing,0,0,78,4,null
-RECIPE: /material/cloth/,green dress,/obj/item/clothing/under/civfg,3,75,0,1,feminine clothing,0,0,78,4,null
-RECIPE: /material/cloth/,red dress,/obj/item/clothing/under/civfr,3,75,0,1,feminine clothing,0,0,78,4,null
-RECIPE: /material/cloth/,blue debutante gown,/obj/item/clothing/under/debutante/blue,8,130,0,1,feminine clothing,0,0,80,8,null
-RECIPE: /material/cloth/,orange debutante gown,/obj/item/clothing/under/debutante/orange,8,130,0,1,feminine clothing,0,0,80,8,null
-RECIPE: /material/cloth/,purple debutante gown,/obj/item/clothing/under/debutante/purple,8,130,0,1,feminine clothing,0,0,80,8,null
-RECIPE: /material/cloth/,red debutante gown,/obj/item/clothing/under/debutante/red,8,130,0,1,feminine clothing,0,0,80,8,null
-RECIPE: /material/cloth/,yellow debutante gown,/obj/item/clothing/under/debutante/yellow,8,130,0,1,feminine clothing,0,0,80,8,null
-RECIPE: /material/cloth/,nightingale dress,/obj/item/clothing/under/nightingale,4,90,0,1,feminine clothing,0,0,88,5,null
-RECIPE: /material/cloth/,saloon dress outfit,/obj/item/clothing/under/saloondress,4,75,0,1,feminine clothing,0,0,98,6,null
-RECIPE: /material/cloth/,cheongsam dress,/obj/item/clothing/under/cheongsam,5,100,0,1,feminine clothing,0,0,98,8,null
-RECIPE: /material/cloth/,short black dress,/obj/item/clothing/under/blackdress/short,4,75,0,1,feminine clothing,0,0,98,6,null
-RECIPE: /material/cloth/,wedding dress,/obj/item/clothing/under/wedding,10,160,0,1,feminine clothing,0,0,98,8,null
-RECIPE: /material/cloth/,victorian black dress,/obj/item/clothing/under/victorian_dress,5,75,0,1,feminine clothing,0,0,112,6,null
-RECIPE: /material/cloth/,blue traditional dress,/obj/item/clothing/under/tradwife,5,75,0,1,feminine clothing,0,0,112,6,null
-RECIPE: /material/cloth/,yellow traditional dress,/obj/item/clothing/under/tradwife/yellow,4,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,orange traditional dress,/obj/item/clothing/under/tradwife/orange,4,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,purple traditional dress,/obj/item/clothing/under/tradwife/purple,4,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,red traditional dress,/obj/item/clothing/under/tradwife/red,4,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,yellow sundress,/obj/item/clothing/under/sundress,3,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,blue sundress,/obj/item/clothing/under/sundress/blue,3,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,orange sundress,/obj/item/clothing/under/sundress/orange,3,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,purple sundress,/obj/item/clothing/under/sundress/purple,3,75,0,1,feminine clothing,0,0,128,8,null
-RECIPE: /material/cloth/,red sundress,/obj/item/clothing/under/sundress/red,3,75,0,1,feminine clothing,0,0,128,8,null
+RECIPE: /material/cloth/,indian shaman clothing,/obj/item/clothing/under/indianshaman,4,100,0,1,clothing,0,0,0,8,null
 
 //*****************| CLOTH MILITARY & LAW ENFORCMENT UNIFORMS |***************************
-
-RECIPE: /material/cloth/,green landschneckt uniform,/obj/item/clothing/under/landschneckt,6,105,0,1,clothing,0,0,48,2,null
-RECIPE: /material/cloth/,blue landschneckt uniform,/obj/item/clothing/under/landschneckt/blue,6,105,0,1,clothing,0,0,48,2,null
-RECIPE: /material/cloth/,red landschneckt uniform,/obj/item/clothing/under/landschneckt/red,6,105,0,1,clothing,0,0,48,2,null
-RECIPE: /material/cloth/,conquistador uniform,/obj/item/clothing/under/conquistador,5,75,0,1,military & law enforcement clothes,0,0,78,4,null
-RECIPE: /material/cloth/,constable outfit,/obj/item/clothing/under/constable,5,75,0,1,military & law enforcement clothes,0,0,138,8,null
-RECIPE: /material/cloth/,police outfit,/obj/item/clothing/under/traffic_police,5,75,0,1,military & law enforcement clothes,0,0,160,8,null
-RECIPE: /material/cloth/,custom camo uniform,/obj/item/clothing/under/customuniform_modern,4,100,0,1,military & law enforcement clothes,0,0,130,8,null
 
 //**************************************************************
 //*********************| BARBWIRE |*****************************
 //**************************************************************
 
-RECIPE: /material/barbedwire/,barbwire,/obj/structure/barbwire,1,20,0,1,none,0,0,0,8,null
-
 //**************************************************************
 //***********************| LEAD |*******************************
 //**************************************************************
-
-RECIPE: /material/lead/,lead safe,/obj/structure/closet/crate/lead,3,100,1,1,none,0,0,65,8,null
 
 //**************************************************************
 //*********************| PLASTIC |******************************
 //**************************************************************
 
-RECIPE: /material/plastic/,camera film,/obj/item/camera_film,4,55,1,1,none,95,0,0,8,null
-RECIPE: /material/plastic/,blood pack,/obj/item/weapon/reagent_containers/blood/empty,2,40,0,1,none,0,0,95,8,null
-RECIPE: /material/plastic/,lighter,/obj/item/weapon/flame/lighter/random,3,95,0,1,none,150,0,0,8,null
-
-RECIPE: /material/plastic/,bug swatter,/obj/item/weapon/swatter/modern,8,70,0,1,none,0,0,0,8,null
-
 //*****************| PLASTIC STORAGE |***************************
-
-RECIPE: /material/plastic/,filing cabinet,/obj/structure/filingcabinet,6,95,1,1,storage,0,0,0,8,null
-RECIPE: /material/plastic/,large filing cabinet,/obj/structure/filingcabinet/filingcabinet,6,95,1,1,storage,0,0,0,8,null
-RECIPE: /material/plastic/,chest drawer,/obj/structure/filingcabinet/chestdrawer,6,95,1,1,storage,0,0,0,8,null
-RECIPE: /material/plastic/,dumpster,/obj/structure/closet/crate/dumpster,5,95,1,1,storage,105,0,0,8,null
-
-RECIPE: /material/plastic/,trash bag,/obj/item/weapon/storage/bag/trash,1,95,0,1,storage,150,0,0,8,null
-RECIPE: /material/plastic/,plastic bag,/obj/item/weapon/storage/bag/plasticbag,0.75,95,0,1,storage,150,0,0,8,null
 
 //*****************| PLASTIC GAS MASKS |***************************
 
-RECIPE: /material/plastic/,german gas mask,/obj/item/clothing/mask/gas/german,8,70,0,1,gas masks,0,0,102,8,null
-RECIPE: /material/plastic/,british gas mask,/obj/item/clothing/mask/gas/british,8,70,0,1,gas masks,0,0,102,8,null
-RECIPE: /material/plastic/,modern gas mask (single sided),/obj/item/clothing/mask/gas/modern,8,70,0,1,gas masks,0,0,132,8,null
-RECIPE: /material/plastic/,modern gas mask (double sized),/obj/item/clothing/mask/gas/modern2,8,70,0,1,gas masks,0,0,132,8,null
-
 //*****************| PLASTIC FACE MASKS |***************************
-
-RECIPE: /material/plastic/,rat mask,/obj/item/clothing/mask/rat,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,raven mask,/obj/item/clothing/mask/raven,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,bat mask,/obj/item/clothing/mask/bat,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,bear mask,/obj/item/clothing/mask/bear,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,owl mask,/obj/item/clothing/mask/owl,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,bee mask,/obj/item/clothing/mask/bee,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,jackal mask,/obj/item/clothing/mask/jackal,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,frog mask,/obj/item/clothing/mask/frog,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,cow mask,/obj/item/clothing/mask/cow,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,pig mask,/obj/item/clothing/mask/pig,3,55,0,1,face masks,0,0,165,8,null
-RECIPE: /material/plastic/,joy mask,/obj/item/clothing/mask/joy,3,55,0,1,face masks,0,0,210,8,null
 
 //*****************| PLASTIC SIGNS |***************************
 
-RECIPE: /material/plastic/,traffic cone,/obj/item/weapon/trafficcone,1,35,0,1,signs,125,0,0,8,null
-RECIPE: /material/plastic/,do not enter sign,/obj/structure/sign/traffic/noentry,2,75,0,1,signs,125,0,0,8,null
-RECIPE: /material/plastic/,stop sign,/obj/structure/sign/traffic/stop,2,75,0,1,signs,125,0,0,8,null
-RECIPE: /material/plastic/,yeld sign,/obj/structure/sign/traffic/yeld,2,75,0,1,signs,125,0,0,8,null
-RECIPE: /material/plastic/,radiation sign,/obj/structure/sign/radiation,2,75,0,1,signs,125,0,0,8,null
-RECIPE: /material/plastic/,pedestrian crossing sign,/obj/structure/sign/traffic/crossing,2,75,0,1,signs,125,0,0,8,null
-
 //*****************| PLASTIC DRINKS |***************************
 
-RECIPE: /material/plastic/,fast food cup,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/custom/fastfoodcup,1,15,0,1,drinks,170,0,0,8,null
-RECIPE: /material/plastic/,condiment bottle,/obj/item/weapon/reagent_containers/food/drinks/plastic/condiment,0.75,15,0,1,drinks,170,0,0,8,null
-RECIPE: /material/plastic/,plastic bottle,/obj/item/weapon/reagent_containers/food/drinks/plastic/cola,1.5,15,0,1,drinks,170,0,0,8,null
-
 //*****************| PLASTIC CLOTHING & ARMOR |***************************
-
-RECIPE: /material/plastic/,constable helmet,/obj/item/clothing/head/helmet/constable,6,165,0,1,none,0,0,138,8,null
-RECIPE: /material/plastic/,surgical apron,/obj/item/clothing/suit/storage/jacket/surgeon,8,140,0,1,jackets & vests,0,0,138,8,null
-RECIPE: /material/plastic/,surgical mask,/obj/item/clothing/mask/sterile,1,140,0,1,none,0,0,108,8,null
 
 //**************************************************************
 //**********************| KEVLAR |******************************
 //**************************************************************
 
-RECIPE: /material/kevlar/,rubber wheel,/obj/structure/vehicleparts/movement,1,20,0,1,none,175,0,0,8,null
-
-RECIPE: /material/kevlar/,civilian kevlar armor,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,10,210,0,1,none,180,0,185,8,null
-RECIPE: /material/kevlar/,USSR 6B3 body armor,/obj/item/clothing/suit/b3,12,260,0,1,none,175,0,175,7,null
-
 //**************************************************************
 //*********************| CHITIN |*******************************
 //**************************************************************
-
-RECIPE: /material/chitin/,chitin mask,/obj/item/clothing/mask/chitinmask,4,65,0,1,none,0,0,0,0,null
-RECIPE: /material/chitin/,chitin helmet,/obj/item/clothing/head/helmet/chitin,7,115,0,1,none,0,0,0,0,null
-RECIPE: /material/chitin/,chitin armor,/obj/item/clothing/suit/armor/chitin,14,180,0,1,none,0,0,0,0,null
 
 //**************************************************************
 //*********************| BEARPELT |*****************************
 //**************************************************************
 //*****************| BROWN BEARPELT CLOTHES|***************************
 
-RECIPE: /material/bearpelt/brown/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/bearpelt/brown/,fur coat,/obj/item/clothing/suit/storage/coat/fur/brown,6,150,0,1,none,0,0,20,8,null
-RECIPE: /material/bearpelt/brown/,fancy fur coat,/obj/item/clothing/suit/storage/coat/fur/fancy_fur_coat,10,200,0,1,none,0,0,0,25,null
+RECIPE: /material/bearpelt/brown/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/brown/,fur boots,/obj/item/clothing/shoes/fur/brown,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/brown/,fur gloves,/obj/item/clothing/gloves/thick/leather/brown,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/brown/,bear pelt headcover,/obj/item/clothing/head/bearpelt/brown,4,150,0,1,none,0,0,0,8,null
-RECIPE: /material/bearpelt/brown/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/bearpelt/brown/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 
 //*****************| BROWN BEARPELT ARMOR|***************************
 
-RECIPE: /material/bearpelt/brown/,brown napoleonic bearskin hat,/obj/item/clothing/head/helmet/napoleonic/bearskin/brown,4,120,0,1,none,0,88,92,3,null
-
 //*****************| WHITE BEARPELT CLOTHES |***************************
 
-RECIPE: /material/bearpelt/white/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/white,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/bearpelt/white/,fur coat,/obj/item/clothing/suit/storage/coat/fur/white,6,150,0,1,none,0,0,20,8,null
+RECIPE: /material/bearpelt/white/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/white,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/white/,fur boots,/obj/item/clothing/shoes/fur/white,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/white/,fur gloves,/obj/item/clothing/gloves/thick/leather/white,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/white/,bear pelt headcover,/obj/item/clothing/head/bearpelt/white,4,150,0,1,none,0,0,0,8,null
-RECIPE: /material/bearpelt/white/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/bearpelt/white/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 RECIPE: /material/bearpelt/white/,regal ermine cape,/obj/item/clothing/suit/storage/jacket/regal,9,220,0,1,none,0,0,38,8,null
 
 //*****************| WHITE BEARPELT ARMOR|***************************
 
-RECIPE: /material/bearpelt/white/,white napoleonic bearskin hat,/obj/item/clothing/head/helmet/napoleonic/bearskin/white,4,120,0,1,none,0,88,92,3,null
-
 //*****************| BLACK BEARPELT CLOTHES |***************************
 
-RECIPE: /material/bearpelt/black/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/black,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/bearpelt/black,fur coat,/obj/item/clothing/suit/storage/coat/fur/black,6,150,0,1,none,0,0,20,8,null
-RECIPE: /material/bearpelt/black/,fancy fur coat,/obj/item/clothing/suit/storage/coat/fancy_fur_coat,10,200,0,1,none,0,0,0,25,null
+RECIPE: /material/bearpelt/black/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/black,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/black/,fur boots,/obj/item/clothing/shoes/fur/black,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/black/,fur gloves,/obj/item/clothing/gloves/thick/leather/black,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/bearpelt/black/,bear pelt headcover,/obj/item/clothing/head/bearpelt/black,4,150,0,1,none,0,0,0,8,null
-RECIPE: /material/bearpelt/black/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/bearpelt/black/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 
 //*****************| BLACK BEARPELT ARMOR|***************************
-
-RECIPE: /material/bearpelt/black/,black napoleonic bearskin hat,/obj/item/clothing/head/helmet/napoleonic/bearskin,4,120,0,1,none,0,88,92,3,null
 
 //**************************************************************
 //*********************| WOLFPELT |*****************************
 //**************************************************************
 
-RECIPE: /material/wolfpelt/,primative pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/grey,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/wolfpelt/,fur coat,/obj/item/clothing/suit/storage/coat/fur/grey,6,150,0,1,none,0,0,20,8,null
+RECIPE: /material/wolfpelt/,primative pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/grey,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/wolfpelt/,fur boots,/obj/item/clothing/shoes/fur/grey,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/wolfpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/grey,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/wolfpelt/,wolf pelt headcover,/obj/item/clothing/head/wolfpelt,4,150,0,1,none,0,0,0,8,null
-RECIPE: /material/wolfpelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/wolfpelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 RECIPE: /material/wolfpelt/,regal ermine cape,/obj/item/clothing/suit/storage/jacket/regal,12,220,0,1,none,0,0,38,8,null
 
 //**************************************************************
@@ -972,59 +500,32 @@ RECIPE: /material/wolfpelt/,regal ermine cape,/obj/item/clothing/suit/storage/ja
 //**************************************************************
 
 RECIPE: /material/catpelt/,pelt coat,/obj/item/clothing/suit/prehistoricfurcoat,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/catpelt/,fur coat,/obj/item/clothing/suit/storage/coat/fur,6,150,0,1,none,0,0,20,8,null
 RECIPE: /material/catpelt/,fur boots,/obj/item/clothing/shoes/fur,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/catpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather,3,80,0,1,none,0,0,0,8,null
-RECIPE: /material/catpelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/catpelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 
 //*****************| PANTHERPELT |***************************
 
 RECIPE: /material/pantherpelt/,panther pelt headcover,/obj/item/clothing/head/pantherpelt,3,150,0,1,none,0,0,0,8,null
 
-RECIPE: /material/pantherpelt/,mbata pelt vest,/obj/item/clothing/suit/zulu_mbata,3,110,0,1,none,0,0,0,3,null
-RECIPE: /material/pantherpelt/,umghele headband,/obj/item/clothing/head/zulu_umghele,2,110,0,1,none,0,0,0,3,null
-
 //*****************| LIONPELT |***************************
 
 RECIPE: /material/lionpelt/,lion pelt headcover,/obj/item/clothing/head/lionpelt,3,150,0,1,none,0,0,0,8,null
-
-RECIPE: /material/lionpelt/,mbata pelt vest,/obj/item/clothing/suit/zulu_mbata,3,110,0,1,none,0,0,0,3,null
-RECIPE: /material/lionpelt/,umghele headband,/obj/item/clothing/head/zulu_umghele,2,110,0,1,none,0,0,0,3,null
 
 //***************************************************************
 //*********************| LIZARDPELT |***************************
 //***************************************************************
 
 RECIPE: /material/lizardpelt/,lizard pelt headcover,/obj/item/clothing/head/lizardpelt,3,150,0,1,none,0,0,0,8,null
-RECIPE: /material/lizardpelt/,lizard scale belt,/obj/item/weapon/storage/belt/lizard_belt,3,80,0,1,none,0,0,98,7,null
-RECIPE: /material/lizardpelt/,lizard scale biker jacket,/obj/item/clothing/suit/storage/coat/ww2/biker/lizard_jacket,6,110,0,1,none,150,0,175,8,null
-RECIPE: /material/lizardpelt/,lizard scale wallet,/obj/item/clothing/accessory/storage/coinpouch/lizard_wallet,2,60,0,1,storage,87,0,0,8,null
-RECIPE: /material/lizardpelt/,lizard scale satchel,/obj/item/weapon/storage/backpack/satchel/lizard_satchel,5,100,0,1,storage,120,0,125,8,null
-RECIPE: /material/lizardpelt/,lizard scale riding boots,/obj/item/clothing/shoes/riding1/lizard_cowboy,3,60,0,1,foot wear,0,0,98,4,null
-RECIPE: /material/lizardpelt/,lizard scale ankle boots,/obj/item/clothing/shoes/lizard_ankleboots,3,60,0,1,foot wear,0,0,98,7,null
-RECIPE: /material/lizardpelt/,lizard scale laceup shoes,/obj/item/clothing/shoes/lizard_laceup,3,60,0,1,foot wear,112,0,112,8,null
-RECIPE: /material/lizardpelt/,shirtless lizard scale pants,/obj/item/clothing/under/lizardpants,3,120,0,1,none,0,0,175,8,null
 
 //*********************| GATORPELT |****************************
 
 RECIPE: /material/gatorpelt/,alligator pelt headcover,/obj/item/clothing/head/gatorpelt,3,150,0,1,none,0,0,0,8,null
-RECIPE: /material/gatorpelt/,alligator scale armor,/obj/item/clothing/suit/armor/ancient/gator_scale_armor,9,100,0,1,none,0,18,18,2,null
-RECIPE: /material/gatorpelt/,alligator scale belt,/obj/item/weapon/storage/belt/gator_belt,3,80,0,1,none,0,0,98,7,null
-RECIPE: /material/gatorpelt/,alligator scale biker jacket,/obj/item/clothing/suit/storage/coat/ww2/biker/gator_jacket,6,110,0,1,none,150,0,175,8,null
-RECIPE: /material/gatorpelt/,alligator scale wallet,/obj/item/clothing/accessory/storage/coinpouch/gator_wallet,2,60,0,1,storage,87,0,0,8,null
-RECIPE: /material/gatorpelt/,alligator scale satchel,/obj/item/weapon/storage/backpack/satchel/gator_satchel,5,100,0,1,storage,120,0,125,8,null
-RECIPE: /material/gatorpelt/,alligator scale riding boots,/obj/item/clothing/shoes/riding1/gator_cowboy,3,60,0,1,foot wear,0,0,98,4,null
-RECIPE: /material/gatorpelt/,alligator scale ankle boots,/obj/item/clothing/shoes/gator_ankleboots,3,60,0,1,foot wear,0,0,98,7,null
-RECIPE: /material/gatorpelt/,alligator scale laceup shoes,/obj/item/clothing/shoes/gator_laceup,3,60,0,1,foot wear,112,0,112,8,null
-RECIPE: /material/gatorpelt/,shirtless alligator scale pants,/obj/item/clothing/under/gatorpants,3,120,0,1,none,0,0,175,8,null
 
 //**************************************************************
 //*********************| SHEEPPELT |***************************
 //**************************************************************
 
-RECIPE: /material/sheeppelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/white,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/sheeppelt/,wool coat,/obj/item/clothing/suit/storage/coat/fur/white,6,150,0,1,none,0,0,20,8,null
+RECIPE: /material/sheeppelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/white,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/sheeppelt/,wool boots,/obj/item/clothing/shoes/fur/white,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/sheeppelt/,wool gloves,/obj/item/clothing/gloves/thick/leather/white,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/sheeppelt/,sheep pelt headcover,/obj/item/clothing/head/sheeppelt,3,150,0,1,none,0,0,0,8,null
@@ -1038,9 +539,6 @@ RECIPE: /material/goatpelt/,goat pelt headcover,/obj/item/clothing/head/goatpelt
 //*********************| COWPELT |***************************
 //**************************************************************
 
-RECIPE: /material/cowpelt/,slene cattlefur loincloth,/obj/item/clothing/under/zulu_slene,2,80,0,1,none,0,0,0,3,null
-RECIPE: /material/cowpelt/,nguni shield,/obj/item/weapon/shield/nguni_shield,6,160,0,1,none,0,0,0,3,null
-
 RECIPE: /material/cowpelt/,fur boots,/obj/item/clothing/shoes/fur/white,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/cowpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/white,3,80,0,1,none,0,0,0,8,null
 
@@ -1048,13 +546,7 @@ RECIPE: /material/cowpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/wh
 
 RECIPE: /material/bisonpelt/,bison pelt headcover,/obj/item/clothing/head/bisonpelt,3,150,0,1,none,0,0,0,8,null
 
-RECIPE: /material/bisonpelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/bisonpelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/bisonpelt/,bisonhead furhat,/obj/item/clothing/head/furhat/bison,3,100,0,1,none,0,0,89,8,null
-
-RECIPE: /material/bisonpelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/bisonpelt/,fur coat,/obj/item/clothing/suit/storage/coat/fur/brown,6,150,0,1,none,0,0,20,8,null
-RECIPE: /material/bisonpelt/,fancy fur coat,/obj/item/clothing/suit/storage/coat/fur/fancy_fur_coat,10,200,0,1,none,0,0,0,8,null
+RECIPE: /material/bisonpelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/bisonpelt/,fur boots,/obj/item/clothing/shoes/fur/brown,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/bisonpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/brown,3,80,0,1,none,0,0,0,8,null
 
@@ -1062,12 +554,9 @@ RECIPE: /material/bisonpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/
 //*********************| MONKEYPELT |***************************
 //**************************************************************
 
-RECIPE: /material/monkeypelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/monkeypelt/,fur coat,/obj/item/clothing/suit/storage/coat/fur/brown,6,150,0,1,none,0,0,20,8,null
+RECIPE: /material/monkeypelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/monkeypelt/,fur boots,/obj/item/clothing/shoes/fur/brown,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/monkeypelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/brown,3,80,0,1,none,0,0,0,8,null
-RECIPE: /material/monkeypelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/monkeypelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 
 //**************************************************************
 //*********************| ORCPELT |******************************
@@ -1081,12 +570,9 @@ RECIPE: /material/orcpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/or
 //*********************| GORILLAPELT |**************************
 //**************************************************************
 
-RECIPE: /material/gorillapelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/black,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/gorillapelt/,fur coat,/obj/item/clothing/suit/storage/coat/fur/black,6,150,0,1,none,0,0,20,8,null
+RECIPE: /material/gorillapelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/black,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/gorillapelt/,fur boots,/obj/item/clothing/shoes/fur/black,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/gorillapelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/black,3,80,0,1,none,0,0,0,8,null
-RECIPE: /material/gorillapelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/gorillapelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 
 //**************************************************************
 //*********************| HUMANPELT |****************************
@@ -1100,38 +586,28 @@ RECIPE: /material/humanpelt/,skin gloves,/obj/item/clothing/gloves/thick/leather
 //*********************| FOXPELT |******************************
 //**************************************************************
 
-RECIPE: /material/foxpelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/foxpelt/,fur coat,/obj/item/clothing/suit/storage/coat/fur/brown,6,150,0,1,none,0,0,20,8,null
+RECIPE: /material/foxpelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/brown,6,125,0,1,none,0,0,0,8,null
 RECIPE: /material/foxpelt/,fur boots,/obj/item/clothing/shoes/fur/brown,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/foxpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/brown,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/foxpelt/,fox pelt headcover,/obj/item/clothing/head/foxpelt,3,150,0,1,none,0,0,0,8,null
-RECIPE: /material/foxpelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/foxpelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 
 //*****************| WHITE FOXPELT |***************************
 
 RECIPE: /material/whitefoxpelt/,primitive pelt coat,/obj/item/clothing/suit/prehistoricfurcoat/white,6,125,0,1,none,0,0,0,0,null
-RECIPE: /material/whitefoxpelt/,fur coat,/obj/item/clothing/suit/storage/coat/fur/white,6,150,0,1,none,0,0,20,8,null
 RECIPE: /material/whitefoxpelt/,fur boots,/obj/item/clothing/shoes/fur/white,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/whitefoxpelt/,fur gloves,/obj/item/clothing/gloves/thick/leather/white,3,80,0,1,none,0,0,0,8,null
 RECIPE: /material/whitefoxpelt/,white fox pelt headcover,/obj/item/clothing/head/foxpelt/white,3,150,0,1,none,0,0,0,8,null
 RECIPE: /material/whitefoxpelt/,regal ermine cape,/obj/item/clothing/suit/storage/jacket/regal,9,220,0,1,none,0,0,38,8,null
-RECIPE: /material/whitefoxpelt/,furcap,/obj/item/clothing/head/furcap,2,100,0,1,none,0,0,89,8,null
-RECIPE: /material/whitefoxpelt/,furhat,/obj/item/clothing/head/furhat,2,100,0,1,none,0,0,89,8,null
 
 //**************************************************************
 //*********************| TOBACCO |******************************
 //**************************************************************
 
 RECIPE: /material/tobacco/,cigar,/obj/item/clothing/mask/smokable/cigarette/cigar,3,75,0,1,none,0,0,23,8,null
-RECIPE: /material/tobacco/,cuban cigar,/obj/item/clothing/mask/smokable/cigarette/cigar/havana,5,100,0,1,none,0,0,57,8,null
-RECIPE: /material/tobacco/,cigarette,/obj/item/clothing/mask/smokable/cigarette,2,60,0,1,none,0,0,80,8,null
 
 //**************************************************************
 //*********************| COCAINE |******************************
 //**************************************************************
-
-RECIPE: /material/coca/,cocaine,/obj/item/weapon/reagent_containers/pill/cocaine,10,55,0,1,none,0,0,93,8,null
 
 //**************************************************************
 //*********************| POPPY |********************************
@@ -1143,18 +619,18 @@ RECIPE: /material/poppy/,opium,/obj/item/weapon/reagent_containers/pill/opium,3,
 //*********************| BONE |********************************
 //*************************************************************
 
-RECIPE: /material/bone/,bone talisman,/obj/item/clothing/accessory/armband/talisman,2,75,0,1,none,0,0,0,3,null
-RECIPE: /material/bone/,skull mask,/obj/item/clothing/mask/skullmask,5,100,0,1,none,0,0,0,2,null
-RECIPE: /material/bone/,bone helmet,/obj/item/clothing/head/helmet/bone,10,100,0,1,none,0,0,0,2,null
-RECIPE: /material/bone/,bone armor,/obj/item/clothing/suit/storage/jacket/bonearmor,10,170,0,2,none,0,0,0,1,null
+RECIPE: /material/bone/,bone talisman,/obj/item/clothing/accessory/armband/talisman,2,75,0,1,none,0,0,0,8,null
+RECIPE: /material/bone/,skull mask,/obj/item/clothing/mask/skullmask,5,100,0,1,none,0,0,0,8,null
+RECIPE: /material/bone/,bone helmet,/obj/item/clothing/head/helmet/bone,10,100,0,1,none,0,0,0,8,null
+RECIPE: /material/bone/,primitive bone hair-pipe armor,/obj/item/clothing/suit/hairbonearmor,6,100,0,1,none,0,0,0,8,null
 RECIPE: /material/bone/,bone hatchet,/obj/item/weapon/material/hatchet/tribal/bone,2,35,0,1,none,0,0,0,8,bone
-RECIPE: /material/bone/,battle axe,/obj/item/weapon/material/hatchet/bone_battleaxe,10,70,0,1,none,0,0,0,4,bone
-RECIPE: /material/bone/,tribal bone knife,/obj/item/weapon/material/kitchen/utensil/knife/bone,4,90,0,1,none,0,0,0,4,bone
+RECIPE: /material/bone/,battle axe,/obj/item/weapon/material/hatchet/bone_battleaxe,10,70,0,1,none,0,0,0,8,bone
+RECIPE: /material/bone/,tribal bone knife,/obj/item/weapon/material/kitchen/utensil/knife/bone,4,90,0,1,none,0,0,0,8,bone
 RECIPE: /material/bone/,bone pickaxe,/obj/item/weapon/material/pickaxe/bone,2,50,0,1,none,0,0,0,8,null
 RECIPE: /material/bone/,bone shovel,/obj/item/weapon/material/shovel/bone,2,50,0,1,none,0,0,0,8,bone
-RECIPE: /material/bone/,blowing horn,/obj/item/weapon/horn,4,110,0,1,none,0,0,0,4,null
+RECIPE: /material/bone/,blowing horn,/obj/item/weapon/horn,4,110,0,1,none,0,0,0,8,null
 RECIPE: /material/bone/,dice,/obj/item/weapon/dice,2,90,0,1,none,15,0,0,8,null
-RECIPE: /material/bone/,tomahawk,/obj/item/weapon/material/thrown/tomahawk,4,30,0,1,none,25,0,0,4,bone
+RECIPE: /material/bone/,tomahawk,/obj/item/weapon/material/thrown/tomahawk,4,30,0,1,none,0,0,0,8,bone
 
 //*********************| FOSSILS |***********************
 
@@ -1171,12 +647,9 @@ RECIPE: /material/stone/,well,/obj/structure/sink/well,7,250,1,1,none,21,0,0,8,n
 //*****************| STONE SUPPORTS & ROOFING |***************************
 
 RECIPE: /material/stone/,stone pillar,/obj/structure/mine_support/stone,2,130,1,1,construction,0,0,0,8,null
-RECIPE: /material/stone/,ionic column,/obj/structure/mine_support/stone/ionic,2.5,130,1,1,construction,22,0,0,8,null
-RECIPE: /material/stone/,solomonic column,/obj/structure/mine_support/stone/solomonic,2.5,130,1,1,construction,22,0,0,8,null
-RECIPE: /material/stone/,thick solomonic column,/obj/structure/mine_support/stone/solomonic/thick,2.5,130,1,1,construction,22,0,0,8,null
-RECIPE: /material/stone/,aztec column,/obj/structure/mine_support/stone/aztec,2.5,130,1,1,construction,32,0,0,8,null
+RECIPE: /material/stone/,aztec column,/obj/structure/mine_support/stone/aztec,2.5,130,1,1,construction,0,0,0,8,null
 
-RECIPE: /material/stone/,mayan roof builder,/obj/item/weapon/roofbuilder/mayan,1,20,0,1,construction,0,0,0,3,null
+RECIPE: /material/stone/,mayan roof builder,/obj/item/weapon/roofbuilder/mayan,1,20,0,1,construction,0,0,0,8,null
 
 //*************| STONE RESEARCH & TOOLS |***************
 
@@ -1189,41 +662,16 @@ RECIPE: /material/stone/,stone hatchet,/obj/item/weapon/material/hatchet/tribal,
 
 //*************| STONE FLOORS |***************
 
-RECIPE: /material/stone/,cobblestone floor,/obj/covers/cobblestone,1,25,1,1,floors,0,0,0,8,null
-RECIPE: /material/stone/,roman road,/obj/covers/roads/roman,1,25,1,1,floors,20,0,0,8,null
-RECIPE: /material/stone/,slate floor,/obj/covers/slatefloor,1,25,1,1,floors,25,0,0,8,null
-RECIPE: /material/stone/,stone decorative slab floor,/obj/covers/stone/slab/decorative,1,25,1,1,floors,32,0,0,8,null
-RECIPE: /material/stone/,road,/obj/covers/road,1,25,1,1,floors,100,0,0,8,null
-RECIPE: /material/stone/,sidewalk,/obj/covers/sidewalk,1,25,1,1,floors,100,0,0,8,null
+RECIPE: /material/stone/,slate floor,/obj/covers/slatefloor,1,25,1,1,floors,0,0,0,8,null
+RECIPE: /material/stone/,stone decorative slab floor,/obj/covers/stone/slab/decorative,1,25,1,1,floors,0,0,0,8,null
 
 //*************| (STONE) RAW MARBLE FLOORS |***************
 
-RECIPE: /material/stone/,raw marble floor,/obj/covers/raw_marblefloor,1,25,1,1,marble floors,20,0,0,8,null
-RECIPE: /material/stone/,raw black marble floor,/obj/covers/raw_marblefloor/black,1,25,1,1,marble floors,20,0,0,8,null
-RECIPE: /material/stone/,raw pink marble floor,/obj/covers/raw_marblefloor/pink,1,25,1,1,marble floors,20,0,0,8,null
-
 //*************| (STONE) MARBLE FLOORS |***************
-
-RECIPE: /material/stone/,marble floor,/obj/covers/marblefloor,1,25,1,1,marble floors,25,0,0,8,null
-RECIPE: /material/stone/,marble tiles,/obj/covers/marbletile,1,25,1,1,marble floors,25,0,0,8,null
-RECIPE: /material/stone/,black marble tiles,/obj/covers/marbletile/black,1,25,1,1,marble floors,25,0,0,8,null
-RECIPE: /material/stone/,pink marble tiles,/obj/covers/marbletile/pink,1,25,1,1,marble floors,25,0,0,8,null
 
 //*************| (STONE) DECORATIVE MARBLE FLOORS #1 |***************
 
-RECIPE: /material/stone/,ornate marble tile,/obj/covers/ornatemarblefloor,1,25,1,1,marble floors,32,0,0,8,null
-RECIPE: /material/stone/,ornate black marble tile,/obj/covers/ornatemarblefloor/black,1,25,1,1,marble floors,32,0,0,8,null
-RECIPE: /material/stone/,decorative marble tile,/obj/covers/decorative_marbletile,1,25,1,1,marble floors,32,0,0,8,null
-RECIPE: /material/stone/,decorative black marble tile,/obj/covers/decorative_marbletile/black,1,25,1,1,marble floors,32,0,0,8,null
-RECIPE: /material/stone/,decorative pink marble tile,/obj/covers/decorative_marbletile/pink,1,25,1,1,marble floors,32,0,0,8,null
-
 //*************| (STONE) DECORATIVE MARBLE FLOORS #2 |***************
-
-RECIPE: /material/stone/,marble grid tile floor,/obj/covers/marble_grid,1,25,1,1,marble floors,45,0,0,8,null
-RECIPE: /material/stone/,marble checkerboard floor,/obj/covers/marble_checkerboard,1,25,1,1,marble floors,45,0,0,8,null
-RECIPE: /material/stone/,reverse marble checkerboard floor,/obj/covers/marble_checkerboard/reverse,1,25,1,1,marble floors,45,0,0,8,null
-RECIPE: /material/stone/,pink marble checkerboard floor,/obj/covers/marble_checkerboard/pink,1,25,1,1,marble floors,45,0,0,8,null
-RECIPE: /material/stone/,reverse pink marble checkerboard floor,/obj/covers/marble_checkerboard/pink/reverse,1,25,1,1,marble floors,45,0,0,8,null
 
 //*************| STONE CONSTRUCTIONS & DECORATIONS |***************
 
@@ -1237,28 +685,14 @@ RECIPE: /material/stone/,aztec statue,/obj/structure/religious/aztec_statue,8,14
 RECIPE: /material/stone/,large stone head,/obj/structure/religious/olmec_head,12,190,1,1,religious & decoration,0,0,0,8,null
 RECIPE: /material/stone/,moai,/obj/structure/religious/moai,20,250,1,1,religious & decoration,0,0,0,8,null
 RECIPE: /material/stone/,long moai,/obj/structure/religious/moai/long,20,250,1,1,religious & decoration,0,0,0,8,null
-RECIPE: /material/stone/,gravestone,/obj/structure/religious/gravestone,3,60,1,1,religious & decoration,26,0,0,8,null
-RECIPE: /material/stone/,gargoyle statue,/obj/structure/religious/gargoyle,12,190,1,1,religious & decoration,32,0,0,8,null
-RECIPE: /material/stone/,angel statue,/obj/structure/religious/angel,12,190,1,1,religious & decoration,32,0,0,8,null
+RECIPE: /material/stone/,gravestone,/obj/structure/religious/gravestone,3,60,1,1,religious & decoration,0,0,0,8,null
 
 //*************| STONE MONUMENTS |***************
 
-RECIPE: /material/stone/,monumental stone megalith,/obj/structure/religious/monument/megalith,45,300,1,1,religious & decoration,0,0,0,2,null
-RECIPE: /material/stone/,monumental statue of a giant ape,/obj/structure/religious/monument/shaman/ape,45,300,1,1,religious & decoration,0,0,0,2,null
-RECIPE: /material/stone/,monumental stone pillar,/obj/structure/religious/monument/pillar_monument,45,300,1,1,religious & decoration,22,0,0,8,null
-RECIPE: /material/stone/,monumental ominous statue of the deep-one,/obj/structure/religious/monument/cultist/cthulu,45,300,1,1,religious & decoration,22,0,0,8,null
-RECIPE: /material/stone/,monumental ominous statue of the evil-one,/obj/structure/religious/monument/cultist/moloch,45,300,1,1,religious & decoration,22,0,0,8,null
-RECIPE: /material/stone/,monumental ominous statue of the outsider,/obj/structure/religious/monument/cultist/outsider,45,300,1,1,religious & decoration,22,0,0,8,null
-RECIPE: /material/stone/,monumental ominous statue of the ruler,/obj/structure/religious/monument/cultist/sauron,45,300,1,1,religious & decoration,32,0,0,8,null
-RECIPE: /material/stone/,monumental stone buddha,/obj/structure/religious/monument/monk/quangshi,45,300,1,1,religious & decoration,32,0,0,8,null
-RECIPE: /material/stone/,monumental saint statue,/obj/structure/religious/monument/priesthood/saint,45,300,1,1,religious & decoration,32,0,0,8,null
-RECIPE: /material/stone/,monumental marble statue of venus,/obj/structure/religious/monument/venus,45,300,1,1,religious & decoration,62,0,0,8,null
+RECIPE: /material/stone/,monumental stone megalith,/obj/structure/religious/monument/megalith,45,300,1,1,religious & decoration,0,0,0,8,null
+RECIPE: /material/stone/,monumental statue of a giant ape,/obj/structure/religious/monument/shaman/ape,45,300,1,1,religious & decoration,0,0,0,8,null
 
 //*************| STONE ROADS |***************
-
-RECIPE: /material/stone/,smooth roman road,/obj/covers/roads/roman,1,0,1,1,roads,20,0,0,8,null
-RECIPE: /material/stone/,smooth cobble road,/obj/covers/roads/cobble,1,0,1,1,roads,32,0,0,8,null
-RECIPE: /material/stone/,smooth modern road,obj/covers/roads/modern,1,0,1,1,roads,100,0,0,8,null
 
 //*************| STONE 'STATUE' & WINDOWS |***************
 
@@ -1274,9 +708,6 @@ RECIPE: /material/stone/,stone anvil,/obj/structure/anvil/stone,25,150,1,1,produ
 
 //*************| STONE WEAPONS & PROJECTILES |***************
 
-RECIPE: /material/stone/,stone bust,/obj/item/weapon/material/bust,3,10,0,0,none,20,0,0,8,stone
-RECIPE: /material/stone/,stone bust of hippocrates,/obj/item/weapon/material/hippocratic,3,10,0,0,none,20,0,0,8,stone
-
 RECIPE: /material/stone/,sling projectile (x5),/obj/item/ammo_casing/stone,1,25,0,1,projectiles,0,0,0,8,null
 RECIPE: /material/stone/,stone arrowhead (x4),/obj/item/stack/arrowhead/stone,1,10,0,1,projectiles,0,14,0,8,null
 RECIPE: /material/stone/,catapult projectile,/obj/item/catapult_ball,5,75,0,1,projectiles,24,33,0,4,null
@@ -1284,52 +715,34 @@ RECIPE: /material/stone/,stone projectile (x2),/obj/item/stack/ammopart/stonebal
 
 //*************| STONE BRICKS & CONSTRUCTIONS |***************
 
-RECIPE: /material/stone/,stone bricks,/obj/item/stack/material/stonebrick,1,25,0,1,none,35,0,0,8,null
-RECIPE: /material/stonebrick/,stone brick wall,/obj/covers/stone_wall/brick,6,140,1,1,none,35,0,0,8,null
-RECIPE: /material/stonebrick/,stone brick floor,/obj/covers/stonebrickfloor,1,25,1,1,none,35,0,0,8,null
-RECIPE: /material/stonebrick/,stone brick archway,/obj/covers/stone_wall/brick/archway,6,140,1,1,none,35,0,0,8,null
-
 //*************| STONE WALL, DOORWAYS & FORTIFICATION CONSTRUCTIONS |***************
 
-RECIPE: /material/stone/,stone wall,/obj/covers/stone_wall,8,140,1,1,construction,0,0,0,2,null
-RECIPE: /material/stone/,stone block wall,/obj/covers/stone_wall/classic,8,140,1,1,construction,0,0,0,2,null
-RECIPE: /material/stone/,roman stone wall,/obj/covers/stone_wall/roman,6,70,1,1,construction,28,0,0,2,null
-RECIPE: /material/stone/,mayan wall,/obj/covers/stone_wall/mayan,6,70,1,1,construction,28,0,0,2,null
-RECIPE: /material/stone/,fortress wall,/obj/covers/stone_wall/fortress,8,190,1,1,construction,45,35,0,3,null
+RECIPE: /material/stone/,stone wall,/obj/covers/stone_wall,8,140,1,1,construction,0,0,0,8,null
+RECIPE: /material/stone/,stone block wall,/obj/covers/stone_wall/classic,8,140,1,1,construction,0,0,0,8,null
+RECIPE: /material/stone/,mayan wall,/obj/covers/stone_wall/mayan,6,70,1,1,construction,28,0,0,8,null
 
-RECIPE: /material/stone/,stone block archway,/obj/covers/stone_wall/classic/archway,8,140,1,1,doorways and other buildings,0,0,0,2,null
-RECIPE: /material/stone/,fortress archway,/obj/covers/stone_wall/fortress/archway,16,190,1,1,doorways and other buildings,0,0,0,2,null
-RECIPE: /material/stone/,castle gate,/obj/structure/gate,15,210,1,1,doorways and other buildings,30,30,0,8,null
-RECIPE: /material/stone/,castle gate control,/obj/structure/gatecontrol,5,100,1,1,doorways and other buildings,30,30,0,8,null
-
-RECIPE: /material/stone/,roman door,/obj/structure/simple_door/key_door/anyone/roman,5,50,1,1,construction,28,0,0,8,null
+RECIPE: /material/stone/,stone block archway,/obj/covers/stone_wall/classic/archway,8,140,1,1,doorways and other buildings,0,0,0,8,null
 
 RECIPE: /material/stone/,rock barrier wall,/obj/structure/window/barrier/rock,3,70,1,1,fortifications,0,0,0,8,null
-RECIPE: /material/stone/,fortified wall (horizontal),/obj/structure/barricade/stone_h,5,80,1,1,fortifications,29,0,0,8,null
-RECIPE: /material/stone/,fortified wall (vertical),/obj/structure/barricade/stone_v,5,80,1,1,fortifications,29,0,0,8,null
-RECIPE: /material/stone/,fortified crenelated wall (horizontal),/obj/structure/barricade/stone_h/crenelated,5,80,1,1,fortifications,29,0,0,8,null
-RECIPE: /material/stone/,fortified crenelated wall (vertical),/obj/structure/barricade/stone_v/crenelated,5,80,1,1,fortifications,29,0,0,8,null
+
 RECIPE: /material/stone/,stone shingled wall (vertical center),/obj/structure/barricade/jap_v,4,80,1,1,fortifications,29,0,0,8,null
 RECIPE: /material/stone/,stone shingled wall (vertical top),/obj/structure/barricade/jap_v_t,4,80,1,1,fortifications,29,0,0,8,null
 RECIPE: /material/stone/,stone shingled wall (vertical bottom),/obj/structure/barricade/jap_v_b,4,80,1,1,fortifications,29,0,0,8,null
 RECIPE: /material/stone/,stone shingled wall (horizontal center),/obj/structure/barricade/jap_h,4,80,1,1,fortifications,29,0,0,8,null
 RECIPE: /material/stone/,stone shingled wall (horizontal left),/obj/structure/barricade/jap_h_l,4,80,1,1,fortifications,29,0,0,8,null
 RECIPE: /material/stone/,stone shingled wall (horizontal right),/obj/structure/barricade/jap_h_r,4,80,1,1,fortifications,29,0,0,8,null
-RECIPE: /material/stone/,jersey barrier,/obj/structure/window/barrier/jersey,3,70,1,1,fortifications,215,0,0,8,null
 
 //*******************************************************
 //*********************| RAGS |**************************
 //*******************************************************
 
 RECIPE: /material/rags/,bandages,/obj/item/stack/medical/bruise_pack/bint,2,30,0,1,none,0,0,0,8,null
-RECIPE: /material/rags/,beggar clothing,/obj/item/clothing/under/medieval/beggar_clothing,4,80,0,1,none,0,39,0,2,null
 
 //*************************************************************
 //*********************| HEMP |********************************
 //*************************************************************
 
 RECIPE: /material/hemp/,rope,/obj/item/stack/material/rope,1,10,0,1,none,0,0,0,8,null
-RECIPE: /material/hemp/,joint,/obj/item/clothing/mask/smokable/cigarette/joint,2,10,0,1,none,0,0,0,8,null
 
 //*************************************************************
 //*********************| FLAX |********************************
@@ -1353,43 +766,18 @@ RECIPE: /material/rope/,garrote,/obj/item/garrote,3,120,0,1,none,0,43,0,8,null
 
 RECIPE: /material/glass/,fermentation jar,/obj/item/weapon/starterjar,3,50,0,1,none,0,0,0,8,null
 RECIPE: /material/glass/,vial arrowhead (x4),/obj/item/stack/arrowhead/vial,1,10,0,1,none,0,26,26,8,null
-RECIPE: /material/glass/,chemical dispenser,/obj/structure/chemical_dispenser,12,180,1,1,none,90,0,0,8,null
 
 //*************| GLASS DRINKS |***************
 
 RECIPE: /material/glass/,tribal pot,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/tribalpot,2,40,0,1,drinks,0,0,0,3,null
-RECIPE: /material/glass/,drinking glass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,2,25,0,1,drinks,22,0,0,8,null
-RECIPE: /material/glass/,small glass bottle,/obj/item/weapon/reagent_containers/food/drinks/bottle/small,2,40,0,1,drinks,22,0,0,8,null
-RECIPE: /material/glass/,glass bottle,/obj/item/weapon/reagent_containers/food/drinks/bottle/large,4,60,0,1,drinks,22,0,0,8,null
-RECIPE: /material/glass/,teapot,/obj/item/weapon/reagent_containers/food/drinks/teapot,4,70,0,1,drinks,49,0,24,8,null
-RECIPE: /material/glass/,teacup,/obj/item/weapon/reagent_containers/food/drinks/tea/empty,2,50,0,1,drinks,49,0,24,8,null
-RECIPE: /material/glass/,wine glass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,2,25,0,1,drinks,49,0,0,8,null
-RECIPE: /material/glass/,beer mug,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/beermug,2,25,0,1,drinks,75,0,0,8,null
-//*************| GLASS ELECTRICAL |***************
 
-RECIPE: /material/glass/,small lightbulb frame,/obj/structure/lamp/lamp_small,2,35,0,1,electrical,115,0,0,8,null
-RECIPE: /material/glass/,light tube frame,/obj/structure/lamp/lamp_big,3,55,0,1,electrical,115,0,0,8,null
-RECIPE: /material/glass/,light tube,/obj/item/lightbulb/tube,1,55,0,1,electrical,115,0,0,8,null
-RECIPE: /material/glass/,lightbulb,/obj/item/lightbulb,2,55,0,1,electrical,115,0,0,8,null
+//*************| GLASS ELECTRICAL |***************
 
 //*************| GLASS CHEMISTRY |***************
 
-RECIPE: /material/glass/,dropper,/obj/item/weapon/reagent_containers/dropper,1,40,0,1,chemistry,90,0,0,8,null
-RECIPE: /material/glass/,vial,/obj/item/weapon/reagent_containers/glass/beaker/vial,1,40,0,1,chemistry,90,0,0,8,null
-RECIPE: /material/glass/,beaker,/obj/item/weapon/reagent_containers/glass/beaker,2,40,0,1,chemistry,105,0,0,8,null
-RECIPE: /material/glass/,large beaker,/obj/item/weapon/reagent_containers/glass/beaker/large,3,40,0,1,chemistry,105,0,0,8,null
-RECIPE: /material/glass/,laboratory distiller,/obj/structure/lab_distillery,10,140,1,1,chemistry,105,0,0,8,null
-
 //*************| GLASS FURNITURE |***************
 
-RECIPE: /material/glass/,toilet,/obj/structure/toilet,4,80,1,1,furniture,95,0,0,8,null
-RECIPE: /material/glass/,mirror,/obj/structure/mirror,3,80,1,1,furniture,55,0,0,8,null
-RECIPE: /material/glass/,shower,/obj/structure/shower,10,190,1,1,furniture,115,0,0,8,null
-
 //*************| GLASS EYEWEAR |***************
-
-RECIPE: /material/glass/,sunglasses,/obj/item/clothing/glasses/sunglasses,2,90,1,1,none,140,0,0,8,null
-RECIPE: /material/glass/,large sunglasses,/obj/item/clothing/glasses/sunglasses/large,2,90,1,1,none,165,0,0,8,null
 
 //**************************************************************
 //************************ROBERTS CARTS*************************
@@ -1399,21 +787,10 @@ RECIPE: /material/glass/,large sunglasses,/obj/item/clothing/glasses/sunglasses/
 RECIPE: /material/wood/,wooden cart,/obj/structure/closet/crate/cart/wooden,40,190,1,1,logistics,20,0,0,8,null
 //COPPER AGE WOODEN CART//
 
-//DARK AGE STONE CART//
-RECIPE: /material/stone/,stone cart,/obj/structure/closet/crate/cart/stone,50,190,1,1,logistics,45,0,0,2,null
-//DARK AGE STONE CART//
-
 //RENAISSANCE AGE COPPER CART//
 RECIPE: /material/copper/,copper cart,/obj/structure/closet/crate/cart/copper,30,190,1,1,logistics,80,0,0,3,null
 //RENAISSANCE AGE COPPER CART//
 
-//NAPOLEONIC AGE BRONZE CART//
-RECIPE: /material/bronze/,bronze cart,/obj/structure/closet/crate/cart/bronze,30,190,1,1,logistics,100,0,0,4,null
-//NAPOLEONIC AGE BRONZE CART//
-
-//EARLY MODERN AGE STEEL CART//
-RECIPE: /material/steel/,steel cart,/obj/structure/closet/crate/cart/steel,30,190,1,1,logistics,147,0,0,9,null
-//EARLY MODERN AGE STEEL CART//
 //**************************************************************
 //************************ROBERTS CARTS*************************
 //**************************************************************
@@ -1421,10 +798,6 @@ RECIPE: /material/steel/,steel cart,/obj/structure/closet/crate/cart/steel,30,19
 //**************************************************************
 //************************ROBERTS FACTORIES*********************
 //***********************COINSMELTER****************************
-
-//MID BRONZE AGE//
-RECIPE: /material/steel/,coin smelter,/obj/structure/machinery/factory/coinsmelter,50,190,1,1,none,25,0,0,9,null
-//MID BRONZE AGE//
 
 //**************************************************************
 //*************************ROBERTS BATHTUBS*********************
@@ -1446,10 +819,6 @@ RECIPE: /material/copper/,copper bathtub,/obj/structure/shower/bathtub/copper,50
 RECIPE: /material/bronze/,bronze bathtub,/obj/structure/shower/bathtub/bronze,50,320,1,1,hygiene,30,0,20,4,null
 //LATE BRONZE AGE //
 
-// WW2 AGE //
-RECIPE: /material/steel/,steel bathtub,/obj/structure/shower/bathtub/steel,50,420,1,1,hygiene,150,0,40,9,null
-//WW2 AGE //
-
 //**************************************************************
 //************************PUBLIC BATHTUBS***********************
 //**************************************************************
@@ -1466,14 +835,6 @@ RECIPE: /material/stone/,stone public bathtub,/obj/structure/shower/bathtub/big/
 RECIPE: /material/copper/,copper public bathtub,/obj/structure/shower/bathtub/big/copper,50,500,1,1,hygiene,70,0,50,3,null
 //RENAISSANCE AGES//
 
-//IMPERIAL AGES//
-RECIPE: /material/bronze/,bronze public bathtub,/obj/structure/shower/bathtub/big/bronze,50,550,1,1,hygiene,85,0,60,4,null
-//IMPERIAL AGES//
-
-//COLD WAR//
-RECIPE: /material/steel/,steel public bathtub,/obj/structure/shower/bathtub/big/steel,50,620,1,1,hygiene,175,0,80,9,null
-//COLD WAR//
-
 //************************************************************
 //*********************| GOLD |*******************************
 //************************************************************
@@ -1483,8 +844,9 @@ RECIPE: /material/gold/,gold coins,/obj/item/stack/money/goldcoin,1,35,0,1,none,
 //*****************| GOLD CLOTHING & ACCESSORIES |***************************
 
 RECIPE: /material/gold/,gold crown,/obj/item/clothing/head/helmet/gold_crown,3,135,0,1,none,25,0,0,8,null
-RECIPE: /material/gold/,gold laurel crown,/obj/item/clothing/head/laurelcrown/gold,2,110,0,1,none,25,0,0,8,null
 RECIPE: /material/gold/,gold arm bangles,/obj/item/clothing/accessory/armband/armbangle/gold,2,95,0,1,none,0,0,0,8,null
+
+RECIPE: /material/gold/,gold indian accessories,/obj/item/clothing/accessory/armband/indian2,4,95,0,1,none,0,0,0,8,null
 
 //*****************| GOLD DECORATION |***************************
 
@@ -1532,38 +894,13 @@ RECIPE: /material/tin/,large tin can,/obj/item/weapon/can/large,1,50,0,1,none,95
 RECIPE: /material/copper/,copper coins,/obj/item/stack/money/coppercoin,1,35,0,1,none,0,0,0,8,null
 RECIPE: /material/copper/,small copper pot,/obj/item/weapon/reagent_containers/glass/small_pot/copper_small,3,90,0,1,none,0,0,0,8,null
 RECIPE: /material/copper/,large copper pot,/obj/item/weapon/reagent_containers/glass/small_pot/copper_large,5,120,0,1,none,0,0,0,8,null
-RECIPE: /material/copper/,trombone,/obj/item/trombone,6,155,0,1,none,83,0,0,8,null
 RECIPE: /material/copper/,handbell,/obj/item/weapon/handbell,2,50,0,1,none,40,0,0,8,null
 
 //*****************| COPPER WEAPONS & TOOLS |***************************
 
 //*****************| COPPER PROJECTILES & BULLETS, GRENADES |***************************
 
-RECIPE: /material/copper/,rifle casing (x3),/obj/item/stack/ammopart/casing/rifle,1,25,0,1,ammunition,105,0,0,8,null
-RECIPE: /material/copper/,pistol casing (x3),/obj/item/stack/ammopart/casing/pistol,1,25,0,1,ammunition,105,0,0,8,null
-
-RECIPE: /material/copper/,artillery casing,/obj/item/stack/ammopart/casing/artillery,2,35,0,1,ammunition,105,0,0,8,null
-RECIPE: /material/copper/,field cannon casing,/obj/item/stack/ammopart/casing/tank,2,35,0,1,ammunition,105,0,0,8,null
-
-RECIPE: /material/copper/,ammo clip (5),/obj/item/ammo_magazine/emptyclip,1,30,0,1,ammunition,105,0,0,8,null
-RECIPE: /material/copper/,ammo belt (100),/obj/item/ammo_magazine/emptybelt,7,25,0,1,ammunition,125,0,0,8,null
-
-RECIPE: /material/copper/,grenade casing,/obj/item/stack/ammopart/casing/grenade,2,35,0,1,ammunition,115,0,0,8,null
-
 //*****************| COPPER MACHINERY & ELECTRONICS |***************************
-
-RECIPE: /material/copper/,electronic circuits,/obj/item/stack/material/electronics,1,80,0,1,none,95,0,0,8,null
-RECIPE: /material/copper/,telegraph,/obj/structure/telegraph,12,90,1,1,machinery,105,0,0,8,null
-RECIPE: /material/copper/,teleprinter,/obj/structure/teleprinter,12,120,1,1,machinery,105,0,0,8,null
-
-RECIPE: /material/copper/,white cable coil (10m),/obj/item/stack/cable_coil/white,1,35,0,1,electrical,105,0,0,8,null
-RECIPE: /material/copper/,red cable coil (10m),/obj/item/stack/cable_coil/red,1,35,0,1,electrical,105,0,0,8,null
-RECIPE: /material/copper/,blue cable coil (10m),/obj/item/stack/cable_coil/blue,1,35,0,1,electrical,105,0,0,8,null
-RECIPE: /material/copper/,yellow cable coil (10m),/obj/item/stack/cable_coil/yellow,1,35,0,1,electrical,105,0,0,8,null
-RECIPE: /material/copper/,green cable coil (10m),/obj/item/stack/cable_coil/green,1,35,0,1,electrical,105,0,0,8,null
-RECIPE: /material/copper/,orange cable coil (10m),/obj/item/stack/cable_coil/orange,1,35,0,1,electrical,105,0,0,8,null
-RECIPE: /material/copper/,cyan cable coil (10m),/obj/item/stack/cable_coil/cyan,1,35,0,1,electrical,105,0,0,8,null
-RECIPE: /material/copper/,pink cable coil (10m),/obj/item/stack/cable_coil/pink,1,35,0,1,electrical,105,0,0,8,null
 
 //*****************| COPPER ARMOR, CLOTHING & ACCESSORIES |***************************
 
@@ -1574,99 +911,19 @@ RECIPE: /material/copper/,copper arm bangles,/obj/item/clothing/accessory/armban
 //*********************| STEEL |**************************
 //********************************************************
 
-RECIPE: /material/steel/,wheelchair,/obj/structure/bed/chair/wheelchair,6,140,0,1,none,95,0,98,8,null
-RECIPE: /material/steel/,zippo lighter,/obj/item/weapon/flame/lighter/zippo,4,95,0,1,none,145,0,0,8,null
-
 //*********************| STEEL WEAPONS & TOOLS |**************************
-
-RECIPE: /material/steel/,wirecutters,/obj/item/weapon/wirecutters,4,70,0,1,tools,90,0,0,8,null
-RECIPE: /material/steel/,welding tool,/obj/item/weapon/weldingtool,7,90,0,1,tools,99,0,0,8,null
-RECIPE: /material/steel/,jackhammer,/obj/item/weapon/material/pickaxe/jackhammer,24,160,0,1,tools,178,0,0,8,null
 
 //*********************| STEEL SIEGE WEAPONS |**************************
 
-RECIPE: /material/steel/,cannon,/obj/structure/cannon,35,600,1,1,siege weapons,71,79,0,4,null
-RECIPE: /material/steel/,artillery cannon,/obj/structure/cannon/modern,40,600,1,1,siege weapons,95,109,0,8,null
-
-RECIPE: /material/steel/,ladder,/obj/item/weapon/siegeladder/metal,6,125,0,1,siege weapons,24,33,0,8,steel
-
 //*********************| STEEL FLOORS & CONSTRUCTIONS |**************************
-
-RECIPE: /material/steel/,jail bars,/obj/covers/jail/steeljail,8,30,1,1,construction,75,0,0,8,null
-RECIPE: /material/steel/,locked jail door,/obj/structure/simple_door/key_door/custom/jail/steeljail,12,30,1,1,construction,75,0,0,8,null
-
-RECIPE: /material/steel/,steel floor,/obj/covers/steelplating,1,15,1,1,construction,96,0,0,8,null
-RECIPE: /material/steel/,white floor,/obj/covers/steelplating/white,1,15,1,1,construction,96,0,0,8,null
-
-RECIPE: /material/steel/,steel window,/obj/structure/window_frame/metal,5,140,1,1,construction,96,0,0,8,null
 
 //*********************| STEEL VEHICLE PARTS |**************************
 
-RECIPE: /material/steel/,tank cannon,/obj/structure/cannon/modern/tank,40,600,1,1,weapons,115,125,0,8,null
-
-RECIPE: /material/steel/,rubber wheel,/obj/structure/vehicleparts/movement,1,20,0,1,vehicle parts,115,0,0,8,null
-RECIPE: /material/steel/,tank track,/obj/structure/vehicleparts/movement/tracks,4,60,0,1,vehicle parts,135,0,0,8,null
-
-RECIPE: /material/steel/,light axis (800 weight),/obj/structure/vehicleparts/axis/car,10,80,0,1,vehicle parts,126,0,0,8,null
-RECIPE: /material/steel/,heavy axis (2500 weight),/obj/structure/vehicleparts/axis/heavy,30,200,0,1,vehicle parts,126,0,0,8,null
-
-RECIPE: /material/steel/,driver's seat,/obj/structure/bed/chair/drivers,8,40,0,1,vehicle parts,126,0,0,8,null
-RECIPE: /material/steel/,loaders's seat,/obj/structure/bed/chair/loader,6,40,0,1,vehicle parts,126,125,0,8,null
-RECIPE: /material/steel/,gunner's seat,/obj/structure/bed/chair/gunner,6,40,0,1,vehicle parts,126,125,0,8,null
-RECIPE: /material/steel/,commander's seat,/obj/structure/bed/chair/commander,10,40,0,1,vehicle parts,126,125,0,8,null
-
-RECIPE: /material/steel/,motorcycle frame,/obj/item/vehicleparts/frame/bike,12,200,0,1,vehicle parts,126,0,0,8,null
-RECIPE: /material/steel/,steel vehicle frame,/obj/structure/vehicleparts/frame,2,40,0,1,vehicle parts,126,0,0,8,null
-RECIPE: /material/steel/,steel ship frame,/obj/structure/vehicleparts/frame/ship/steel,2,40,0,1,vehicle parts,97,0,0,8,null
-
-RECIPE: /material/steel/,fuel pump (star),/obj/structure/fuelpump/star,15,120,1,1,none,120,0,0,8,null
-RECIPE: /material/steel/,fuel pump (small),/obj/structure/fuelpump/small,15,120,1,1,none,120,0,0,8,null
-RECIPE: /material/steel/,fuel pump (N),/obj/structure/fuelpump/n,15,120,1,1,none,120,0,0,8,null
-RECIPE: /material/steel/,fuel pump (S),/obj/structure/fuelpump/s,15,120,1,1,none,120,0,0,8,null
-
-RECIPE: /material/steel/,25u bike fuel tank,/obj/item/weapon/reagent_containers/glass/barrel/fueltank/bike25,2,45,0,1,fuel tanks,120,0,0,8,null
-RECIPE: /material/steel/,50u bike fuel tank,/obj/item/weapon/reagent_containers/glass/barrel/fueltank/bike,4,65,0,1,fuel tanks,120,0,0,8,null
-RECIPE: /material/steel/,75u bike fuel tank,/obj/item/weapon/reagent_containers/glass/barrel/fueltank/bike75,6,85,0,1,fuel tanks,120,0,0,8,null
-RECIPE: /material/steel/,120u small fuel tank,/obj/item/weapon/reagent_containers/glass/barrel/fueltank/small,10,125,0,1,fuel tanks,120,0,0,8,null
-RECIPE: /material/steel/,180u medium fuel tank,/obj/item/weapon/reagent_containers/glass/barrel/fueltank/smalltank,15,185,0,1,fuel tanks,120,0,0,8,null
-RECIPE: /material/steel/,250u large fuel tank,/obj/item/weapon/reagent_containers/glass/barrel/fueltank,20,185,0,1,fuel tanks,120,0,0,8,null
-RECIPE: /material/steel/,450u huge fuel tank,/obj/item/weapon/reagent_containers/glass/barrel/fueltank/tank,36,185,0,1,fuel tanks,120,0,0,8,null
-
 //*********************| STEEL PRODUCTION & ECONOMY |**************************
-
-RECIPE: /material/steel/,wood stove,/obj/structure/oven/woodstove,8,250,1,1,production,86,0,0,8,null
-
-RECIPE: /material/steel/,bakelizer,/obj/structure/bakelizer,18,300,1,1,production,90,0,0,8,null
-RECIPE: /material/steel/,industrial acidic bath,/obj/structure/converter/acid_bath,12,200,1,1,jackets & vests,175,0,180,8,null
-
-RECIPE: /material/steel/,petroleum refinery,/obj/structure/refinery,22,230,1,1,production,110,0,0,8,null
-RECIPE: /material/steel/,biofuel refinery,/obj/structure/refinery/biofuel,18,200,1,1,production,115,0,0,8,null
-
-RECIPE: /material/steel/,steam engine,/obj/structure/engine/external/steam,15,250,1,1,production,95,0,0,8,null
-
-RECIPE: /material/steel/,IV drip,/obj/structure/iv_drip,6,140,0,1,production,95,0,95,8,null
-
-RECIPE: /material/steel/,vending machine,/obj/structure/vending/sales/vending,12,150,1,1,none,200,0,0,8,null
 
 //*********************| STEEL STORAGE |**************************
 
-RECIPE: /material/steel/,red toolbox,/obj/item/weapon/storage/toolbox,4,60,0,1,storage,95,0,0,8,null
-RECIPE: /material/steel/,blue toolbox,/obj/item/weapon/storage/toolbox/blue,4,60,0,1,storage,95,0,0,8,null
-RECIPE: /material/steel/,yellow toolbox,/obj/item/weapon/storage/toolbox/yellow,4,60,0,1,storage,95,0,0,8,null
-
-RECIPE: /material/steel/,footlocker,/obj/structure/closet/crate/footlocker,1.5,50,0,1,storage,95,0,0,8,null
-RECIPE: /material/steel/,metal crate,/obj/structure/closet/crate,3,80,1,1,storage,115,0,0,8,null
-RECIPE: /material/steel/,cash register,/obj/structure/closet/crate/cash_register,3,60,1,1,storage,135,0,0,8,null
-RECIPE: /material/steel/,storage,/obj/structure/closet/fridge,15,230,1,1,storage,150,0,178,8,null
-
-RECIPE: /material/steel/,steel barrel,/obj/item/weapon/reagent_containers/glass/barrel/modern,2,75,1,1,storage,105,0,0,8,null
-RECIPE: /material/steel/,steel jerrycan,/obj/item/weapon/reagent_containers/glass/barrel/jerrycan,1,75,0,1,storage,120,0,0,8,null
-
 //*********************| STEEL ELECTRICAL & COMMUNICATION|**************************
-
-RECIPE: /material/steel/,street lamp,/obj/structure/lamp/lamppost_small,3,35,0,1,electrical,99,0,0,8,null
-
-RECIPE: /material/steel/,cell tower,/obj/structure/cell_tower,15,180,1,1,none,212,0,0,8,null
 
 //*********************| STEEL PROJECTILES|**************************
 
@@ -1680,14 +937,14 @@ RECIPE: /material/steel/,flagpole,/obj/structure/flag/pole,6,95,0,1,none,0,0,0,8
 //********************************************************
 
 //*********************| BRONZE WEAPONS & TOOLS |*************************
+
 RECIPE: /material/bronze/,shears,/obj/item/weapon/shears,2,40,0,1,tools,0,0,0,8,null
 
 //*********************| BRONZE PROJECTILES |*************************
 
 //*********************| BRONZE ARMOR |*************************
-RECIPE: /material/bronze/,bronze phrigian helmet,/obj/item/clothing/head/helmet/phrigian,4,100,0,1,armor,21,16,0,1,bronze
-RECIPE: /material/bronze/,bronze chestplate,/obj/item/clothing/suit/armor/medieval/bronze_chestplate,6,165,0,1,armor,24,21,0,2,bronze
-RECIPE: /material/bronze/,bronze dragoon helmet,/obj/item/clothing/head/helmet/napoleonic/dragoon,7,100,0,1,armor,0,88,92,3,null
+
+RECIPE: /material/bronze/,bronze chestplate,/obj/item/clothing/suit/armor/medieval/bronze_chestplate,6,165,0,1,armor,24,21,0,8,bronze
 
 //*********************| BRONZE HEALTHCARE |*************************
 
@@ -1701,14 +958,11 @@ RECIPE: /material/bronze/,bronze scalpel,/obj/item/weapon/surgery/scalpel/bronze
 //*********************| BRONZE CLOTHING & ACCESSORIES |*************************
 
 RECIPE: /material/bronze/,bronze arm bangles,/obj/item/clothing/accessory/armband/armbangle/bronze,2,95,0,1,none,0,0,0,8,null
-RECIPE: /material/bronze/,spiked bracers,/obj/item/clothing/accessory/armband/punk,3,95,0,1,none,180,0,0,8,null
 
 //*********************| BRONZE DECORATION & MONUMENTS |*************************
 
 RECIPE: /material/bronze/,bronze statue,/obj/structure/religious/statue,10,250,1,1,religious & decoration,10,0,0,8,bronze
 RECIPE: /material/bronze/,bronze sarcophagus,/obj/structure/closet/coffin/sarcophagus,25,350,1,1,religious & decoration,0,0,0,1,bronze
-RECIPE: /material/bronze/,monumental bronze statue of karl marx,/obj/structure/religious/monument/karl_marx,30,300,1,1,religious & decoration,125,0,0,8,null
-RECIPE: /material/bronze/,bronze bust of karl marx,/obj/item/weapon/material/marx,3,80,0,0,religious & decoration,125,0,0,8,bronze
 
 //*******************************************************
 //*********************| WOOD |**************************
@@ -1718,37 +972,20 @@ RECIPE: /material/wood/,torch,/obj/item/flashlight/torch,2,60,0,1,none,0,0,0,8,n
 
 //*********************| WOOD VEHICLES & LOCOMOTIVES |**************************
 
-RECIPE: /material/wood/,mining cart,/obj/structure/trains/storage/miningcart,10,150,1,1,trains,93,0,0,8,null
-
 RECIPE: /material/wood/,raft,/obj/structure/vehicle/raft,10,180,1,1,vehicle parts,22,0,0,8,null
 
-RECIPE: /material/wood/,communications pole,/obj/structure/phoneline,2,50,1,1,none,100,0,0,8,null
 RECIPE: /material/wood/,outrigger boat frame,/obj/item/vehicleparts/frame/boat,22,200,0,1,vehicle parts,22,0,0,8,null
-
-RECIPE: /material/wood/,wood vehicle frame,/obj/structure/vehicleparts/frame/wood,2,40,0,1,vehicle parts,126,0,0,8,null
-
-RECIPE: /material/wood/,wood ship frame,/obj/structure/vehicleparts/frame/ship,4,40,0,1,vehicle parts,41,0,0,8,null
-RECIPE: /material/wood/,ship rudder axis (2500 weight),/obj/structure/vehicleparts/axis/ship/heavy,45,300,0,1,vehicle parts,55,0,0,8,null
-RECIPE: /material/wood/,light ship rudder axis (1200 weight),/obj/structure/vehicleparts/axis/ship,25,200,0,1,vehicle parts,41,0,0,8,null
-RECIPE: /material/wood/,ship rudder control,/obj/structure/vehicleparts/shipwheel,10,100,0,1,vehicle parts,41,0,0,8,null
-RECIPE: /material/wood/,ship mast,/obj/structure/vehicleparts/movement/sails,15,140,0,1,vehicle parts,41,0,0,8,null
 
 //*********************| WOOD PRODUCTION & ECONOMY |**************************
 
 RECIPE: /material/wood/,research desk,/obj/structure/researchdesk,8,250,1,1,economy & production,0,0,0,8,null
-RECIPE: /material/wood/,altar of chad,/obj/structure/researchdesk/chad,8,100,1,1,economy & production,0,0,0,8,null
 
 RECIPE: /material/wood/,tanning rack,/obj/structure/converter/tanning,8,80,1,1,economy & production,16,0,0,8,null
-RECIPE: /material/wood/,salting container,/obj/structure/salting_container,6,100,1,1,economy & production,0,0,18,8,null
 RECIPE: /material/wood/,small mill,/obj/structure/mill,4,90,1,1,economy & production,19,0,0,8,null
 RECIPE: /material/wood/,dehydrator,/obj/structure/dehydrator,5,110,1,1,economy & production,19,0,0,8,null
 RECIPE: /material/wood/,loom,/obj/structure/loom,8,150,1,1,economy & production,19,0,0,8,null
 RECIPE: /material/wood/,retting trough,/obj/structure/converter/retting_trough,8,150,1,1,economy & production,19,0,0,8,null
 RECIPE: /material/wood/,compost bin,/obj/structure/compost,10,150,1,1,economy & production,35,0,0,8,null
-RECIPE: /material/wood/,oil well,/obj/structure/oilwell,40,270,1,1,economy & production,105,0,0,8,null
-RECIPE: /material/wood/,oil deposit,/obj/structure/oil_deposits,6,100,1,1,economy & production,105,0,0,8,null
-RECIPE: /material/wood/,gunsmithing bench,/obj/structure/gunbench,13,180,1,1,economy & production,118,0,0,8,null
-RECIPE: /material/wood/,ethanol distillery,/obj/structure/distillery,15,180,1,1,economy & production,45,0,0,8,null
 
 RECIPE: /material/wood/,market stall,/obj/structure/vending/sales/market_stall,25,150,1,1,economy & production,24,0,0,8,null
 RECIPE: /material/wood/,supply stall,/obj/structure/supplier,25,150,1,1,economy & production,24,0,0,8,null
@@ -1761,8 +998,6 @@ RECIPE: /material/wood/,mine support,/obj/structure/mine_support,2,30,1,1,constr
 RECIPE: /material/wood/,nordic roof support,/obj/structure/roof_support/nordic,2,30,1,1,construction,47,0,0,8,null
 
 RECIPE: /material/wood/,wood roof builder,/obj/item/weapon/roofbuilder,1,20,0,1,construction,0,0,0,8,null
-
-RECIPE: /material/wood/,wall frame,/obj/structure/wallframe,1,150,1,1,construction,35,0,0,8,null
 
 RECIPE: /material/wood/,door,/obj/structure/simple_door/key_door/anyone/wood,5,50,1,1,construction,18,0,0,8,null
 RECIPE: /material/wood/,aztec door,/obj/structure/simple_door/key_door/anyone/aztec,5,50,1,1,construction,35,0,0,8,null
@@ -1787,8 +1022,6 @@ RECIPE: /material/wood/,aztec wall,/obj/covers/wood_wall/aztec,8,170,1,1,constru
 
 RECIPE: /material/wood/,custom rustic sign,/obj/structure/sign/custom,2.5,40,1,1,construction,0,0,0,8,null
 RECIPE: /material/wood/,custom wood sign,/obj/structure/sign/custom/plaque,3,40,1,1,construction,25,0,0,8,null
-RECIPE: /material/wood/,custom metallic sign,/obj/structure/sign/custom/metallic,4,40,1,1,construction,35,0,0,8,null
-RECIPE: /material/wood/,custom golden sign,/obj/structure/sign/custom/golden,6,40,1,1,construction,35,0,0,8,null
 
 RECIPE: /material/wood/,signpost,/obj/structure/sign/signpost,4,40,1,1,construction,0,0,0,8,null
 
@@ -1817,24 +1050,14 @@ RECIPE: /material/wood/,female outhouse,/obj/structure/toilet/outhouse/female,35
 RECIPE: /material/wood/,punji sticks trap,/obj/item/weapon/punji_sticks,4,70,0,1,weapons,0,0,0,8,null
 
 RECIPE: /material/wood/,quarterstaff,/obj/item/weapon/material/quarterstaff,2,50,0,1,weapons,0,0,0,8,wood
-RECIPE: /material/wood/,wood club,/obj/item/weapon/melee/classic_baton/club,3,50,0,1,weapons,0,0,0,0,wood
-RECIPE: /material/wood/,wood spear,/obj/item/weapon/material/spear,4,50,0,1,weapons,0,0,0,3,wood
-RECIPE: /material/wood/,assagai spear,/obj/item/weapon/material/spear/assagai,4,90,0,1,weapons,0,22,0,3,wood
-RECIPE: /material/wood/,pilum,/obj/item/weapon/material/pilum,3,50,0,1,weapons,0,22,0,2,wood
-RECIPE: /material/wood/,wood dory,/obj/item/weapon/material/spear/dory,6,70,0,1,weapons,0,22,0,2,wood
-RECIPE: /material/wood/,wood sarissa,/obj/item/weapon/material/spear/sarissa,8,90,0,1,weapons,0,22,0,2,wood
-RECIPE: /material/wood/,training sword,/obj/item/weapon/material/sword/training,8,80,0,1,weapons,0,24,0,2,wood
-RECIPE: /material/wood/,macuahuitl,/obj/item/weapon/macuahuitl,5,90,0,1,weapons,0,26,0,3,null
-RECIPE: /material/wood/,police baton,/obj/item/weapon/melee/classic_baton,4,90,0,1,weapons,0,95,0,8,null
+RECIPE: /material/wood/,wood club,/obj/item/weapon/melee/classic_baton/club,3,50,0,1,weapons,0,0,0,8,wood
+RECIPE: /material/wood/,training sword,/obj/item/weapon/material/sword/training,8,80,0,1,weapons,0,24,0,8,wood
+RECIPE: /material/wood/,macuahuitl,/obj/item/weapon/macuahuitl,5,90,0,1,weapons,0,26,0,8,null
 
-RECIPE: /material/wood/,wood shield,/obj/item/weapon/shield,8,180,0,1,weapons,0,14,0,3,null
-RECIPE: /material/wood/,chimalli,/obj/item/weapon/shield/chimalli,6,180,0,1,weapons,0,19,0,3,null
+RECIPE: /material/wood/,wood shield,/obj/item/weapon/shield,8,180,0,1,weapons,0,14,0,8,null
+RECIPE: /material/wood/,chimalli,/obj/item/weapon/shield/chimalli,6,180,0,1,weapons,0,19,0,8,null
 
-RECIPE: /material/wood/,primitive bow,/obj/item/weapon/gun/projectile/bow,8,120,0,1,weapons,0,14,0,2,null
-RECIPE: /material/wood/,shortbow,/obj/item/weapon/gun/projectile/bow/shortbow,8,140,0,1,weapons,0,30,0,7,null
-RECIPE: /material/wood/,longbow,/obj/item/weapon/gun/projectile/bow/longbow,12,160,0,1,weapons,0,35,0,7,null
-RECIPE: /material/wood/,crossbow,/obj/item/weapon/gun/projectile/bow/crossbow,12,160,0,1,weapons,0,45,0,8,null
-RECIPE: /material/wood/,compound bow,/obj/item/weapon/gun/projectile/bow/compoundbow,8,170,0,1,weapons,0,175,0,8,null
+RECIPE: /material/wood/,primitive bow,/obj/item/weapon/gun/projectile/bow,8,120,0,1,weapons,0,14,0,8,null
 
 //*********************| WOOD PROJECTILES & SHAFTS |**************************
 
@@ -1875,31 +1098,28 @@ RECIPE: /material/wood/,wood mailbox,/obj/structure/closet/crate/wall_mailbox/wo
 RECIPE: /material/wood/,coffin,/obj/structure/closet/coffin,4,50,1,1,furniture,41,0,0,8,null
 RECIPE: /material/wood/,wardrobe,/obj/structure/closet/cabinet,5,80,1,1,furniture,41,0,0,8,null
 RECIPE: /material/wood/,cabinet,/obj/structure/closet/cabinet/ceiling,4,60,1,1,furniture,41,0,0,8,null
-RECIPE: /material/wood/,grandfather clock,/obj/structure/TV/grandfather,9,160,1,1,furniture,42,0,0,8,null
-RECIPE: /material/wood/,shell rack,/obj/structure/shellrack,6,90,1,1,furniture,80,105,0,8,null
-RECIPE: /material/wood/,large crate,/obj/structure/closet/crate/empty/large,8,80,1,1,furniture,95,0,0,8,null
-RECIPE: /material/wood/,military crate,/obj/structure/closet/crate/ww2,5,50,1,1,furniture,105,0,0,8,null
 
 //*********************| WOOD DECORATION & MONUMENTS |**************************
 
 RECIPE: /material/wood/,wood altar,/obj/structure/altar/wood,20,200,1,1,religious & decoration,0,0,0,8,null
-RECIPE: /material/wood/,decorative wood mask,/obj/structure/religious/tribalmask,2,50,1,1,religious & decoration,0,0,0,2,null
+RECIPE: /material/wood/,decorative wood mask,/obj/structure/religious/tribalmask,2,50,1,1,religious & decoration,0,0,0,8,null
 RECIPE: /material/wood/,impaled skull,/obj/structure/religious/impaledskull,2,50,1,1,religious & decoration,0,0,0,8,null
 RECIPE: /material/wood/,tiki statue,/obj/structure/religious/tiki_statue,10,150,1,1,religious & decoration,0,0,0,8,null
 RECIPE: /material/wood/,small tiki statue,/obj/structure/religious/tiki_statue/small,8,150,1,1,religious & decoration,0,0,0,8,null
-RECIPE: /material/wood/,wood totem pole,/obj/structure/religious/totem_pole,10,250,1,1,religious & decoration,0,0,0,2,null
+RECIPE: /material/wood/,wood totem pole,/obj/structure/religious/totem_pole,10,250,1,1,religious & decoration,0,0,0,8,null
 RECIPE: /material/wood/,cross,/obj/structure/religious/woodcross2,4,80,1,1,religious & decoration,47,0,0,8,null
 RECIPE: /material/wood/,small cross,/obj/structure/religious/woodcross1,2,50,1,1,religious & decoration,47,0,0,8,null
-
-RECIPE: /material/wood/,monumental crucero cross,/obj/structure/religious/monument/crucero,45,300,1,1,religious & decoration,32,0,0,8,null
 
 //*********************| WOOD CLOTHING |**************************
 
 RECIPE: /material/wood/,sandals,/obj/item/clothing/shoes/sandal,1,40,0,1,shoes & clothing,0,0,0,8,null
-RECIPE: /material/wood/,geta sandals,/obj/item/clothing/shoes/geta,1,40,0,1,shoes & clothing,24,0,38,8,null
 
-RECIPE: /material/wood/,wearable wood mask,/obj/item/clothing/mask/wooden,2,50,0,1,shoes & clothing,0,0,0,2,null
-RECIPE: /material/wood/,expressive wearable wood mask,/obj/item/clothing/mask/wooden/expressive,3,50,0,1,shoes & clothing,0,0,0,2,null
+RECIPE: /material/wood/,wearable wood mask,/obj/item/clothing/mask/wooden,2,50,0,1,shoes & clothing,0,0,0,8,null
+RECIPE: /material/wood/,expressive wearable wood mask,/obj/item/clothing/mask/wooden/expressive,3,50,0,1,shoes & clothing,0,0,0,8,null
+
+//*********************| WOOD ARMOR |**************************
+
+RECIPE: /material/wood/,primitive wood armor,/obj/item/clothing/suit/woodarmor,15,150,0,1,none,0,0,0,8,null
 
 //*********************| WOOD KITCHEN |**************************
 
@@ -1918,31 +1138,18 @@ RECIPE: /material/wood/,gong mallet,/obj/item/weapon/gongmallet,3,50,0,1,enterta
 
 RECIPE: /material/wood/,bell stand,/obj/structure/bell_stand,3,100,0,1,entertainment & other,40,0,0,8,null
 
-RECIPE: /material/wood/,matches (x10),/obj/item/weapon/matchbox,2,80,1,1,entertainment & other,67,0,0,8,null
 RECIPE: /material/wood/,cigar case,/obj/item/weapon/storage/fancy/cigar,2,80,1,1,entertainment & other,65,0,0,8,null
-RECIPE: /material/wood/,deck of cards,/obj/item/weapon/deck/cards,2,80,1,1,entertainment & other,65,0,0,8,null
-
-RECIPE: /material/wood/,violin,/obj/item/violin,10,135,0,1,entertainment & other,50,0,0,8,null
-RECIPE: /material/wood/,piano,/obj/structure/piano,18,195,1,1,entertainment & other,45,0,0,8,null
 
 //*********************| WOOD RESEARCH & PAPER |**************************
 
 RECIPE: /material/wood/,research kit,/obj/item/weapon/researchkit,10,190,0,1,paper & printing,0,0,0,8,null
 RECIPE: /material/wood/,scientific literature,/obj/item/weapon/book/research,4,110,0,1,paper & printing,0,0,0,8,null
 
-RECIPE: /material/wood/,language book,/obj/item/weapon/book/language_book,10,160,0,1,paper & printing,0,0,0,8,null
 RECIPE: /material/wood/,holy book,/obj/item/weapon/book/holybook,15,240,1,1,paper & printing,0,0,0,8,null
 
-RECIPE: /material/wood/,visa (empty),/obj/item/weapon/visa,1,40,0,1,paper & printing,19,0,0,8,null
-RECIPE: /material/wood/,passport,/obj/item/clothing/accessory/storage/passport,3,150,0,1,paper & printing,19,0,0,8,null
 RECIPE: /material/wood/,official faction paper,/obj/item/weapon/paper/official,1,25,0,1,paper & printing,19,0,0,8,null
 RECIPE: /material/wood/,envelope,/obj/item/weapon/storage/envelope,2,35,0,1,paper & printing,40,0,0,8,null
 RECIPE: /material/wood/,wax seal stamp,/obj/item/weapon/stamp/mail,1,30,0,1,paper & printing,40,0,0,8,null
-RECIPE: /material/wood/,book,/obj/item/weapon/book,4,75,0,1,paper & printing,45,0,0,8,null
-RECIPE: /material/wood/,grey folder,/obj/item/weapon/folder,1,75,0,1,paper & printing,120,0,0,8,null
-RECIPE: /material/wood/,yellow folder,/obj/item/weapon/folder/yellow,1,75,0,1,paper & printing,120,0,0,8,null
-RECIPE: /material/wood/,red folder,/obj/item/weapon/folder/red,1,75,0,1,paper & printing,120,0,0,8,null
-RECIPE: /material/wood/,photo album,/obj/item/weapon/storage/photo_album,5,85,0,1,paper & printing,95,0,0,8,null
 
 RECIPE: /material/wood/,religious poster,/obj/item/weapon/poster/religious,1,25,0,1,paper & printing,19,0,0,8,null
 RECIPE: /material/wood/,military propaganda poster (flag),/obj/item/weapon/poster/faction/mil1,1,25,0,1,paper & printing,19,0,0,8,null
@@ -1950,12 +1157,9 @@ RECIPE: /material/wood/,military propaganda poster (armed),/obj/item/weapon/post
 RECIPE: /material/wood/,work propaganda poster,/obj/item/weapon/poster/faction/work,1,25,0,1,paper & printing,19,0,0,8,null
 RECIPE: /material/wood/,leader propaganda poster,/obj/item/weapon/poster/faction/lead,1,25,0,1,paper & printing,19,0,0,8,null
 
-RECIPE: /material/wood/,notice board,/obj/structure/noticeboard,12,145,1,1,paper & printing,50,0,0,8,null
-RECIPE: /material/wood/,printing press,/obj/structure/printingpress,12,120,1,1,paper & printing,52,0,0,8,null
-
 //*********************| WOOD SIEGE WEAPONS |**************************
 
-RECIPE: /material/wood/,catapult,/obj/structure/catapult,50,450,1,1,siege weapons,24,33,0,4,null
+RECIPE: /material/wood/,catapult,/obj/structure/catapult,50,450,1,1,siege weapons,24,33,0,8,null
 
 RECIPE: /material/wood/,siege ladder,/obj/item/weapon/siegeladder,8,100,0,1,siege weapons,24,33,0,8,null
 
@@ -1967,22 +1171,9 @@ RECIPE: /material/wood/,doctor handbook,/obj/item/weapon/doctor_handbook,12,210,
 
 //*********************| WOOD PAINTINGS |**************************
 
-RECIPE: /material/wood/,stormy sea,/obj/structure/sign/painting1,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,city street,/obj/structure/sign/painting2,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,sea sunset,/obj/structure/sign/painting3,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,valley,/obj/structure/sign/painting4,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,still life,/obj/structure/sign/painting5,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,bird and blossom,/obj/structure/sign/painting6,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,pine on the shore,/obj/structure/sign/painting7,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,temple by the river,/obj/structure/sign/painting8,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,desert camp,/obj/structure/sign/painting9,3,40,1,1,paintings,65,0,0,8,null
-RECIPE: /material/wood/,barque at sea,/obj/structure/sign/painting10,3,40,1,1,paintings,65,0,0,8,null
-
 //*********************| WOOD PUNISHMENTS |**************************
 
 RECIPE: /material/wood/,gallows,/obj/structure/gallows,3,60,1,1,punishments,0,15,0,8,null
-RECIPE: /material/wood/,greek cross,/obj/structure/cross,10,100,1,1,punishments,0,20,0,8,null
-RECIPE: /material/wood/,tau cross,/obj/structure/cross/tau,10,100,1,1,punishments,0,20,0,8,null
 RECIPE: /material/wood/,pillory,/obj/structure/pillory,8,60,1,1,punishments,0,32,0,8,null
 
 //*******************************************************
@@ -1998,7 +1189,6 @@ RECIPE: /material/bamboo/,tiki torch,/obj/item/flashlight/tiki_torch,5,60,0,1,no
 //*********************| BAMBOO CONSTRUCTIONS |**************************
 
 RECIPE: /material/bamboo/,roof support,/obj/structure/roof_support/bamboo,2,30,1,1,construction,0,0,0,8,null
-RECIPE: /material/bamboo/,bamboo wall frame,/obj/structure/wallframe/bamboo,1,150,1,1,construction,10,0,0,8,null
 RECIPE: /material/bamboo/,horizontal tatami floor,/obj/covers/tatami,0.75,20,1,1,construction,0,0,0,8,null
 RECIPE: /material/bamboo/,vertical tatami floor,/obj/covers/tatami_vertical,0.75,20,1,1,construction,0,0,0,8,null
 RECIPE: /material/bamboo/,horizontal dark tatami floor,/obj/covers/tatami_dark,0.75,20,1,1,construction,0,0,0,8,null
@@ -2008,12 +1198,8 @@ RECIPE: /material/bamboo/,vertical dark tatami floor,/obj/covers/tatami_dark_ver
 
 RECIPE: /material/bamboo/,research kit,/obj/item/weapon/researchkit,10,190,0,1,paper & printing,0,0,0,8,null
 RECIPE: /material/bamboo/,scientific literature,/obj/item/weapon/book/research,4,110,0,1,paper & printing,0,0,0,8,null
-RECIPE: /material/bamboo/,pen,/obj/item/weapon/pen,1,50,0,1,paper & printing,19,0,0,8,null
-RECIPE: /material/bamboo/,paper sheet,/obj/item/weapon/paper,1,25,0,1,paper & printing,19,0,0,8,null
 
 //*********************| BAMBOO CLOTHING |**************************
-
-RECIPE: /material/bamboo/,rice hat,/obj/item/clothing/head/rice_hat,3,75,0,1,none,0,0,38,8,null
 
 //*********************| BAMBOO WEAPONS |**************************
 
@@ -2030,35 +1216,11 @@ RECIPE: /material/iron/,ladder,/obj/item/weapon/siegeladder/metal,8,40,0,1,none,
 
 //*********************| IRON LOCOMOTIVES & TRACKS |**************************
 
-RECIPE: /material/iron/,rail (horizontal),/obj/structure/rails/regular/horizontal,1,50,1,1,trains,93,0,0,8,null
-RECIPE: /material/iron/,rail (vertical),/obj/structure/rails/regular,1,50,1,1,trains,93,0,0,8,null
-RECIPE: /material/iron/,rail (left turn),/obj/structure/rails/turn,1,50,1,1,trains,93,0,0,8,null
-RECIPE: /material/iron/,rail switcher (to left),/obj/structure/rails/split/switcher,2,50,1,1,trains,93,0,0,8,null
-RECIPE: /material/iron/,rail switcher (to right),/obj/structure/rails/split/switcher/right,2,50,1,1,trains,93,0,0,8,null
-RECIPE: /material/iron/,rail rotator platform,/obj/structure/rails/rotate,3,50,1,1,trains,93,0,0,8,null
-RECIPE: /material/iron/,train lever,/obj/structure/train_lever,1,50,1,1,trains,93,0,0,8,null
-
-RECIPE: /material/iron/,steam locomotive,/obj/structure/trains/locomotive/coal,18,250,1,1,trains,101,0,0,8,null
-
-RECIPE: /material/iron/,coal tender,/obj/structure/trains/storage/tender,6,250,1,1,trains,101,0,0,8,null
-RECIPE: /material/iron/,cabin wagon,/obj/structure/trains/transport/cabin,4,250,1,1,trains,101,0,0,8,null
-RECIPE: /material/iron/,flatbed wagon,/obj/structure/trains/transport/flatbed,4,250,1,1,trains,101,0,0,8,null
-RECIPE: /material/iron/,transport wagon,/obj/structure/trains/storage/closed,5,250,1,1,trains,101,0,0,8,null
-
 //*********************| IRON PRODUCTION & ECONOMY |**************************
 
 RECIPE: /material/iron/,armor repair bench,/obj/structure/repair/workbench,16,180,1,1,production,25,0,0,8,null
 
-RECIPE: /material/iron/,engine maker,/obj/item/weapon/enginemaker,5,80,0,1,tools,115,0,0,8,null
-
-RECIPE: /material/iron/,iron furnace,/obj/structure/heatsource,15,140,1,1,production,0,87,0,8,null
-RECIPE: /material/iron/,iron blast furnace,/obj/structure/furnace/blast_furnace,25,220,1,1,production,0,55,0,8,null
-
-RECIPE: /material/iron/,firearm maintenance bench,/obj/structure/repair/gun,18,180,1,1,production,25,70,0,8,null
-
 RECIPE: /material/iron/,large drying rack,/obj/structure/drying_rack,8,120,1,1,production,0,0,16,8,null
-RECIPE: /material/iron/,canner,/obj/structure/canner,7,120,1,1,production,95,0,0,8,null
-RECIPE: /material/iron/,meat grinder,/obj/structure/meat_grinder,8,120,1,1,production,0,0,90,8,null
 
 //*********************| IRON TOOLS |**************************
 
@@ -2068,14 +1230,7 @@ RECIPE: /material/iron/,chisel,/obj/item/weapon/chisel/metal,8,160,1,1,tools,0,0
 RECIPE: /material/iron/,trench shovel,/obj/item/weapon/material/shovel/trench,2,50,0,1,tools,14,0,0,8,null
 RECIPE: /material/iron/,wrench,/obj/item/weapon/wrench,5,50,0,1,tools,18,0,0,8,null
 RECIPE: /material/iron/,planting trowel,/obj/item/weapon/material/trowel,3,35,0,1,tools,20,0,0,8,iron
-RECIPE: /material/iron/,pitchfork,/obj/item/weapon/material/pitchfork,4,120,0,1,tools,30,0,0,8,null
-RECIPE: /material/iron/,extraction kit,/obj/item/weapon/reagent_containers/glass/extraction_kit,14,200,0,1,tools,33,0,0,8,null
-RECIPE: /material/iron/,telescope,/obj/item/weapon/attachment/scope/adjustable/binoculars,5,140,0,1,tools,0,46,0,8,null
-RECIPE: /material/iron/,firearm cleaning kit,/obj/item/weapon/gun_cleaning_kit,5,80,0,1,tools,0,90,0,8,null
-RECIPE: /material/iron/,clawhammer,/obj/item/weapon/hammer/modern,3,40,0,1,tools,110,0,0,8,null
 RECIPE: /material/iron/,fishing rod,/obj/item/weapon/fishing/modern,5,60,0,1,tools,120,0,0,8,null
-
-RECIPE: /material/iron/,handcuffs,/obj/item/weapon/handcuffs,1,50,0,1,tools,0,61,0,8,null
 
 //*********************| IRON FURNITURE, DECORATION & RELIGION |**************************
 
@@ -2085,43 +1240,20 @@ RECIPE: /material/iron/,cooking pot,/obj/structure/pot,8,180,1,1,production,33,0
 
 RECIPE: /material/iron/,brazier,/obj/structure/brazier,4,90,1,1,production,33,0,0,8,null
 
-RECIPE: /material/iron/,grill,/obj/structure/oven/grill,8,150,1,1,production,150,0,0,8,null
-
 RECIPE: /material/iron/,iron altar,/obj/structure/altar/iron,12,200,1,1,furniture,0,0,0,8,null
 
-RECIPE: /material/iron/,locker,/obj/structure/closet,4,80,1,1,furniture,105,0,0,8,null
-
-RECIPE: /material/iron/,wall mailbox,/obj/structure/closet/crate/wall_mailbox,3,65,1,1,furniture,90,0,0,8,null
-
 //*********************| IRON WEAPONS |**************************
-
-RECIPE: /material/iron/,mechanical trap,/obj/item/weapon/beartrap,5,140,0,1,weapons,0,32,0,8,null
-RECIPE: /material/iron/,shuriken,/obj/item/weapon/material/thrown/star,2,15,0,1,weapons,0,39,0,8,iron
-RECIPE: /material/iron/,kunai,/obj/item/weapon/material/thrown/kunai_normal,3,20,0,1,weapons,0,39,0,8,iron
-
-RECIPE: /material/iron/,bayonet,/obj/item/weapon/attachment/bayonet,2,30,0,1,weapons,0,90,0,8,null
 
 //*********************| IRON CONSTRUCTIONS |**************************
 
 RECIPE: /material/iron/,unlocked iron door,/obj/structure/simple_door/key_door/anyone,5,50,1,1,construction,28,0,0,8,null
 RECIPE: /material/iron/,locked iron door,/obj/structure/simple_door/key_door/custom,5,50,1,1,construction,28,0,0,8,null
 
-RECIPE: /material/iron/,iron fence,/obj/structure/grille/ironfence,2,80,1,1,construction,50,0,0,8,null
-RECIPE: /material/iron/,chainlink fence,/obj/structure/grille/chainlinkfence,3,80,1,1,construction,120,0,0,8,null
-RECIPE: /material/iron/,barbwire,/obj/item/stack/material/barbwire,1,30,1,1,construction,120,0,0,8,null
-
 //*********************| IRON PROJECTILES & BULLETS |**************************
-
-RECIPE: /material/iron/,revolver speedloader (6),/obj/item/ammo_magazine/emptyspeedloader,1,45,0,1,magazines,100,0,0,8,null
-RECIPE: /material/iron/,pistol magazine (8),/obj/item/ammo_magazine/emptymagazine/pistol/a45,2,45,0,1,magazines,105,0,0,8,null
-RECIPE: /material/iron/,pistol magazine (15),/obj/item/ammo_magazine/emptymagazine/pistol,3,45,0,1,magazines,105,0,0,8,null
-RECIPE: /material/iron/,magazine (30),/obj/item/ammo_magazine/emptymagazine/small,4,45,0,1,magazines,130,0,0,8,null
-RECIPE: /material/iron/,drum magazine (65),/obj/item/ammo_magazine/emptymagazine,7,45,0,1,magazines,135,0,0,8,null
 
 //*********************| IRON CLOTHING & ACCESSORIES |**************************
 
 RECIPE: /material/iron/,iron arm bangles,/obj/item/clothing/accessory/armband/armbangle,2,95,0,1,none,0,0,0,8,null
-RECIPE: /material/iron/,monocle,/obj/item/clothing/glasses/monocle,3,110,0,1,none,0,61,0,8,null
 
 //*********************| IRON HEALTHCARE |**************************
 
@@ -2137,12 +1269,6 @@ RECIPE: /material/iron/,surgical drill,/obj/item/weapon/surgery/surgicaldrill,2,
 
 //*********************| IRON FIREARMS |**************************
 
-RECIPE: /material/iron/,matchlock musket,/obj/item/weapon/gun/projectile/ancient/matchlock,18,140,0,1,firearms,0,70,0,5,null
-RECIPE: /material/iron/,matchlock tanegashima,obj/item/weapon/gun/projectile/ancient/tanegashima,18,140,0,1,firearms,0,70,0,5,null
-RECIPE: /material/iron/,arquebus,/obj/item/weapon/gun/projectile/ancient/arquebus,15,110,0,1,firearms,0,62,0,4,null
-RECIPE: /material/iron/,hand cannon,/obj/item/weapon/gun/projectile/ancient/handcannon,14,100,0,1,firearms,0,56,0,4,null
-RECIPE: /material/iron/,fire lance,/obj/item/weapon/gun/projectile/ancient/firelance,6,50,0,1,firearms,0,49,0,4,null
-
 //*******************************************************
 //*********************| SANDSTONE |*********************
 //*******************************************************
@@ -2152,14 +1278,9 @@ RECIPE: /material/sandstone/,smooth sandstone road,/obj/covers/roads/sandstone,1
 //*********************| SANDSTONE CONSTRUCTIONS |**************************
 
 RECIPE: /material/sandstone/,sandstone wall,/obj/covers/sandstone_smooth_wall,8,125,1,1,construction,0,0,0,8,null
-RECIPE: /material/sandstone/,egyptian wall,/obj/covers/stone_wall/egyptian,6,125,1,1,construction,0,0,0,1,null
 
 RECIPE: /material/sandstone/,sandstone brick wall,/obj/covers/sandstone_wall,8,25,1,1,construction,0,0,0,8,null
 
-RECIPE: /material/sandstone/,castle gate,/obj/structure/gate/sandstone,15,210,1,1,construction,30,30,0,8,null
-RECIPE: /material/sandstone/,castle gate control,/obj/structure/gatecontrol/sandstone,5,100,1,1,construction,30,30,0,8,null
-
-RECIPE: /material/sandstone/,egyptian archway,/obj/covers/stone_wall/egyptian/archway,6,125,1,1,construction,0,0,0,1,null
 RECIPE: /material/sandstone/,sandstone statue,/obj/structure/religious/statue,15,250,1,1,religious & decoration,10,0,0,8,sandstone
 
 RECIPE: /material/sandstone/,sandstone floor,/obj/covers/sandstone,1,25,1,1,floors,0,0,0,8,null
@@ -2172,10 +1293,6 @@ RECIPE: /material/sandstone/,red sandstone decorative tile,/obj/covers/sandstone
 RECIPE: /material/sandstone/,sandstone stairs,/obj/covers/sandstone/stairs,3,45,1,1,construction,0,0,0,8,null
 
 RECIPE: /material/sandstone/,pillar,/obj/structure/mine_support/stone/sandstone,2,130,1,1,construction,0,0,0,8,sandstone
-RECIPE: /material/sandstone/,egyptian column,/obj/structure/mine_support/stone/egyptian,2.5,130,1,1,construction,22,0,0,8,null
-RECIPE: /material/sandstone/,ionic column,/obj/structure/mine_support/stone/ionic/sandstone,2.5,130,1,1,construction,22,0,0,8,null
-RECIPE: /material/sandstone/,solomonic column,/obj/structure/mine_support/stone/solomonic/sandstone,2.5,130,1,1,construction,22,0,0,8,null
-RECIPE: /material/sandstone/,thick solomonic column,/obj/structure/mine_support/stone/solomonic/thick/sandstone,2.5,130,1,1,construction,22,0,0,8,null
 RECIPE: /material/sandstone/,aztec column,/obj/structure/mine_support/stone/aztec/sandstone,2.5,130,1,1,construction,32,0,0,8,null
 
 RECIPE: /material/sandstone/,sandstone window,/obj/structure/window_frame/sandstone,5,140,1,1,construction,18,0,0,8,null
@@ -2187,7 +1304,6 @@ RECIPE: /material/sandstone/,sandstone roof builder,/obj/item/weapon/roofbuilder
 
 RECIPE: /material/sandstone/,sandstone totem,/obj/structure/religious/totem/sandstone,8,150,1,1,religious & decoration,0,0,0,8,null
 RECIPE: /material/sandstone/,sandstone altar,/obj/structure/altar/sandstone,15,200,1,1,religious & decoration,0,0,0,8,null
-RECIPE: /material/sandstone/,monumental sandstone obelisk,/obj/structure/religious/monument/obelisk,45,300,1,1,religious & decoration,22,0,0,2,null
 RECIPE: /material/sandstone/,gravestone,/obj/structure/religious/gravestone,3,60,1,1,religious & decoration,26,0,0,8,sandstone
 
 //*********************| SANDSTONE STRUCTURES, PRODUCTION & ECONOMY |**************************
@@ -2201,8 +1317,6 @@ RECIPE: /material/sandstone/,sandstone kiln,/obj/structure/furnace/kiln/sandston
 //*********************| SANDSTONE FORTIFICATIONS |**************************
 
 RECIPE: /material/sandstone/,sandstone barrier wall,/obj/structure/window/barrier/sandstone,3,70,1,1,fortifications,0,0,0,8,null
-RECIPE: /material/sandstone/,horizontal sandstone crenelated wall,/obj/structure/barricade/sandstone_h/crenelated,5,80,1,1,fortifications,0,0,0,8,null
-RECIPE: /material/sandstone/,verticle sandstone crenelated wall,/obj/structure/barricade/sandstone_v/crenelated,5,80,1,1,fortifications,0,0,0,8,null
 
 //*********************| SANDSTONE TOOLS & RESEARCH |**************************
 
@@ -2219,7 +1333,7 @@ RECIPE: /material/sandstone/,sling projectile (x5),/obj/item/ammo_casing/stone,1
 RECIPE: /material/sandstone/,projectile (x2),/obj/item/stack/ammopart/stoneball,1,25,0,1,projectiles,24,49,0,8,sandstone
 RECIPE: /material/sandstone/,sandstone arrowhead (x4),/obj/item/stack/arrowhead/sandstone,1,10,0,1,projectiles,0,14,0,8,sandstone
 
-RECIPE: /material/sandstone/,catapult projectile,/obj/item/catapult_ball,5,75,0,1,projectiles,24,33,0,4,sandstone
+RECIPE: /material/sandstone/,catapult projectile,/obj/item/catapult_ball,5,75,0,1,projectiles,24,33,0,8,sandstone
 
 //******************************************************
 //*********************| OBISIDAN |*********************
@@ -2230,9 +1344,6 @@ RECIPE: /material/obsidian/,obsidian brazier,/obj/structure/brazier/obsidian,3,1
 //*********************| OBSIDIAN CONSTRUCTIONS |**************************
 
 RECIPE: /material/obsidian/,pillar,/obj/structure/mine_support/stone/obsidian,2,130,1,1,construction,0,0,0,8,obsidian
-RECIPE: /material/obsidian/,ionic column,/obj/structure/mine_support/stone/ionic/obsidian,2.5,130,1,1,construction,22,0,0,8,obsidian
-RECIPE: /material/obsidian/,solomonic column,/obj/structure/mine_support/stone/solomonic/obsidian,2.5,130,1,1,construction,22,0,0,8,obsidian
-RECIPE: /material/obsidian/,thick solomonic column,/obj/structure/mine_support/stone/solomonic/thick/obsidian,2.5,130,1,1,construction,22,0,0,8,obsidian
 RECIPE: /material/obsidian/,aztec column,/obj/structure/mine_support/stone/aztec/obsidian,2.5,130,1,1,construction,32,0,0,8,obsidian
 
 //*********************| OBSIDIAN DECORATIONS & RELIGION |**************************


### PR DESCRIPTION
## Additions

Many thanks for the significant code help from Taslin in helping to make this a reality.

* Craftable wood armor & Hair Bone armor, made out of relevant stack material combined with ropes, also ported to nomads mode.
* Unique cultural carib craftables only availible in ``hunt`` of the loincloths, gold accessories, chief hat, and giant leopardskins

## Tweaks
* Carib people cannot produce items of european or asian influence, including technological items such a metal traps, certain clothing and meta-powerful oriental weaponry like kunais.
* Where relevant, certain choices have been downgraded, carib's can only craft selections of primitive items like pelt coats over regular coats, and primitive bows.
* Carib people cannot produce any material related to firearms, they must trade, steal or coerce other factions to arm their people.
* Carib people do not have wood spears.
* Some fixes to context on stoneage apparel.dm to make them more palatable.

* Carib people can now handle and use a variety of firearms without being scared or unknowledgeable about how they work.

## Other details 
Carib's still follow the general rules of metallurgy, but any additional content or problems experienced you want to suggest or factions to suggest custom factional content for should be contacted at the discord channels ``#devchat`` & ``#dev_resources``

The beauty is that pirates remain the same, though watch this space that may be subject to change.