### PR TITLE
Adds maxeggs var to simple_animal.dm & Updates Egglaying Code

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -67,6 +67,7 @@
 
 	var/simplehunger = 1000
 	var/eggsleft = FALSE //Eggs left that may be generated, currently set to FALSE by default to decide what animals lay eggs, may cause issues later
+	var/maxeggs = 5
 
 	//hostile mob stuff
 	var/stance = HOSTILE_STANCE_IDLE	//Used to determine behavior
@@ -438,7 +439,7 @@
 	if (stat == CONSCIOUS)
 		if (granivore && istype(O, /obj/item/stack/farming/seeds))
 			var/obj/item/stack/S = O
-			if (eggsleft != null && eggsleft < 5)
+			if (eggsleft != null && eggsleft < maxeggs)
 				eggsleft++
 			else if (simplehunger >= 1000)
 				user << "<span class = 'red'>\The [src] is not hungry.</span>"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -439,7 +439,7 @@
 	if (stat == CONSCIOUS)
 		if (granivore && istype(O, /obj/item/stack/farming/seeds))
 			var/obj/item/stack/S = O
-			if (eggsleft != null && eggsleft < maxeggs)
+			if (eggsleft != FALSE && eggsleft < maxeggs)
 				eggsleft++
 			else if (simplehunger >= 1000)
 				user << "<span class = 'red'>\The [src] is not hungry.</span>"


### PR DESCRIPTION
This PR adds a maxeggs var to simple_animal to allow for individual animals to have different levels of max eggs they can lay before needing to be fed, and updates a bit of code to be in line with earlier code.