### PR TITLE
Makes Dirt Yield Two Clay

### DIFF
--- a/code/modules/1713/barriers/sandbag.dm
+++ b/code/modules/1713/barriers/sandbag.dm
@@ -212,7 +212,7 @@
 		if (W.reagents.has_reagent("water", 10))
 			W.reagents.remove_reagent("water", 10)
 			user << "You mold the dirt and water into clay."
-			new/obj/item/stack/material/clay(user.loc)
+			new/obj/item/stack/material/clay(user.loc, 2)
 			qdel(src)
 			return
 


### PR DESCRIPTION
According to 3rd Trooper Hsu#7940 on the Civ13 Discord using ten units of water on one loose dirt is supposed to yield two clay, currently it yields one. This pull request makes it so that using ten units of water on a loose dirt yields two clay.

Why it's good for the game:
May help to make it easier to acquire large quantities of clay quickly which can help with building certain things and with building modern buildings and with modern building materials.

Why it's bad for the game:
May make clay less valuable, and remove some of the rightful difficulty in acquiring clay.