### PR TITLE
Makes it so Turkeys can Be Fed & Regenerate Eggs, Makes Animal Feeding Code

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/birds.dm
+++ b/code/modules/mob/living/simple_animal/friendly/birds.dm
@@ -91,7 +91,7 @@
 	response_harm   = "kicks"
 	attacktext = "kicked"
 	health = 10
-	var/eggsleft = 5
+	eggsleft = 5
 	var/roosting_icon = "brownhen_roosting"
 	var/body_color
 	var/egg_timer = FALSE
@@ -120,16 +120,6 @@
 /mob/living/simple_animal/chicken/Destroy()
 
 	chicken_count &= src
-	..()
-/mob/living/simple_animal/chicken/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if (stat == CONSCIOUS && istype(O, /obj/item/stack/farming/seeds))
-		var/obj/item/stack/S = O
-		if (eggsleft < 5)
-			user.visible_message("<span class='notice'>[user] feeds [src] \the [O].</span>")
-			eggsleft++
-			S.use(1)
-		else
-			user << "<span class = 'red'>The [src] is not hungry.</span>"
 	..()
 /mob/living/simple_animal/chicken/Life()
 	. =..()
@@ -267,7 +257,7 @@
 	health = 12
 	pass_flags = PASSTABLE
 	mob_size = MOB_MEDIUM
-	var/eggsleft = 5
+	eggsleft = 5
 	var/egg_timer = FALSE
 	granivore = 1
 	behaviour = "wander"


### PR DESCRIPTION
Currently the turkeys do not regenerate eggs since they can not be fed. This PR makes it so they can be fed and ergo can generate eggs, and adds to simple_animals.dm by porting feeding code from birds.dm concerning feeding to make it so that birds can be fed to regenerate health along with eggs and that herbivores can be fed grains to regenerate health.

Why it's good for the game:
Makes it so turkeys can regenerate eggs an ergo serve a potential purpose after laying all five starting eggs, makes it so that you may feed herbivores and granivores and therefore regenerate their health and hunger manually beyond medical items, allows for the manual generation of manure in some animals.

Why it's bad for the game:
Maybe makes farming manure via feeding medium animals seeds too prevalent since manure is generated each time an animal is fed and you can feed the animal if they're a little hungry/ain't full on eggs, maybe lowers the need and demand for chickens by making turkeys work the same.