### PR TITLE
Fat Ballancing 2.0

### DIFF
--- a/code/game/objects/structures/kitchen/oven.dm
+++ b/code/game/objects/structures/kitchen/oven.dm
@@ -142,7 +142,7 @@
 					if (I.reagents.get_reagent_amount("lard") > 0)
 						var/lard_amnt = I.reagents.get_reagent_amount("lard")
 						I.reagents.del_reagent("lard")
-						I.reagents.add_reagent("fat_oil", lard_amnt/5)
+						I.reagents.add_reagent("fat_oil", lard_amnt/2)
 			if (fuel <= 0 && consume_itself == TRUE)
 				visible_message("<span class = 'warning'>\The [src] burns out.</span>")
 				new/obj/item/stack/ore/charcoal(loc)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -5,7 +5,7 @@
 	var/plough_road = FALSE
 	var/cattle_gender = null			//Nice info to have about the cattle. Will make it easier to work with
 	var/calf = FALSE  //Each gender was taking this var
-	fat_extra = 3
+	fat_penalty = 1 //For ballance reasons
 /mob/living/simple_animal/cattle/cow
 	name = "cow"
 	cattle_gender = "female"
@@ -368,7 +368,7 @@
 	scavenger = 1 //if it will be attracted to trash, rotting meat, etc (mice, mosquitoes)
 	carnivore = 1 //if it will be attracted to meat and dead bodies. Wont attack living animals by default.
 	wandersounds = list('sound/animals/pig/pig_1.ogg','sound/animals/pig/pig_2.ogg')
-	fat_extra = 3
+	fat_extra = 2
 
 /mob/living/simple_animal/pig_gilt
 	name = "pig gilt"
@@ -399,7 +399,7 @@
 	scavenger = 1 //if it will be attracted to trash, rotting meat, etc (mice, mosquitoes)
 	carnivore = 1 //if it will be attracted to meat and dead bodies. Wont attack living animals by default.
 	wandersounds = list('sound/animals/pig/pig_1.ogg','sound/animals/pig/pig_2.ogg')
-	fat_extra = 3
+	fat_extra = 2
 
 /mob/living/simple_animal/pig_gilt/death()
 
@@ -545,7 +545,7 @@
 	predatory_carnivore = 1
 	behaviour = "defends"
 	wandersounds = list('sound/animals/pig/pig_1.ogg','sound/animals/pig/pig_2.ogg')
-	fat_extra = 3
+	fat_extra = 2
 
 /mob/living/simple_animal/boar_gilt
 	name = "boar gilt"
@@ -577,7 +577,7 @@
 	carnivore = 1 //if it will be attracted to meat and dead bodies. Wont attack living animals by default.
 	behaviour = "defends"
 	wandersounds = list('sound/animals/pig/pig_1.ogg','sound/animals/pig/pig_2.ogg')
-	fat_extra = 3
+	fat_extra = 2
 
 /mob/living/simple_animal/boar_gilt/death()
 
@@ -1053,7 +1053,7 @@
 	var/content_size = 0
 	var/list/packed_items = list()
 	herbivore = 1
-	fat_extra = 5
+	fat_extra = 3
 
 /mob/living/simple_animal/camel/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if (!stat && user.a_intent == I_HELP && icon_state != icon_dead && !istype(O, /obj/item/weapon/leash))

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -26,7 +26,7 @@
 	predatory_carnivore = 1
 	carnivore = 1
 	scavenger = 1
-	fat_extra = 4
+	fat_extra = 3
 
 	var/cub = FALSE
 	var/growing = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wolf.dm
@@ -25,7 +25,7 @@
 	mob_size = MOB_MEDIUM
 	predatory_carnivore = 1
 	carnivore = 1
-	fat_penalty = 2
+	fat_penalty = 1
 
 
 	var/btype = "grey"


### PR DESCRIPTION
It was way too hard to get. Had a long talk with Siro and other players about it.
Siro agreed, also the other players.

Change the cooking  for fat oil: Fat oil = Lard / 2. It was Lard / 5.

Nerf the fat_extra from pigs and cattle.
Pigs: 5 animal fat slabs.
Cattle:  3 animal fat slabs.
Pig: 5 animal fat slabs.
Camel: 7 animal fat slabs.
Buffalo: 6 animal fat slabs.
Bison: 6 animal fat slabs.
Mammoth: 27 animal fat  slabs.
Bear: 6 animal fat slabs.
Wolf: 1 animal fat  slab.
Alligator: 0.
Crab: 0.
Chicken: 0.