### PR TITLE
Granivores feeding improvement

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -971,7 +971,10 @@
 					new/obj/item/weapon/reagent_containers/food/snacks/poo/animal(src.loc)
 				simplehunger += 500
 				adjustBruteLoss(-4)
-				qdel(SD)
+				if(SD.amount >= 2)
+					SD.amount -= 1
+				else
+					qdel(SD)
 				return
 		for(var/obj/structure/farming/plant/PL in range(2,src))
 			if (prob(15))


### PR DESCRIPTION
Granivores would eat the whole seed, ignoring the seed.amount. After having a pig eating 100 seeds in only one bite, I've decided that this would be a good change.

This will open way to feed granivores over sleeping time and such.
Now they'll check the amount and if its >= 2, they'll eat only 1 seed out of the seed.amount.