### PR TITLE
Modular boats bugfix pack(4 bugfix + People can click things outside the modular boat now)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -222,6 +222,8 @@
 
 	for(var/obj/structure/vehicleparts/frame/F in src.loc)
 		var/found = FALSE
+		if(istype(F, /obj/structure/vehicleparts/frame/ship))
+			continue
 		for(var/obj/structure/vehicleparts/frame/FR in get_turf(A))
 			if (FR.axis != F.axis && FR != F)
 				if (!F.CanPass(src, get_turf(A)) || !F.CheckExit(src, get_turf(A)))

--- a/code/modules/1713/machinery/modular_vehicles/frame.dm
+++ b/code/modules/1713/machinery/modular_vehicles/frame.dm
@@ -354,9 +354,25 @@
 				H << "This key does not match this lock!"
 				return
 		else
-			doorcode = K.code
-			H << "You assign this key to the lock."
-			return
+			if(istype(src, /obj/structure/vehicleparts/frame/ship )) //adds routines to lock the boat
+				if(src.w_right[1] == "boat_port2")
+					src.w_right[6] = TRUE
+				else if(src.w_left[1] == "boat_port2")
+					src.w_left[6] = TRUE
+				else if(src.w_back[1] == "boat_port2")
+					src.w_back[6] = TRUE
+				else if(src.w_front[1] == "boat_port2")
+					src.w_front[6] = TRUE
+				else
+					H << "This is not a door."
+					return
+				doorcode = K.code
+				H << "You assign this key to the lock."
+				return
+			else
+				doorcode = K.code		//Leave it as before if its not a boat
+				H << "You assign this key to the lock."
+				return
 	else
 		..()
 /obj/structure/vehicleparts/frame/proc/CheckPenLoc(var/obj/item/proj)

--- a/code/modules/1713/machinery/modular_vehicles/ships/axis.dm
+++ b/code/modules/1713/machinery/modular_vehicles/ships/axis.dm
@@ -321,11 +321,18 @@
 	var/timer = 15
 	if (!masts.len || !moving)
 		return
-	if (!istype(get_turf(get_step(src,dir)), /turf/floor/beach/water) && !istype(get_turf(get_step(src,dir)), /turf/floor/trench/flooded))
-		visible_message("<span class='notice'>\The [src] crashes into \the [get_turf(get_step(src,dir))]!</span>")
-		moving = FALSE
-		stopmovementloop()
-		return
+	if(reverse)
+		if (!istype(get_turf(get_step(src,OPPOSITE_DIR(dir))), /turf/floor/beach/water) && !istype(get_turf(get_step(src,OPPOSITE_DIR(dir))), /turf/floor/trench/flooded))
+			visible_message("<span class='notice'>\The [src] crashes into \the [get_turf(get_step(src,dir))]!</span>")
+			moving = FALSE
+			stopmovementloop()
+			return
+	else
+		if (!istype(get_turf(get_step(src,dir)), /turf/floor/beach/water) && !istype(get_turf(get_step(src,dir)), /turf/floor/trench/flooded))
+			visible_message("<span class='notice'>\The [src] crashes into \the [get_turf(get_step(src,dir))]!</span>")
+			moving = FALSE
+			stopmovementloop()
+			return
 	var/found = FALSE
 	for(var/obj/structure/vehicleparts/movement/sails/SL in masts)
 		found = TRUE

--- a/code/modules/1713/trench.dm
+++ b/code/modules/1713/trench.dm
@@ -242,6 +242,8 @@ var/list/global/floor_cache = list()
 	return ..()
 
 /turf/floor/trench/Exit(atom/movable/O, atom/newloc)
+	if(locate(/obj/structure/vehicleparts/frame/ship) in newloc.contents)
+		return ..()
 	if (isliving(O) && !ishuman(O))
 		return ..()
 	if(isliving(O))

--- a/code/modules/1713/trench.dm
+++ b/code/modules/1713/trench.dm
@@ -178,6 +178,8 @@ var/list/global/floor_cache = list()
 	var/trench_stage = 0
 	available_dirt = 2
 /turf/floor/trench/Enter(atom/movable/O, atom/oldloc)
+	if(locate(/obj/structure/vehicleparts/frame/ship) in contents)
+		return ..()
 	for (var/obj/OB in src)
 		if (OB.density == 1 && !(istype(OB, /obj/structure/window/barrier)))
 			return 0


### PR DESCRIPTION
Bugfix: People couldnt move while over the boat frame when inside flooded trenchs. This would get the whole boat stucked.

Bugfix: Modular boat wouldnt check if it was reversed before moving in reverse. It would check the crash and then reversed, making people getting stuck. Now, if you reverse and theres something behind you blocking, it doesnt matter. It will check if its reversed before checking the crash.

Bugfix: There was actually no routine to register keys and make that door lockable/unlockable(that sixth position on the w_side). Now its possible to register keys, then locking and unlocking doors.

Bugfix: People couldnt climb into modular ship from inside a flooded trench, which was a pain in the a**. Now its possible.

Little change: Now people can click into things outside the boat, both for trench digging, fishing and whale hunting in the near future.