### PR TITLE
Adds the Game ID to the Status panel

### DIFF
--- a/code/game/mob/mob.dm
+++ b/code/game/mob/mob.dm
@@ -680,6 +680,8 @@
 			stat("")
 			stat("Players Online (Playing, Observing, Lobby):", "[clients.len] ([human_clients_mob_list.len], [clients.len-human_clients_mob_list.len-new_player_mob_list.len], [new_player_mob_list.len])")
 			stat("Round Duration:", roundduration2text_days())
+			stat("Game ID:", "<b>[game_id]</b>")
+			stat("")
 
 			if (map && !map.civilizations)
 				var/grace_period_string = ""


### PR DESCRIPTION
Makes the Game ID appear right under the Round Duration in the Status panel (makes it easier for players to find it, instead of scrolling all the way up through their logs).