### PR TITLE
Adds var/unacidable to objs - Fix Issue #879

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -24,6 +24,8 @@
 	var/obj/structure/cable/powersource = null
 	var/powered = FALSE
 	var/quality = 0
+	var/unacidable = FALSE	//For acids interactions, called at Chemistry-Reagents-Compounds.dm
+
 /obj/examine(mob/user,distance=-1)
 	..(user,distance)
 	return distance == -1 || (get_dist(src, user) <= distance)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Compounds.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Compounds.dm
@@ -224,8 +224,8 @@
 		return
 
 /datum/reagent/acid/touch_obj(var/obj/O)
-//	if (O.unacidable)
-	//	return
+	if (O.unacidable)
+		return
 	if (istype(O, /obj/item))
 		var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
 		I.desc = "Looks like this was \an [O] some time ago."

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -238,6 +238,9 @@
 	name = "beaker"
 	desc = "A beaker."
 	icon = 'icons/obj/chemical.dmi'
+
+	unacidable = TRUE
+
 	icon_state = "beaker"
 	item_state = "beaker"
 


### PR DESCRIPTION
 - Adds var/unacidable to objs as FALSE
 - Uncomment the routine expected at /datum/reagent/acid/touch_obj() to not melt unacidable objs
 - Sets /obj/item/weapon/reagent_containers/glass/beaker and it's children unacidable to TRUE

``Maintainer Edit to initiate auto-close on merge``
fixes #879