### PR TITLE
Makes Cars Incapable of Destroying Placed Wires

### DIFF
--- a/code/game/turfs/floor_attackby.dm
+++ b/code/game/turfs/floor_attackby.dm
@@ -158,7 +158,7 @@
 					H.shoveling_snow = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel snow into a pile.</span>", "<span class = 'notice'>You start to shovel snow into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels snow into a pile.</span>", "<span class = 'notice'>You shovel snow into a pile.</span>")
 						H.shoveling_snow = FALSE
 						H.adaptStat("strength", 1)
@@ -180,7 +180,7 @@
 					H.shoveling_dirt = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel dirt into a pile.</span>", "<span class = 'notice'>You start to shovel dirt into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels dirt into a pile.</span>", "<span class = 'notice'>You shovel dirt into a pile.</span>")
 						H.shoveling_dirt = FALSE
 						H.adaptStat("strength", 1)
@@ -195,7 +195,7 @@
 					H.shoveling_sand = TRUE
 					visible_message("<span class = 'notice'>[user] starts to shovel sand into a pile.</span>", "<span class = 'notice'>You start to shovel sand into a pile.</span>")
 					playsound(src,'sound/effects/shovelling.ogg',100,1)
-					if (do_after(user, rand(45,60)/SH.usespeed))
+					if (do_after(user, (80/(H.getStatCoeff("strength"))/SH.usespeed)))
 						visible_message("<span class = 'notice'>[user] shovels sand into a pile.</span>", "<span class = 'notice'>You shovel sand into a pile.</span>")
 						H.shoveling_sand = FALSE
 						H.adaptStat("strength", 1)
@@ -210,7 +210,7 @@
 			if (radiation >= 1 && (istype(src, /turf/floor/dirt) || istype(src, /turf/floor/grass)))
 				visible_message("<span class = 'notice'>[user] starts to clean the irradiated soil.</span>", "<span class = 'notice'>You start to clean the irradiated soil.</span>")
 				playsound(src,'sound/effects/shovelling.ogg',100,1)
-				if (do_after(user, 150/SH.usespeed))
+				if (do_after(user, (150/(H.getStatCoeff("strength"))/SH.usespeed)))
 					visible_message("<span class = 'notice'>[user] finishes cleaning the irradiated soil.</span>", "<span class = 'notice'>You finish cleaning the irradiated soil.</span>")
 					H.adaptStat("strength", 1)
 					radiation *= 0.1

