### PR TITLE
Patches Issue with Naming Seed/Ore Collectors Names with 0 Characters

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -39,6 +39,8 @@
 	var/yn = input(usr, "Give this [src] a name?") in list("Yes", "No")
 	if (yn == "Yes")
 		var/_name = input(usr, "What name?") as text
+		if (length(_name) <= 0)
+			return
 		name = sanitize(_name, 20)
 	return
 

--- a/code/game/turfs/floor_attackby.dm
+++ b/code/game/turfs/floor_attackby.dm
@@ -158,7 +158,7 @@
 					H.shoveling_snow = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel snow into a pile.</span>", "<span class = 'notice'>You start to shovel snow into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels snow into a pile.</span>", "<span class = 'notice'>You shovel snow into a pile.</span>")
 						H.shoveling_snow = FALSE
 						H.adaptStat("strength", 1)
@@ -180,7 +180,7 @@
 					H.shoveling_dirt = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel dirt into a pile.</span>", "<span class = 'notice'>You start to shovel dirt into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels dirt into a pile.</span>", "<span class = 'notice'>You shovel dirt into a pile.</span>")
 						H.shoveling_dirt = FALSE
 						H.adaptStat("strength", 1)
@@ -195,7 +195,7 @@
 					H.shoveling_sand = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel sand into a pile.</span>", "<span class = 'notice'>You start to shovel sand into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels sand into a pile.</span>", "<span class = 'notice'>You shovel sand into a pile.</span>")
 						H.shoveling_sand = FALSE
 						H.adaptStat("strength", 1)
@@ -210,7 +210,7 @@
 			if (radiation >= 1 && (istype(src, /turf/floor/dirt) || istype(src, /turf/floor/grass)))
 				visible_message("<span class = 'notice'>[user] starts to clean the irradiated soil.</span>", "<span class = 'notice'>You start to clean the irradiated soil.</span>")
 				playsound(src,'sound/effects/shovelling.ogg',100,1)
-				if (do_after(user, 150/SH.usespeed))
+				if (do_after(user, (150/(H.getStatCoeff("strength"))/SH.usespeed)))
 					visible_message("<span class = 'notice'>[user] finishes cleaning the irradiated soil.</span>", "<span class = 'notice'>You finish cleaning the irradiated soil.</span>")
 					H.adaptStat("strength", 1)
 					radiation *= 0.1

--- a/code/modules/1713/trench.dm
+++ b/code/modules/1713/trench.dm
@@ -385,12 +385,14 @@ var/list/global/floor_cache = list()
 	..()
 
 /turf/floor/grass/attackby(obj/item/C as obj, mob/user as mob)
+	var/mob/living/human/H = user
 	if (istype(C, /obj/item/weapon/material/shovel/trench))
 		var/obj/item/weapon/material/shovel/trench/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove grass layer.</span>")
-		if (!do_after(user, (10 - S.dig_speed)*10, src))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/(12/S.dig_speed)))) //Think a DEFINE for the number being divided over S.dig_speed could be helpful, keeping it this for now
 			return
 		visible_message("<span class = 'notice'>[user] removes grass layer.</span>")
+		H.adaptStat("strength", 1)
 		var/area/A = get_area(src)
 		if (A.climate == "jungle" || A.climate == "savanna")
 			ChangeTurf(/turf/floor/dirt/jungledirt)
@@ -398,10 +400,12 @@ var/list/global/floor_cache = list()
 			ChangeTurf(/turf/floor/dirt)
 		return
 	else if (istype(C, /obj/item/weapon/material/shovel))
+		var/obj/item/weapon/material/shovel/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove grass layer.</span>")
-		if (!do_after(user, 100))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/S.usespeed)))
 			return
 		visible_message("<span class = 'notice'>[user] removes grass layer.</span>")
+		H.adaptStat("strength", 1)
 		var/area/A = get_area(src)
 		if (A.climate == "jungle" || A.climate == "savanna")
 			ChangeTurf(/turf/floor/dirt/jungledirt)
@@ -411,12 +415,14 @@ var/list/global/floor_cache = list()
 	..()
 
 /turf/floor/winter/attackby(obj/item/C as obj, mob/user as mob)
+	var/mob/living/human/H = user
 	if (istype(C, /obj/item/weapon/material/shovel/trench))
 		var/obj/item/weapon/material/shovel/trench/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove snow layer.</span>")
-		if (!do_after(user, (10 - S.dig_speed)*10, src))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/(12/S.dig_speed))))
 			return
 		visible_message("<span class = 'notice'>[user] removes snow layer.</span>")
+		H.adaptStat("strength", 1)
 		ChangeTurf(/turf/floor/dirt)
 		return
 	..()


### PR DESCRIPTION
Currently it's possible to name seed collector and assumedly ore collectors (but I ain't tested for them) names that have zero characters; this makes it impossible to right-click on them since they have no names, even though you can still pick them up and assumedly open them. This PR makes it so that inputting a seed/ore collector with a name with no characters drops you out of the menu instead and keeps the original name.