### PR TITLE
Early russian era hotfix

### DIFF
--- a/code/game/objects/map_metadata/hill203.dm
+++ b/code/game/objects/map_metadata/hill203.dm
@@ -38,7 +38,7 @@
 		else
 			. = TRUE
 	if (istype(J, /datum/job/russian))
-		if (J.is_ww2 || J.is_rcw || J.is_prison || J.is_yeltsin)
+		if (J.is_ww2 || J.is_rcw || J.is_prison || J.is_yeltsin || J.is_rusretreat || J.is_modernday)
 			. = FALSE
 		else
 			. = TRUE

--- a/code/game/objects/map_metadata/port_arthur.dm
+++ b/code/game/objects/map_metadata/port_arthur.dm
@@ -37,7 +37,7 @@
 		else
 			. = TRUE
 	if (istype(J, /datum/job/russian))
-		if (J.is_ww2 || J.is_rcw || (J.is_prison || J.is_yeltsin))
+		if (J.is_ww2 || J.is_rcw || (J.is_prison || J.is_yeltsin || J.is_rusretreat || J.is_modernday))
 			. = FALSE
 		else
 			. = TRUE

--- a/code/modules/1713/jobs/rusretreat.dm
+++ b/code/modules/1713/jobs/rusretreat.dm
@@ -13,6 +13,8 @@
 	spawn_location = "JoinLateCCWL"
 	is_rusretreat = TRUE
 	is_commander = TRUE
+	is_ww2 = FALSE
+	is_modernday = TRUE
 	whitelisted = TRUE
 
 	min_positions = 1
@@ -80,6 +82,7 @@
 	min_positions = 10
 	max_positions = 200
 	is_rusretreat = TRUE
+	is_modernday = TRUE
 
 /datum/job/arab/civilian/chechen/militia/equip(var/mob/living/human/H)
 
@@ -259,6 +262,8 @@
 
 	is_medic = TRUE
 	is_rusretreat = TRUE
+	is_modernday = TRUE
+	is_ww2 = FALSE
 
 	min_positions = 3
 	max_positions = 10
@@ -326,6 +331,8 @@
 	is_rusretreat = TRUE
 	is_officer = TRUE
 	is_commander = TRUE
+	is_modernday = TRUE
+	is_ww2 = FALSE
 	whitelisted = TRUE
 
 	min_positions = 1
@@ -391,6 +398,8 @@
 	spawn_location = "JoinLateRUSgt"
 
 	is_rusretreat = TRUE
+	is_modernday = TRUE
+	is_ww2 = FALSE
 	is_squad_leader = TRUE
 	uses_squads = TRUE
 
@@ -467,6 +476,8 @@
 
 	is_medic = TRUE
 	is_rusretreat = TRUE
+	is_modernday = TRUE
+	is_ww2 = FALSE
 
 	min_positions = 2
 	max_positions = 8
@@ -532,7 +543,8 @@
 	return TRUE
 
 /datum/job/russian/ruff_radioman
-	title = "Russian Federal Forces Radio Operator"
+	title = "Russian Federal Forces Artillery Liaison"
+	en_meaning = "Radio Operator"
 	rank_abbreviation = "Pfc."
 
 	spawn_location = "JoinLateRURadop"
@@ -540,6 +552,8 @@
 	is_rusretreat = TRUE
 	is_radioman = TRUE
 	uses_squads = TRUE
+	is_modernday = TRUE
+	is_ww2 = FALSE
 
 	min_positions = 1
 	max_positions = 5
@@ -559,7 +573,6 @@
 		if (prob(65))
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/afghanka(H), slot_wear_suit)
 
-	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/armor/coldwar/platecarriergreen/armour = new /obj/item/clothing/accessory/armor/coldwar/platecarriergreen(null)
 	uniform.attackby(armour, H)
@@ -632,6 +645,8 @@
 	spawn_location = "JoinLateRU"
 
 	is_rusretreat = TRUE
+	is_modernday = TRUE
+	is_ww2 = FALSE
 
 	uses_squads = TRUE
 
@@ -731,6 +746,8 @@
 	spawn_location = "JoinLateRUsptz"
 	whitelisted = TRUE
 	is_rusretreat = TRUE
+	is_modernday = TRUE
+	is_ww2 = FALSE
 
 	uses_squads = TRUE
 


### PR DESCRIPTION
Restricts modern russian units to modern era as they could be joined as in Port Arthur and Hill 203

+ Also removes the walkie talkie from the modern russian radio operator