### PR TITLE
The buckshot files Case 1 the case of buckshot pellets 

### DIFF
--- a/code/modules/1713/_mags1904.dm
+++ b/code/modules/1713/_mags1904.dm
@@ -573,7 +573,7 @@ RUSSO-JAPANESE WAR WEAPONS MAGS N AMMO
 	caliber = "12guage"
 	w_class = 3
 
-	ammo_type = /obj/item/ammo_casing/shotgun
+	ammo_type = /obj/item/ammo_casing/buckshot
 	max_ammo = 12
 	multiple_sprites = TRUE
 	is_box = TRUE

--- a/code/modules/projectiles/__projectiles.dm
+++ b/code/modules/projectiles/__projectiles.dm
@@ -522,7 +522,7 @@ obj/item/projectile/bullet/rifle/a556x45
 	penetrating = 1
 	armor_penetration = 1
 
-/obj/item/projectile/bullet/shotgun/buckshot
+/obj/item/projectile/bullet/pellet/buckshot
 	name = "buckshot"
 	damage = DAMAGE_VERY_HIGH + 35
 	armor_penetration = 33

--- a/code/modules/projectiles/_ammo_casing.dm
+++ b/code/modules/projectiles/_ammo_casing.dm
@@ -943,13 +943,13 @@
 	caliber = "a57x28"
 	value = 2
 
-/obj/item/ammo_casing/shotgun
+/obj/item/ammo_casing/buckshot
 	name = "buckshot shell"
 	desc = "A 12 gauge buckshot."
 	icon_state = "shell-bullet"
 	spent_icon = "shell-casing"
 	weight = 0.12
-	projectile_type = /obj/item/projectile/bullet/shotgun/buckshot
+	projectile_type = /obj/item/projectile/bullet/pellet/buckshot
 	caliber = "12gauge"
 	value = 2
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -151,12 +151,13 @@
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
-/obj/item/projectile/bullet/pellet/shotgun
+/obj/item/projectile/bullet/pellet/buckshot
 	name = "shrapnel"
-	damage = 13
+	damage = 10
 	pellets = 6
-	range_step = TRUE
 	spread_step = 10
+	base_spread = 19
+	range_step = 3
 
 /* "Rifle" rounds */
 


### PR DESCRIPTION
So ive spent the entire day working on this buff/nerf no its more of a rebalance yes a rebalance to buckshot buckshot now has 6 pellets which do 13 dmg per pellet attached to 1 projectile buckshot losses 1 pellet every 3 tiles the projectile travels buckshot at range  will spread its pellets across the target hitting more then one part of the body legs arms hands etc at shorter range buckshot becomes even more deadly being able to land every pellet into the targeted area landing all 6 could lead to a total of 78 dmg at close range to one body part  