### PR TITLE
Makes Digging Based Partially Upon Strength, Makes Digging Grass Add to Strength (And Patches Empty Refineries)

### DIFF
--- a/code/game/turfs/floor_attackby.dm
+++ b/code/game/turfs/floor_attackby.dm
@@ -158,7 +158,7 @@
 					H.shoveling_snow = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel snow into a pile.</span>", "<span class = 'notice'>You start to shovel snow into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels snow into a pile.</span>", "<span class = 'notice'>You shovel snow into a pile.</span>")
 						H.shoveling_snow = FALSE
 						H.adaptStat("strength", 1)
@@ -180,7 +180,7 @@
 					H.shoveling_dirt = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel dirt into a pile.</span>", "<span class = 'notice'>You start to shovel dirt into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels dirt into a pile.</span>", "<span class = 'notice'>You shovel dirt into a pile.</span>")
 						H.shoveling_dirt = FALSE
 						H.adaptStat("strength", 1)
@@ -195,7 +195,7 @@
 					H.shoveling_sand = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel sand into a pile.</span>", "<span class = 'notice'>You start to shovel sand into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels sand into a pile.</span>", "<span class = 'notice'>You shovel sand into a pile.</span>")
 						H.shoveling_sand = FALSE
 						H.adaptStat("strength", 1)
@@ -210,7 +210,7 @@
 			if (radiation >= 1 && (istype(src, /turf/floor/dirt) || istype(src, /turf/floor/grass)))
 				visible_message("<span class = 'notice'>[user] starts to clean the irradiated soil.</span>", "<span class = 'notice'>You start to clean the irradiated soil.</span>")
 				playsound(src,'sound/effects/shovelling.ogg',100,1)
-				if (do_after(user, 150/SH.usespeed))
+				if (do_after(user, (150/(H.getStatCoeff("strength"))/SH.usespeed)))
 					visible_message("<span class = 'notice'>[user] finishes cleaning the irradiated soil.</span>", "<span class = 'notice'>You finish cleaning the irradiated soil.</span>")
 					H.adaptStat("strength", 1)
 					radiation *= 0.1

--- a/code/modules/1713/modern_items.dm
+++ b/code/modules/1713/modern_items.dm
@@ -470,12 +470,6 @@
 			usr << "This refinery will now produce <b>Diesel</b>."
 			return
 /obj/structure/refinery/attack_hand(var/mob/living/human/H)
-	if (isemptylist(barrel))
-		H << "<span class = 'notice'>There is no barrel to collect the refined products.</span>"
-		return
-	if (volume <= 0 && volume_di <= 0 && volume_et <= 0)
-		H << "<span class = 'notice'>The refinery is empty! Put some percursors in first.</span>"
-		return
 	if (active)
 		active = FALSE
 		powered = FALSE
@@ -484,8 +478,14 @@
 		powersource.lastupdate2 = world.time
 		H << "You power off the refinery."
 		return
+	if (isemptylist(barrel))
+		H << "<span class = 'notice'>There is no barrel to collect the refined products.</span>"
+		return
+	if (volume <= 0 && volume_di <= 0 && volume_et <= 0)
+		H << "<span class = 'notice'>The refinery is empty! Put some precursors in first.</span>"
+		return
 
-	else if (!active && powersource && !powersource.powered)
+	if (!active && powersource && !powersource.powered)
 		H << "<span class = 'notice'>There is not enough power to start the refinery.</span>"
 		return
 	else if (!active && powersource.powered && ((powersource.powerflow-powersource.currentflow) >= powerneeded))
@@ -806,9 +806,6 @@
 
 
 /obj/structure/bakelizer/attack_hand(var/mob/living/human/H)
-	if (volume < 1)
-		H << "<span class = 'notice'>The bakelizer is empty! Put some crude petroleum in first.</span>"
-		return
 	if (active)
 		active = FALSE
 		powered = FALSE
@@ -818,8 +815,11 @@
 		H << "You power off the [src]."
 		update_icon()
 		return
+	if (volume < 1)
+		H << "<span class = 'notice'>The bakelizer is empty! Put some crude petroleum in first.</span>"
+		return
 
-	else if (!active && !powersource.powered)
+	if (!active && !powersource.powered)
 		H << "<span class = 'notice'>There is not enough power to start the [src].</span>"
 		update_icon()
 		return

--- a/code/modules/1713/trench.dm
+++ b/code/modules/1713/trench.dm
@@ -385,12 +385,14 @@ var/list/global/floor_cache = list()
 	..()
 
 /turf/floor/grass/attackby(obj/item/C as obj, mob/user as mob)
+	var/mob/living/human/H = user
 	if (istype(C, /obj/item/weapon/material/shovel/trench))
 		var/obj/item/weapon/material/shovel/trench/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove grass layer.</span>")
-		if (!do_after(user, (10 - S.dig_speed)*10, src))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/(12/S.dig_speed)))) //Think a DEFINE for the number being divided over S.dig_speed could be helpful, keeping it this for now
 			return
 		visible_message("<span class = 'notice'>[user] removes grass layer.</span>")
+		H.adaptStat("strength", 1)
 		var/area/A = get_area(src)
 		if (A.climate == "jungle" || A.climate == "savanna")
 			ChangeTurf(/turf/floor/dirt/jungledirt)
@@ -398,10 +400,12 @@ var/list/global/floor_cache = list()
 			ChangeTurf(/turf/floor/dirt)
 		return
 	else if (istype(C, /obj/item/weapon/material/shovel))
+		var/obj/item/weapon/material/shovel/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove grass layer.</span>")
-		if (!do_after(user, 100))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/S.usespeed)))
 			return
 		visible_message("<span class = 'notice'>[user] removes grass layer.</span>")
+		H.adaptStat("strength", 1)
 		var/area/A = get_area(src)
 		if (A.climate == "jungle" || A.climate == "savanna")
 			ChangeTurf(/turf/floor/dirt/jungledirt)
@@ -411,12 +415,14 @@ var/list/global/floor_cache = list()
 	..()
 
 /turf/floor/winter/attackby(obj/item/C as obj, mob/user as mob)
+	var/mob/living/human/H = user
 	if (istype(C, /obj/item/weapon/material/shovel/trench))
 		var/obj/item/weapon/material/shovel/trench/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove snow layer.</span>")
-		if (!do_after(user, (10 - S.dig_speed)*10, src))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/(12/S.dig_speed))))
 			return
 		visible_message("<span class = 'notice'>[user] removes snow layer.</span>")
+		H.adaptStat("strength", 1)
 		ChangeTurf(/turf/floor/dirt)
 		return
 	..()


### PR DESCRIPTION
Currently digging dirt into piles is based on a random number divided by the shovel use speed despite increasing your strength, and digging grass does not contribute to strength and is not based on it. This Pull Request makes it so that shoveling dirt into piles is partially based on strength, and that digging grass both contributes to strength and is partially based on strength.

Why it's good for the game:
Helps to ease on the arguably excessive grind for dirt and digging out grass with higher strength levels, adds additional reason to dig grass, possibly sets up code for tweaking grind for later.

Why it's bad for the game:
Does not necessarily make it easier for lower strength players at the start to dig easier (possibly makes it slightly longer for them to dig), does not necessarily tweak the grind, not necessarily a good thing to encourage digging grass.

Also because I accidentally merged some files this Pull Request now also makes it so that you can take a barrel out of an empty refinery that was on when it emptied without having to fill the refinery with precursors again.