### PR TITLE
Patches Issue with Zooming Using Guns Making Storage Object's Inventory Invisible

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -207,6 +207,7 @@ var/list/slot_equipment_priority = list( \
 		if (W.scoped_invisible)
 			if (W.invisibility > 0)
 				W.invisibility = FALSE
+			W.scoped_invisible = FALSE
 
 		if (istype(W, /obj/item/clothing/glasses) && ishuman(src))
 			var/obj/item/clothing/glasses/G = W

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -207,7 +207,6 @@ var/list/slot_equipment_priority = list( \
 		if (W.scoped_invisible)
 			if (W.invisibility > 0)
 				W.invisibility = FALSE
-			W.scoped_invisible = FALSE
 
 		if (istype(W, /obj/item/clothing/glasses) && ishuman(src))
 			var/obj/item/clothing/glasses/G = W


### PR DESCRIPTION
This PR patches the issue with zooming with guns making the inventory for storage objects that are open when the user zooms turning invisible and unclickable.