--- a/code/modules/1713/machinery/modular_vehicles/axis.dm
+++ b/code/modules/1713/machinery/modular_vehicles/axis.dm
@@ -184,11 +184,10 @@ var/global/list/tank_names_usa = list("Charlie", "Alpha", "Foxtrot", "Tango", "E
 							visible_message("<span class='warning'>\the [src] crushes \the [O]!</span>","<span class='warning'>You crush \the [O]!</span>")
 							qdel(O)
 						else
-						
 							visible_message("<span class='warning'>\the [src] hits \the [O]!</span>","<span class='warning'>You hit \the [O]!</span>")
 							return FALSE
 					else if (O.density == FALSE && !(O in transporting))
-						if (!istype(O, /obj/structure/sign/traffic/zebracrossing) && !istype(O, /obj/structure/sign/traffic/central) && !istype(O, /obj/structure/sign/traffic/side) && !istype(O, /obj/structure/sign/traffic/side) && !istype(O, /obj/structure/rails))
+						if (!istype(O, /obj/structure/sign/traffic/zebracrossing) && !istype(O, /obj/structure/sign/traffic/central) && !istype(O, /obj/structure/sign/traffic/side) && !istype(O, /obj/structure/sign/traffic/side) && !istype(O, /obj/structure/rails) && !istype(O, /obj/structure/cable))
 	//						visible_message("<span class='warning'>\the [src] crushes \the [O]!</span>","<span class='warning'>You crush \the [O]!</span>")
 							qdel(O)
 
@@ -299,7 +298,7 @@ var/global/list/tank_names_usa = list("Charlie", "Alpha", "Foxtrot", "Tango", "E
 					qdel(BAT)
 					visible_message("<span class='warning'>\the [src] crushes \the [BAT]!</span>","<span class='warning'>You crush \the [BAT]!</span>")
 			if ((istype(M, /mob/living) || istype(M, /obj/structure) || istype(M, /obj/item)) && !(M in transporting))
-				if (!istype(M, /obj/structure/sign/traffic/zebracrossing) && !istype(M, /obj/structure/sign/traffic/side) && !istype(M, /obj/structure/sign/traffic/central) && !istype(M, /obj/structure/rails))
+				if (!istype(M, /obj/structure/sign/traffic/zebracrossing) && !istype(M, /obj/structure/sign/traffic/side) && !istype(M, /obj/structure/sign/traffic/central) && !istype(M, /obj/structure/rails) && !istype(M, /obj/structure/cable))
 					transporting += M
 	return transporting.len
 
@@ -544,7 +543,7 @@ var/global/list/tank_names_usa = list("Charlie", "Alpha", "Foxtrot", "Tango", "E
 					else
 						todestroy += O
 			for(var/obj/OM in todestroy)
-				if (!istype(OM, /obj/structure/sign/traffic/zebracrossing) && !istype(OM, /obj/structure/sign/traffic/side) && !istype(OM, /obj/structure/sign/traffic/central) && !istype(OM, /obj/structure/rails)&& !istype(OM, /obj/covers))
+				if (!istype(OM, /obj/structure/sign/traffic/zebracrossing) && !istype(OM, /obj/structure/sign/traffic/side) && !istype(OM, /obj/structure/sign/traffic/central) && !istype(OM, /obj/structure/rails) && !istype(OM, /obj/covers) && !istype(OM, /obj/structure/cable))
 					qdel(OM)
 	dir = newdir
 	for (var/obj/structure/vehicleparts/movement/OBB in wheels)
@@ -582,7 +581,7 @@ var/global/list/tank_names_usa = list("Charlie", "Alpha", "Foxtrot", "Tango", "E
 						if (!ST.density)
 							ST.Destroy()
 				for (var/atom/movable/M in matrix_current_locs[loc2textv][2])
-					if (!istype(M, /obj/structure/sign/traffic/zebracrossing) && !istype(M, /obj/structure/sign/traffic/side) && !istype(M, /obj/structure/sign/traffic/central) && !istype(M, /obj/structure/rails) && !istype(M,/obj/covers))
+					if (!istype(M, /obj/structure/sign/traffic/zebracrossing) && !istype(M, /obj/structure/sign/traffic/side) && !istype(M, /obj/structure/sign/traffic/central) && !istype(M, /obj/structure/rails) && !istype(M,/obj/covers) && !istype(M,/obj/structure/cable))
 						M.forceMove(matrix_current_locs[dlocfind][1])
 						if (istype(M, /obj))
 							var/obj/O = M

--- a/code/modules/1713/trench.dm
+++ b/code/modules/1713/trench.dm
@@ -385,12 +385,14 @@ var/list/global/floor_cache = list()
 	..()
 
 /turf/floor/grass/attackby(obj/item/C as obj, mob/user as mob)
+	var/mob/living/human/H = user
 	if (istype(C, /obj/item/weapon/material/shovel/trench))
 		var/obj/item/weapon/material/shovel/trench/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove grass layer.</span>")
-		if (!do_after(user, (10 - S.dig_speed)*10, src))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/(12/S.dig_speed)))) //Think a DEFINE for the number being divided over S.dig_speed could be helpful, keeping it this for now
 			return
 		visible_message("<span class = 'notice'>[user] removes grass layer.</span>")
+		H.adaptStat("strength", 1)
 		var/area/A = get_area(src)
 		if (A.climate == "jungle" || A.climate == "savanna")
 			ChangeTurf(/turf/floor/dirt/jungledirt)
@@ -398,10 +400,12 @@ var/list/global/floor_cache = list()
 			ChangeTurf(/turf/floor/dirt)
 		return
 	else if (istype(C, /obj/item/weapon/material/shovel))
+		var/obj/item/weapon/material/shovel/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove grass layer.</span>")
-		if (!do_after(user, 100))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/S.usespeed)))
 			return
 		visible_message("<span class = 'notice'>[user] removes grass layer.</span>")
+		H.adaptStat("strength", 1)
 		var/area/A = get_area(src)
 		if (A.climate == "jungle" || A.climate == "savanna")
 			ChangeTurf(/turf/floor/dirt/jungledirt)
@@ -411,12 +415,14 @@ var/list/global/floor_cache = list()
 	..()
 
 /turf/floor/winter/attackby(obj/item/C as obj, mob/user as mob)
+	var/mob/living/human/H = user
 	if (istype(C, /obj/item/weapon/material/shovel/trench))
 		var/obj/item/weapon/material/shovel/trench/S = C
 		visible_message("<span class = 'notice'>[user] starts to remove snow layer.</span>")
-		if (!do_after(user, (10 - S.dig_speed)*10, src))
+		if (!do_after(user, (100/(H.getStatCoeff("strength"))/(12/S.dig_speed))))
 			return
 		visible_message("<span class = 'notice'>[user] removes snow layer.</span>")
+		H.adaptStat("strength", 1)
 		ChangeTurf(/turf/floor/dirt)
 		return
 	..()


### PR DESCRIPTION
Currently modular vehicles driving over placed wires will destroy the placed wires. This change makes it so that cars are incapable of destroying placed wires, regardless of whether or not the wires are under or over any floor covers.

Why it's good for the game:
Helps to encourage people to wire streets without as much worry of vehicles destroying the underfloor wiring.

Why it's bad for the game:
Cars could instead be made to destroy wiring but not wiring that is currently underneath a floor cover, also this PR may add to spaghetti code in adding itself to a list of !ifs used for seeing within the axis.dm file alone if something should be destroyed or not.