### PR TITLE
Makes Hunger Level Animals can be Manually Fed to Lower

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -441,7 +441,7 @@
 			var/obj/item/stack/S = O
 			if (eggsleft != FALSE && eggsleft < maxeggs)
 				eggsleft++
-			else if (simplehunger >= 1000)
+			else if (simplehunger >= 800)
 				user << "<span class = 'red'>\The [src] is not hungry.</span>"
 				return
 			if (mob_size >= MOB_MEDIUM)
@@ -455,7 +455,7 @@
 				qdel(S)
 		if (herbivore && istype(O, GRAIN))
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = O
-			if (simplehunger >= 1000)
+			if (simplehunger >= 800)
 				user << "<span class = 'red'>\The [src] is not hungry.</span>"
 				return
 			if (mob_size >= MOB_MEDIUM)


### PR DESCRIPTION
This PR lowers the value an animal can be at before you can't manually feed them seeds or wheat.

Why it's good for the game:
Possibly discourages spam feeding animals to unfairly aqcuire vast amounts of fertilizer.

Why it's bad for the game:
Makes it more difficult to top off animals hunger to prevent starvation, maybe lowers the ability for people to gain fertilizer too much.