### PR TITLE
Adds Faction Door

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -287,6 +287,7 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 	var/mob/living/human/H = user
 	var/obj/structure/religious/totem/newtotem = null
 	var/obj/structure/simple_door/key_door/custom/build_override_door = null
+	var/obj/structure/simple_door/key_door/faction_door/faction_override_door = null
 	var/obj/item/weapon/key/civ/build_override_key = null
 	var/obj/item/stack/money/coppercoin/build_override_coins_copper = null
 	var/obj/item/stack/money/silvercoin/build_override_coins_silver = null
@@ -412,6 +413,22 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 		indesc = input(user, "Add a South sign? Leave empty to not add one.", "Signpost", "") as text|null
 		if (indesc != null && indesc != "")
 			customdesc += "<br><b>South:</b> [indesc]"
+
+	else if (findtext(recipe.title, "faction") && findtext(recipe.title, "door"))
+		if (H.getStatCoeff("crafting") < 1)
+			H << "<span class = 'danger'>This is too complex for your skill level.</span>"
+			return
+
+		if (!ishuman(user))
+			return
+		if(H.civilization == "none")
+			H << "You must be part of a faction to craft this door"
+			return
+		else
+			faction_override_door = new /obj/structure/simple_door/key_door/faction_door
+			faction_override_door.faction = H.civilization
+			faction_override_door.name = "[H.civilization]'s Door"
+
 	else if (findtext(recipe.title, "locked") && findtext(recipe.title, "door") && !findtext(recipe.title, "unlocked"))
 		if (H.getStatCoeff("crafting") < 1)
 			H << "<span class = 'danger'>This is too complex for your skill level.</span>"
@@ -1928,6 +1945,12 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 			build_override_door.loc = get_turf(O)
 			build_override_door.set_dir(user.dir)
 			build_override_door.add_fingerprint(user)
+			qdel(O)
+			return
+		if (faction_override_door)
+			faction_override_door.loc = get_turf(O)
+			faction_override_door.set_dir(user.dir)
+			faction_override_door.add_fingerprint(user)
 			qdel(O)
 			return
 		if (customname != "")

--- a/code/game/objects/structures/key_doors/key_door.dm
+++ b/code/game/objects/structures/key_doors/key_door.dm
@@ -21,6 +21,42 @@ var/list/nonbreaking_types = list(
 	material = "iron"
 	icon = 'icons/obj/doors/material_doors_leonister.dmi'
 
+/obj/structure/simple_door/key_door/faction_door
+	var/faction = null
+	locked = 1
+
+/obj/structure/simple_door/key_door/faction_door/attack_hand(mob/user as mob)
+	if(istype(user, /mob/living/human))
+		var/mob/living/human/H = user
+
+		if(H.civilization == faction)
+			if(!state)
+				Open()
+			else
+				Close()
+		else
+			user.visible_message("<span class = 'notice'>[H] knocks at the door.</span>")
+			playsound(get_turf(src), "doorknock", 75, TRUE)
+
+/obj/structure/simple_door/key_door/faction_door/Bumped(atom/user)
+	if(istype(user, /mob/living/human))
+		var/mob/living/human/H = user
+
+		if(H.civilization == faction)
+			if(!state)
+				Open()
+		else
+			user.visible_message("<span class = 'notice'>[H] knocks at the door.</span>")
+			playsound(get_turf(src), "doorknock", 75, TRUE)
+
+/obj/structure/simple_door/key_door/faction_door/Crossed(atom/user)
+	if(istype(user, /mob/living/human))
+		var/mob/living/human/H = user
+		if(H.civilization == faction)
+			if(state)
+				spawn(10)
+					Close()
+
 /obj/structure/simple_door/key_door/New(_loc, _material = null)
 
 	var/map_door_name = name

--- a/config/crafting/material_recipes_global.txt
+++ b/config/crafting/material_recipes_global.txt
@@ -2355,6 +2355,7 @@ RECIPE: /material/iron/,bayonet,/obj/item/weapon/attachment/bayonet,2,30,0,1,wea
 
 RECIPE: /material/iron/,unlocked iron door,/obj/structure/simple_door/key_door/anyone,10,100,1,1,construction,28,0,0,8,null
 RECIPE: /material/iron/,locked iron door,/obj/structure/simple_door/key_door/custom,15,180,1,1,construction,28,0,0,8,null
+RECIPE: /material/iron/,faction door,/obj/structure/simple_door/key_door/faction_door,15,180,1,1,construction,28,0,0,8,null
 
 RECIPE: /material/iron/,unlocked large iron double doors,/obj/structure/simple_door/key_door/anyone/doubledoor/iron,10,100,1,1,construction,28,0,0,8,null
 


### PR DESCRIPTION
Description: Iron Door that scans the user's faction. It auto-closes after a faction member crosses it.
Regular Iron Door health.

Requirements: 28 Industral Technology and crafting >= 1.

Why: Deliver a better experience to faction players. Ive had some bad experiences with people tempted to steal easy loot, leading to deaths.
The Iron Door is fairly easy to destroy. If someone wants to steal, they'll have to break it down.
Its all about making it easier for Faction members to use locks and control people who walks by.