### PR TITLE
Fixes marble storage in ore satchels

### DIFF
--- a/code/modules/1713/production.dm
+++ b/code/modules/1713/production.dm
@@ -400,7 +400,7 @@
 		/obj/item/stack/material/stone,
 		/obj/item/stack/material/sandstone,
 		/obj/item/stack/material/obsidian,
-		/obj/item/stack/material/marble,
+		/obj/item/stack/material/marble
 		)
 	flammable = TRUE
 


### PR DESCRIPTION
A comma was blocking the list from completion, and also tested in game to be double-sure.