### PR TITLE
Stack Fixes

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -139,7 +139,7 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
-		var/obj/item/stack/F = split(1)
+		var/obj/item/stack/F = split(min(1, src.amount))
 		if (F)
 			F.update_icon()
 			src.update_icon()
@@ -2110,7 +2110,7 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 
 	if (href_list["make"])
 
-		if (amount < 1)
+		if (amount <= 0)
 			qdel(src)
 			return
 


### PR DESCRIPTION
Some issues seemed to be around with how you can have a stack with an amount between zero and one after you have used the stack for some recipes to bring it within these boundaries.

One noticeable issue was that a stack with an amount in this interval would always transfer one material's worth of itself to a new stack when you move it from an inactive hand to an active one, which is a problem when the amount for the stack happens to be less than one.

Another problem stemming from the fact that a stack can have its amount in the interval (0,1) was that it would get immediately deleted as you tried to use it to craft something; for example, if you tried to use a clay sheet with an amount of 0.5 to craft some unfired roof tiles, you would notice that the stack gets deleted while you receive no unfired roof tiles, which in itself is annoying as you would expect it to be possible to use this remaining 0.5 clay.

So the following were done to fix these issues:

- The minimum of one and the amount of a stack in an inactive hand is used instead of using one in all cases in the attack_hand() proc for the splitting.

- We now check that the amount is less than or equal to zero instead of seeing if it's less than one in the Topic() proc before we attempt to delete the stack.