### PR TITLE
Various Warlords tweaks

### DIFF
--- a/code/game/mob/living/carbon/human/death.dm
+++ b/code/game/mob/living/carbon/human/death.dm
@@ -124,11 +124,21 @@
 					map.scores["Eastern Army"] += 5
 				else
 					map.scores["Eastern Army"] += 1
+
 	else if (map && map.ID == MAP_AFRICAN_WARLORDS)
-		if (faction_text == CIVILIAN && original_job_title == "United Nations Doctor" && ishuman(last_harmed))
+		if (faction_text == CIVILIAN && original_job_title == "United Nations Doctor")
 			var/mob/living/human/killer = last_harmed
-			if (killer.nationality && killer.nationality in map.scores)
-				map.scores[killer.nationality] -=10
+			if (ishuman(killer))
+				map.scores[killer.nationality] -= 12
+				world << "<b><big>A United Nations Doctor has been killed! The elders are furious and have put a bounty on [killer.real_name], a [killer.original_job_title]! Bring his head to your altar for a generous reward!</big></b>"
+				killer.nationality = "Exiled"
+		if (faction_text == CIVILIAN && original_job_title == "United Nations Engineer")
+			var/mob/living/human/killer = last_harmed
+			if (ishuman(killer))
+				map.scores[killer.nationality] -= 10
+				killer.nationality = "Exiled"
+				world << "<b><big>A United Nations Engineer has been killed! The elders are furious and have put a bounty on [killer.real_name], a [killer.original_job_title]! Bring his head to your altar for a generous reward!</big></b>"
+
 
 	else if (map && map.ID == MAP_THE_ART_OF_THE_DEAL)
 		if (civilization && civilization in map.scores)

--- a/code/game/mob/living/carbon/human/human_defense.dm
+++ b/code/game/mob/living/carbon/human/human_defense.dm
@@ -81,6 +81,16 @@ bullet_act
 				else
 					last_harmed = H
 					H.civilization = "Killer"
+
+	else if (map.ID == MAP_AFRICAN_WARLORDS)
+		var/mob/living/human/H = user
+		if (W.sharp && !istype(W, /obj/item/weapon/reagent_containers) && istype(W))
+			if (src.stat != DEAD && H.civilization != "CIVILIAN")
+				if (H.civilization == "CIVILIAN")
+					return ..(W, user)
+				else
+					last_harmed = H
+
 	else
 		return ..(W, user)
 
@@ -123,6 +133,13 @@ bullet_act
 					SW2.reason = reason
 					map.pending_warrants += SW2
 					SW2.forceMove(null)
+
+		else if (map.ID == MAP_AFRICAN_WARLORDS)
+			var/mob/living/human/Huser = P.firer
+			if (src.stat != DEAD && (Huser.civilization != "CIVILIAN"))
+				if (Huser.civilization != "CIVILIAN")
+					last_harmed = Huser
+
 
 		else if (!map.civilizations && !map.nomads && !map.is_RP)
 			var/mob/living/human/Huser = P.firer

--- a/code/game/objects/map_metadata/african_warlords.dm
+++ b/code/game/objects/map_metadata/african_warlords.dm
@@ -131,10 +131,25 @@ obj/map_metadata/african_warlords/job_enabled_specialcheck(var/datum/job/J)
 		switch(faction)
 			if("Blugisi")
 				AW.scores["Blugisi"] += 2
+				if (head_nationality == "Exiled")
+					AW.scores["Blugisi"] += 4
+					new/obj/item/weapon/gun/projectile/submachinegun/ak74/aks74(user.loc)
+					new/obj/item/ammo_magazine/ak74(user.loc)
+					new/obj/item/ammo_magazine/ak74(user.loc)
 			if("Yellowagwana")
 				AW.scores["Yellowagwana"] += 2
+				if (head_nationality == "Exiled")
+					AW.scores["Yellowagwana"] += 4
+					new/obj/item/weapon/gun/projectile/submachinegun/ak74/aks74(user.loc)
+					new/obj/item/ammo_magazine/ak74(user.loc)
+					new/obj/item/ammo_magazine/ak74(user.loc)
 			if("Redkantu")
 				AW.scores["Redkantu"] += 2
+				if (head_nationality == "Exiled")
+					AW.scores["Redkantu"] += 4
+					new/obj/item/weapon/gun/projectile/submachinegun/ak74/aks74(user.loc)
+					new/obj/item/ammo_magazine/ak74(user.loc)
+					new/obj/item/ammo_magazine/ak74(user.loc)
 		switch(head_nationality)
 			if("Blugisi")
 				AW.scores["Blugisi"] -= 1

--- a/code/modules/1713/jobs/civilian.dm
+++ b/code/modules/1713/jobs/civilian.dm
@@ -2703,9 +2703,10 @@
 	can_be_female = FALSE
 	selection_color = "#53ADD0"
 	additional_languages = list("Zulu" = 10)
+	whitelisted = TRUE
 
 	min_positions = 2
-	max_positions = 8
+	max_positions = 6
 /datum/job/civilian/unitednations/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
@@ -2741,7 +2742,7 @@
 	is_medic = TRUE
 	can_be_female = TRUE
 	min_positions = 2
-	max_positions = 8
+	max_positions = 4
 	additional_languages = list("Zulu" = 20)
 
 /datum/job/civilian/unitednations/doctor/equip(var/mob/living/human/H)
@@ -2757,7 +2758,6 @@
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(H), slot_back)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/combat/modern(H), slot_belt)
-	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/m1911(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/armband/un/white = new /obj/item/clothing/accessory/armband/un(null)
@@ -2765,7 +2765,7 @@
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
 	give_random_name(H)
-	H.add_note("Role", "You are a <b>[title]</b>. Keep both the UN troops and civilians safe!<br>Do not engage the militias (unless they breach the perimeter or fire upon you), but recover the bodies if possible and safe to do so.")
+	H.add_note("Role", "You are a <b>[title]</b>. Keep both the UN troops and civilians in good health!<br> <b>You are a noncombative role, you may not engage in combat situations</b>.Do not engage the militias (unless they breach the perimeter or fire upon you), but recover the bodies if it's possible and safe to do so.")
 
 	H.setStat("strength", STAT_NORMAL)
 	H.setStat("crafting", STAT_NORMAL)
@@ -2787,7 +2787,7 @@
 	additional_languages = list("Zulu" = 10)
 
 	min_positions = 2
-	max_positions = 4
+	max_positions = 2
 
 /datum/job/civilian/unitednations/engineer/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
@@ -2807,7 +2807,7 @@
 	var/obj/item/clothing/accessory/armband/un/blue = new /obj/item/clothing/accessory/armband/un(null)
 	uniform.attackby(blue, H)
 	give_random_name(H)
-	H.add_note("Role", "You are a <b>[title]</b>. Keep the hospital infrastructure intact and develop surrounding areas if it's safe to do so.<br>Do not engage the militias (unless they breach the perimeter or fire upon you).")
+	H.add_note("Role", "You are a <b>[title]</b>. <b>You are a noncombative role, you may not engage in combat situations</b>.<br>Keep the hospital infrastructure intact and develop surrounding areas if it's safe to do so.")
 
 	H.setStat("strength", STAT_NORMAL)
 	H.setStat("crafting", STAT_HIGH)
@@ -2827,6 +2827,7 @@
 	can_be_female = FALSE
 	selection_color = "#007f00"
 	additional_languages = list("Zulu" = 100, "Swahili" = 80)
+	whitelisted = TRUE
 
 	min_positions = 2
 	max_positions = 4
@@ -2868,7 +2869,7 @@
 	H.r_facial = hex2num(copytext(hex_hair, 2, 4))
 	H.g_facial = hex2num(copytext(hex_hair, 4, 6))
 	H.b_facial = hex2num(copytext(hex_hair, 6, 8))
-	H.add_note("Role", "You are a <b>[title]</b>. Keep the town safe and arrest criminals.<br>Do not kill the militias (unless they breach the perimeter or fire upon you).")
+	H.add_note("Role", "You are a <b>[title]</b>. You're the liaison between the local population and UN. Use your language knowledge to act as an interprator.<br>Do not kill the militias, instead, try to arrest them (unless they breach the perimeter or fire upon you).")
 
 	H.setStat("strength", STAT_MEDIUM_HIGH)
 	H.setStat("crafting", STAT_LOW)

--- a/maps/WIP/african_warlords.dmm
+++ b/maps/WIP/african_warlords.dmm
@@ -23,7 +23,7 @@
 "aw" = (/obj/covers/wood_ship,/turf/floor/dirt/dust,/area/caribbean/roofed/jungle)
 "ax" = (/obj/structure/goalpost{dir = 1},/obj/structure/railing,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "ay" = (/obj/structure/goalpost{dir = 5},/obj/structure/railing,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
-"az" = (/obj/covers/wood_ship,/obj/structure/simple_door/key_door/anyone/wood,/turf/floor/dirt,/area/caribbean/roofed/jungle)
+"az" = (/obj/structure/barricade/hescobastion{health = 1200},/obj/structure/sign/custom{desc = "NO ARMED MILITIAS ALLOWED INSIDE THE PERIMETER. TRANSGRESSORS WILL BE SHOT ON SIGHT!"; name = "United Nations demilitarized zone"},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "aA" = (/obj/structure/railing{dir = 4; icon_state = "railing0"},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "aB" = (/obj/structure/goalpost{dir = 8},/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
 "aC" = (/obj/covers/fancywood,/obj/structure/religious/woodcross1,/turf/floor/dirt,/area/caribbean/roofed/jungle)
@@ -101,9 +101,9 @@
 "bW" = (/obj/covers/wood_ship,/obj/structure/table/modern/table,/obj/item/weapon/telephone,/turf/floor/dirt/dust,/area/caribbean/roofed/jungle)
 "bX" = (/obj/covers/wood_ship,/obj/covers/steelplating/white,/obj/structure/table/glass,/obj/item/clothing/gloves/color/white,/obj/item/clothing/mask/sterile,/obj/structure/window/barrier/sandbag{dir = 1},/obj/structure/curtain/open{pixel_y = 32},/turf/floor/dirt,/area/caribbean/roofed/jungle)
 "bY" = (/obj/covers/wood_ship,/obj/structure/table/modern/table,/obj/item/weapon/pen/pencil,/turf/floor/dirt,/area/caribbean/roofed/jungle)
-"bZ" = (/obj/covers/wood_ship,/obj/structure/table/modern/table,/obj/item/weapon/pen/pencil,/turf/floor/dirt/dust,/area/caribbean/roofed/jungle)
+"bZ" = (/obj/structure/barricade/hescobastion,/obj/structure/sign/securearea,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "ca" = (/obj/covers/sandstone_wall,/turf/floor/dirt/dust,/area/caribbean/roofed/jungle)
-"cb" = (/obj/structure/sign/greencross{pixel_y = 32},/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"cb" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "cc" = (/obj/covers/wood_ship,/obj/covers/steelplating/white,/obj/structure/window/barrier/sandbag{dir = 1},/obj/structure/curtain/open{pixel_y = 32},/turf/floor/dirt,/area/caribbean/roofed/jungle)
 "cd" = (/obj/covers/sandstone_wall,/turf/floor/beach/sand/desert,/area/caribbean/roofed/jungle)
 "ce" = (/obj/structure/window/classic/metal,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/roofed/jungle)
@@ -395,7 +395,7 @@
 "hE" = (/obj/covers/wood_ship,/obj/structure/curtain/open{pixel_y = 32},/turf/floor/dirt,/area/caribbean/roofed/jungle)
 "hF" = (/obj/covers/wood_ship,/obj/structure/table/wood,/turf/floor/dirt/dust,/area/caribbean/roofed/jungle)
 "hG" = (/obj/structure/barbwire,/obj/structure/barbwire{dir = 1},/obj/structure/barricade/antitank,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
-"hH" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
+"hH" = (/obj/effect/floor_decal/industrial/danger{dir = 8},/obj/structure/sign/traffic/noentry,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "hI" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/obj/structure/barricade/antitank,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "hJ" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/obj/structure/barricade/antitank,/obj/structure/sign/custom{desc = "NO ARMED MILITIAS ALLOWED INSIDE THE PERIMETER. TRANSGRESSORS WILL BE SHOT ON SIGHT!"; name = "United Nations demilitarized zone"},/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
 "hK" = (/obj/structure/curtain/open{pixel_x = 32},/turf/floor/wood,/area/caribbean/roofed/jungle)
@@ -514,16 +514,38 @@
 "jT" = (/obj/structure/simple_door/fence{dir = 4},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "jU" = (/obj/structure/simple_door/fence{dir = 4},/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
 "jV" = (/obj/covers/wood_ship,/obj/structure/mill,/turf/floor/dirt,/area/caribbean/roofed/jungle)
-"jW" = (/obj/structure/lamp/lamp_big/alwayson{dir = 1; icon_state = "tube"},/obj/structure/window/barrier/sandbag{dir = 8},/obj/item/weapon/storage/box/bodybags,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"jW" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/item/weapon/beartrap/armed,/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "jX" = (/obj/structure/closet/crate/steel,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "jY" = (/obj/structure/window/barrier/sandbag,/obj/structure/floodlight{layer = 4; pixel_y = 16},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"jZ" = (/obj/item/weapon/trafficcone{dir = 1},/obj/effect/floor_decal/industrial/danger{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"ka" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"kb" = (/obj/item/weapon/trafficcone{dir = 4},/obj/effect/floor_decal/industrial/danger{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"kc" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"kd" = (/obj/item/weapon/trafficcone{dir = 8},/obj/effect/floor_decal/industrial/danger{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"ke" = (/obj/covers/wood_ship,/obj/covers/steelplating/white,/obj/structure/bed,/obj/item/weapon/bedsheet/medical,/obj/structure/lamp/lamp_big/alwayson,/turf/floor/dirt,/area/caribbean/roofed/jungle)
+"kf" = (/obj/covers/wood_ship,/obj/structure/simple_door/key_door/custom/doubledoor/steel{code = 4975; custom_code = 4975; opacity = 1},/turf/floor/dirt,/area/caribbean/roofed/jungle)
+"kg" = (/obj/covers/wood_ship,/obj/structure/table/modern/table,/obj/item/weapon/key/soviet/guard{name = "UN key"},/obj/item/weapon/key/soviet/guard{name = "UN key"},/obj/item/weapon/key/soviet/guard{name = "UN key"},/turf/floor/dirt/dust,/area/caribbean/roofed/jungle)
+"kh" = (/obj/structure/sign/greencross{pixel_y = 32},/obj/structure/window/barrier/sandbag{dir = 8},/obj/covers/cobblestone/stairs,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"ki" = (/obj/covers/cobblestone/stairs,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"kj" = (/obj/structure/sign/greencross{pixel_y = 32},/obj/structure/window/barrier/sandbag{dir = 4},/obj/covers/cobblestone/stairs,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"kk" = (/obj/structure/lamp/lamp_big/alwayson{dir = 1; icon_state = "tube"},/obj/structure/window/barrier/sandbag{dir = 8},/obj/item/weapon/storage/box/bodybags,/obj/structure/table/wood,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"kl" = (/obj/structure/barricade/hescobastion{health = 3600},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"km" = (/obj/structure/window/barrier/jersey,/obj/structure/barbwire,/obj/structure/barbwire{dir = 1},/obj/structure/barbwire{dir = 1},/obj/structure/barbwire{dir = 1},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"kn" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"ko" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/obj/structure/barbwire{dir = 1},/obj/structure/barbwire{dir = 1},/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
+"kp" = (/obj/structure/barbwire{dir = 8},/obj/item/weapon/beartrap/armed,/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"kq" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/window/barrier/sandbag{dir = 8},/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 8},/obj/item/weapon/beartrap/armed,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"kr" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"ks" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/obj/structure/sign/custom{desc = "NO ARMED MILITIAS ALLOWED INSIDE THE PERIMETER. TRANSGRESSORS WILL BE SHOT ON SIGHT!"; name = "United Nations demilitarized zone"},/obj/structure/lamp/lamp_small/alwayson/red{dir = 8},/obj/structure/window/barrier/sandbag{dir = 8},/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "kt" = (/mob/living/simple_animal/rooster,/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
+"ku" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/obj/structure/barbwire{dir = 1},/obj/structure/barbwire{dir = 1},/obj/item/weapon/beartrap/armed,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
+"kv" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/obj/structure/barbwire{dir = 1},/obj/structure/barbwire{dir = 1},/obj/item/weapon/beartrap/armed,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
+"kw" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/obj/structure/barbwire{dir = 1},/obj/structure/barbwire{dir = 1},/obj/item/weapon/beartrap/armed,/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
 "kG" = (/obj/structure/window/barrier/rock{dir = 1; icon_state = "rock_barricade"},/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "kJ" = (/obj/structure/barricade/hescobastion,/obj/structure/sign/custom{desc = "NO ARMED MILITIAS ALLOWED INSIDE THE PERIMETER. TRANSGRESSORS WILL BE SHOT ON SIGHT!"; name = "United Nations demilitarized zone"},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "kR" = (/obj/structure/wild/smallbush,/turf/floor/beach/sand/dark,/area/caribbean/nomads/forest/Jungle)
 "lf" = (/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 8},/obj/structure/barricade/antitank,/obj/structure/lamp/lamp_small/alwayson/red{dir = 8},/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "li" = (/obj/item/weapon/trafficcone{dir = 1},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
-"lM" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/obj/structure/sign/custom{desc = "NO ARMED MILITIAS ALLOWED INSIDE THE PERIMETER. TRANSGRESSORS WILL BE SHOT ON SIGHT!"; name = "United Nations demilitarized zone"},/obj/structure/lamp/lamp_small/alwayson/red{dir = 8},/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "lN" = (/obj/structure/window/barrier/sandbag,/obj/structure/window/barrier/sandbag{dir = 4},/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "mQ" = (/obj/structure/wild/tallgrass2,/turf/floor/dirt,/area/caribbean/no_mans_land/invisible_wall/jungle/one)
 "mT" = (/obj/structure/barbwire{dir = 8},/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
@@ -560,7 +582,6 @@
 "td" = (/obj/structure/wild/tallgrass2,/turf/floor/beach/water/swamp{name = "Swamp Water"},/area/caribbean/nomads/forest/Jungle)
 "te" = (/obj/structure/wild/junglebush,/turf/floor/grass/jungle,/area/caribbean/no_mans_land/invisible_wall/jungle/two)
 "tI" = (/obj/item/weapon/trafficcone,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
-"ua" = (/obj/structure/barbwire{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "ud" = (/obj/structure/barricade/hescobastion,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "un" = (/obj/structure/wild/tallgrass2,/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "uy" = (/obj/structure/window/barrier/sandbag{dir = 1},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
@@ -591,12 +612,10 @@
 "Ay" = (/obj/structure/window/barrier/rock{dir = 4; icon_state = "rock_barricade"},/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "AG" = (/obj/structure/window/barrier/sandbag,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "AJ" = (/obj/structure/gate/barrier/vertical{pixel_y = 15},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
-"AP" = (/obj/structure/window/barrier/jersey,/obj/structure/barbwire,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "AR" = (/obj/item/weapon/trafficcone{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "Bj" = (/obj/structure/window/classic,/obj/covers/wood_ship,/obj/structure/curtain/open,/turf/floor/dirt,/area/caribbean/roofed/jungle)
 "Bo" = (/obj/item/stack/farming/seeds/coca,/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "BX" = (/obj/structure/wild/tallgrass,/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 8},/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
-"Cg" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "Cx" = (/obj/structure/sign/traffic/stop,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "CI" = (/obj/structure/wild/junglebush,/turf/floor/beach/water/swamp{name = "Swamp Water"},/area/caribbean/nomads/forest/Jungle)
 "Di" = (/obj/structure/window/barrier/rock{dir = 8; icon_state = "rock_barricade"},/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
@@ -626,11 +645,9 @@
 "Ie" = (/obj/covers/thatch2,/obj/structure/mine_support,/obj/structure/curtain/open/black,/turf/floor/grass/jungle,/area/caribbean/roofed/jungle)
 "IB" = (/obj/covers/wood_ship,/obj/structure/closet/cabinet,/turf/floor/dirt,/area/caribbean/roofed/jungle)
 "IN" = (/turf/floor/dirt/dust{name = "dry dirt"},/area/caribbean/nomads/forest/Jungle)
-"Jj" = (/obj/structure/barbwire{dir = 8},/obj/structure/barricade/antitank,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "Jl" = (/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 8},/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
 "Jp" = (/obj/structure/barbwire{dir = 8},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "Jr" = (/obj/covers/wood_ship,/obj/structure/table/wood,/turf/floor/dirt,/area/caribbean/roofed/jungle)
-"Jx" = (/obj/structure/sign/greencross{pixel_y = 32},/obj/structure/window/barrier/sandbag{dir = 4},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "JP" = (/obj/structure/wild/tallgrass,/turf/floor/beach/water/swamp{name = "Swamp Water"},/area/caribbean/nomads/forest/Jungle)
 "KA" = (/turf/floor/beach/water/flooded,/area/caribbean/nomads/forest/Jungle)
 "KR" = (/obj/structure/barbwire{dir = 4},/obj/structure/barbwire{dir = 8},/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
@@ -640,7 +657,6 @@
 "LH" = (/obj/covers/wood_ship,/obj/structure/table/wood,/obj/item/trash/candle,/turf/floor/dirt,/area/caribbean/roofed/jungle)
 "LT" = (/obj/structure/wild/smallbush,/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "LW" = (/turf/floor/plating/stone_old,/area/caribbean/nomads/forest/Jungle)
-"Ma" = (/obj/structure/simple_door/key_door/anyone/doubledoor/wood,/obj/covers/wood_ship,/turf/floor/dirt,/area/caribbean/roofed/jungle)
 "Mo" = (/obj/structure/window/barrier/sandbag,/obj/structure/window/barrier/sandbag{dir = 8},/obj/item/ammo_magazine/browning,/obj/item/ammo_magazine/browning,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "Mq" = (/obj/effect/landmark{name = "JoinLateIND2"},/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "Mx" = (/obj/covers/repairedfloor,/turf/floor/beach/water/jungle,/area/caribbean/nomads/forest/Jungle)
@@ -660,13 +676,10 @@
 "Pn" = (/obj/structure/wild/jungle,/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "Pq" = (/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "Qc" = (/mob/living/simple_animal/frog,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
-"Qy" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "QP" = (/obj/covers/thatch2,/obj/structure/mine_support/stone/aztec/sandstone{name = "sandstone column"},/turf/floor/grass/jungle,/area/caribbean/roofed/jungle)
 "Ri" = (/obj/structure/wild/tallgrass,/obj/map_metadata/african_warlords,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
-"RC" = (/obj/structure/barbwire{dir = 1},/obj/structure/barbwire,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "RD" = (/obj/item/stack/farming/seeds/tomato,/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
 "RY" = (/obj/structure/wild/palm,/turf/floor/beach/water/deep/jungle,/area/caribbean/nomads/forest/Jungle)
-"Sg" = (/obj/structure/barbwire{dir = 8},/obj/structure/barbwire{dir = 4},/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "Sq" = (/obj/structure/wild/palm,/turf/floor/grass/jungle,/area/caribbean/nomads/forest/Jungle)
 "SH" = (/obj/structure/wild/smallbush,/turf/floor/plating/stone_old,/area/caribbean/nomads/forest/Jungle)
 "SK" = (/obj/structure/curtain/leather,/obj/covers/wood_ship,/turf/floor/dirt,/area/caribbean/roofed/jungle)
@@ -674,7 +687,6 @@
 "Tf" = (/obj/structure/wild/burnedtree,/turf/floor/beach/water/swamp{name = "Swamp Water"},/area/caribbean/nomads/forest/Jungle)
 "TE" = (/obj/structure/wild/rock,/turf/floor/beach/water/jungle,/area/caribbean/nomads/forest/Jungle)
 "TK" = (/obj/structure/window/barrier/jersey{dir = 4},/obj/item/ammo_magazine/browning,/obj/item/ammo_magazine/browning,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
-"Ur" = (/obj/structure/barbwire{dir = 8},/obj/structure/barricade/antitank,/turf/floor/dirt/dust,/area/caribbean/nomads/forest/Jungle)
 "Us" = (/obj/structure/bed/roller,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
 "Uw" = (/obj/structure/barbwire{dir = 4},/obj/structure/barricade/antitank,/turf/floor/dirt,/area/caribbean/nomads/forest/Jungle)
 "UM" = (/obj/structure/window/barrier/sandbag{dir = 4},/obj/structure/window/barrier/sandbag,/turf/floor/plating/road,/area/caribbean/nomads/forest/Jungle)
@@ -746,35 +758,35 @@ ZrHVVxWEZrZrZrZrVxZrZrZrZrJPZrVxZrfKfKfKZrZrWEWEZrZrZrZrZrZrMGWEZrZrWEsZxTaAZrxT
 ZrZrWEWEZrVNVNFkCIZrWEZrZrZrVxVxfKHVZrZrZrZrZrZrZrFkFkVxZrVxZrZrZrMGZrZrxTaAxTxTxTZrZrxTxTxTZrZraHPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqlixTaZcKbjbjbjbjbjbjbjcLaZZrZrZreWeWxTxTZrWEMGZrZrEWaaEWhkvuMGVNHkZrMGMGMGMGMGMGvuMGMGMGSqMGMGZrMGZrZroYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrWEWEWEZrZrZrZrozOOVNVNZrHpZrfKZrZrWEsSZrDZZrZrFkFkZrZrCIMGZrZrVxZrZrxTaAZrZrZrZrZrxTxTZrZrZraHPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqnaPqxTaZcMcNbjbjbjbjbjbjcOaZZrFkZrxTeBxTWECIMGZrZrCIEWaaaaEWEWZrZrLTZrMGMGWvMGMGMGMGMGPnMGMGMGZrZrZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrOOZrZrZrZrZrZrZrZrZrvuVxfXfXfKZrVxWEWEWETfZrVxVxZrZrZrZrMGZrZrVxZrZrxTbkZrZrYGYGZrZrZrZrxTZrpqliPqtInatIPqPqPqPqPqPqPqPqPqPqPqPqPqPqtIARPqPqxTbeaZbbbjbjbjbjbjbbbbbbZrZrxTxTeBZrZrZGCIMGWEZrEWEWaaaaEWZrLTZrZrSqMGMGMGMGMGMGMGMGMGMGMGSqMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-WEDZZrWEWEDZZrOOWEozVxZrfKfXneZrHVZGWEWEWEWEWEWECIZrWEWEDZZrWEZrZrZrFkxTxTbkZrxTZrYGZrZrZrZrxTZrFPeXPqeXeYeYxuyExuxTxuyExuyExuxTxuyExuZiWWAPAPAPLzWWiSxTxTxTxTxTxTxTxTdDxTxTxTxTxTxTxTxTxTfafafaDZZrEWaaEWEWZrMGLTMGvuvuMGMGMGMGMGMGMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-CIZrZrVxCIZrSYZrZruPHVfXsufXZrozZrZrWEWEWEZrZrZrZrZrVxCIZrZrMGVxZrZrFkZrxTbkZrZrZrZrZrxTZrZrZrZrfbXdPqfefgakalaGalalamaGalaGalamamaGamakfguyuyuyuyFxCgliPqPqPqPqPqPqPqfiPqPqPqPqPqPqPqPqPqPqPqfaWEZrEWaafjfoZraVLTMGvuMGMGSqMGMGMGWvMGMGMGMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrozZrZrZrozZrFkZrfKfKZrZrWEJPVNZrZrOOZrZrZrFkZrZrMGZrZrZrZrWEZrWEitcpcvxTbkZrZrZrxTxTxTZrZrZrZraHshPqfueGakiAbniBalbvbHbpbXbrariAcciBamxTPqPqPqPqUMQynaPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqxTWEZrZrEWaaEWEWZrZrMGMGPnMGHkMGMGWvLTMGZrMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-WEozWEHVWEozZrfKfKfKZrVxZrVxYGVNYGZrHpZrZrZrZrZrCIZrWEWEZrWEZrZrZritoJZrxTbkYGZrZrbsbtbtaEZrZrZraHPqPqPqxTakapapapalbucsapapcAasapapapalxTPqPqPqPqWWCgARPqPqPqPqPqPqPqPqedPqPqPqPqPqPqPqPqPqPqxTZrWEZrZrEWEWEWEWZrMGMGLTMGHkMGMGMGMGMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrZrZrfKfKfKfKfKWEHpHpZrZrZrZrZrOcZrZrDZWEZrFkZrZrZrWEWEVxZrVxHpZritoJZrxTaAbwbwZrbxbybybzbAbAbAaHPqPqPqxTakblaqbmalapcDapapcTasblaqbmalxTPqPqPqxTLziSxTxTxTxTxTxTxTxTgAxTxTxTxTxTxTxTxTPqPqPqxTMGZrZrDZefZrhkhDeVZrLTLTMGMGHkHkMGMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+WEDZZrWEWEDZZrOOWEozVxZrfKfXneZrHVZGWEWEWEWEWEWECIZrWEWEDZZrWEZrZrZrFkxTxTbkZrxTZrYGZrZrZrZrxTZrFPeXPqeXeYeYxuyExuxTxuyExuyExuxTxuyExuZiWWkmkmkmazbZcbhHxTxTxTxTxTxTxTdDxTxTxTxTxTxTxTxTxTfafafaDZZrEWaaEWEWZrMGLTMGvuvuMGMGMGMGMGMGMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+CIZrZrVxCIZrSYZrZruPHVfXsufXZrozZrZrWEWEWEZrZrZrZrZrVxCIZrZrMGVxZrZrFkZrxTbkZrZrZrZrZrxTZrZrZrZrfbXdPqfefgakalaGalalamaGalaGalamamaGamakfguyuyuyuyFxjWjZPqPqPqPqPqPqPqfiPqPqPqPqPqPqPqPqPqPqPqfaWEZrEWaafjfoZraVLTMGvuMGMGSqMGMGMGWvMGMGMGMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrozZrZrZrozZrFkZrfKfKZrZrWEJPVNZrZrOOZrZrZrFkZrZrMGZrZrZrZrWEZrWEitcpcvxTbkZrZrZrxTxTxTZrZrZrZraHshPqfueGakiAbniBalbvbHbpbXbrariAcciBamxTPqPqPqPqUMkakbPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqxTWEZrZrEWaaEWEWZrZrMGMGPnMGHkMGMGWvLTMGZrMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+WEozWEHVWEozZrfKfKfKZrVxZrVxYGVNYGZrHpZrZrZrZrZrCIZrWEWEZrWEZrZrZritoJZrxTbkYGZrZrbsbtbtaEZrZrZraHPqPqPqxTakapapapalbucsapapcAasapapapalxTPqPqPqPqWWkckdPqPqPqPqPqPqPqPqedPqPqPqPqPqPqPqPqPqPqxTZrWEZrZrEWEWEWEWZrMGMGLTMGHkMGMGMGMGMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrZrZrfKfKfKfKfKWEHpHpZrZrZrZrZrOcZrZrDZWEZrFkZrZrZrWEWEVxZrVxHpZritoJZrxTaAbwbwZrbxbybybzbAbAbAaHPqPqPqxTakblaqbmalapcDapapcTasblaqbmalxTPqPqPqxTLzcbhHxTxTxTxTxTxTxTgAxTxTxTxTxTxTxTxTPqPqPqxTMGZrZrDZefZrhkhDeVZrLTLTMGMGHkHkMGMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrfKfKfKfKZrZrZrZrZrWEaQZrZrMGZrZrZrZrVNZrZrZrWEWEZrWEWEVxZrgugujogugujpZrxTZrZrxTxTZrZritErZrxTxTPqPqPqxTakapapapalbBbCapapcAasapapapakxTPqPqPqxTbeaZbaaZegbeaZZrZrZrZrMGZrZrMGZrZrxTxTPqPqPqxTVxZrZrMGefefVxaaaaEWZrMGMGMGHkHkMGMGPnMGMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-fKfKfKZrWEzxZrZrZrZrZrVxZrZrWEWEMGWEWEMGZrFkMGMGZrZrMGCIDZZrjqjsjtjujvjwZrsZxTZrZrxTxTxTxTxTxTxTxTPqPqPqxTakblapblalbDbCcIapcTasblapblalxTPqPqPqfaaZcjbdbdbdbdaZSqMGpikGkGkGVTMGMGSqekxTPqPqPqxTbqWEZrZrefefZrEWaaEWZrZrMGMGHkHkLTMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+fKfKfKZrWEzxZrZrZrZrZrVxZrZrWEWEMGWEWEMGZrFkMGMGZrZrMGCIDZZrjqjsjtjujvjwZrsZxTZrZrxTxTxTxTxTxTxTxTPqPqPqxTakkeapkealbDbCcIapcTaskeapkealxTPqPqPqfaaZcjbdbdbdbdaZSqMGpikGkGkGVTMGMGSqekxTPqPqPqxTbqWEZrZrefefZrEWaaEWZrZrMGMGHkHkLTMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 fKHVZrZrZrWEVxVxZrZrZrZrWEWEZrZrNOZrZrZrZrZrZrVxZrZrMGZrZrZrjxjzjzjzjzjwZrZrxTxTxTaZbbbbbbbebbbbxTPqPqPqiSakascVasalbEbCbCbFauauaucWaualxTPqPqPqfacPcQbdbdbdbdaZMGMGMGHkyKktAyHkFkZrMGxTPqPqPqxTaPZrZrefefefMGZrRYaahDZrMGPnMGMGMGSqSqZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrZrWEZrZrWEWEFkZrZrVxCIZrVNZrZrZrZrHVZrVxVxZrZrZrVxZrZrjqjAjAjAjBjCguguguxTZraZemepimesesbbxTPqPqPqNkcSdkapfGapapapfGapapapfGapdldrxTPqPqPqfaaZbdbdfHcmcnaZPnLTDiHkMGZrAyXWZrSqMGxTPqPqPqxTVxZrZrefefefefeVaaaaMCZrMGMGMGyZMGWvMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrDZZrZrVxVxZrZrZrZrMGZrZrZrWEFkZrVNZrZrZrHpZrFkZrYGYGYGZrjqjDjDjDjzjEjzjzjFxTZraZbhbhbhbhbhbbxTPqPqPqNkcSdxapapapapapapapapapapapdWdrxTPqPqPqxTfIfIfIfIfIfIfJaYaYbaaYaYbaaYaYSqZrFkxTPqPqPqxTVxZrZrMGefefefUwaaaaEWZrSqMGMGzTvuMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrMGRDZrZrVxZrWEWEDZZrWEZrZrMGZrZrZrWEZrVNZrZrZrZrHkZrYGZrSYjxjzjzjzjzjzjzjzjGxTxTaZinbhbhbhbhfLxTPqPqPqiSakalalasalalLnalAlakazazalalakxTPqPqPqxTacfMfMfMfMfMacaYbIbJbdbKbdbgaYFkHkekxTPqPqPqxTekDZZrMGMGMGzTBXEWEWZreVZrMGMGLTMGMGZrMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrZrZrZrZrVxZrZrZrZrMGZrZrMGVxZrZrZrZrZrZrWEWEZrZrZrZrVNVNMGjqjDjHjDjzjDjIjDguevxTaZiobhbhbhbhfLxTPqPqPqxTakbMbNapbOalcZbQbRbSawawaDdaalxTPqPqPqxTcafNbjbjbjcCcaaYbTbfbdbdaobdbaZrZrxTxTPqPqPqxTWEMGDZMGMGZrZrJlEWEWEWEWZrZrZrEWZrZrMGMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrMGRDZrZrVxZrWEWEDZZrWEZrZrMGZrZrZrWEZrVNZrZrZrZrHkZrYGZrSYjxjzjzjzjzjzjzjzjGxTxTaZinbhbhbhbhfLxTPqPqPqiSakalalasalalLnalAlakkfkfalalakxTPqPqPqxTacfMfMfMfMfMacaYbIbJbdbKbdbgaYFkHkekxTPqPqPqxTekDZZrMGMGMGzTBXEWEWZreVZrMGMGLTMGMGZrMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrZrZrZrZrVxZrZrZrZrMGZrZrMGVxZrZrZrZrZrZrWEWEZrZrZrZrVNVNMGjqjDjHjDjzjDjIjDguevxTaZiobhbhbhbhfLxTPqPqPqxTakbMbNfGbOalcZbQbRbSawawaDdaalxTPqPqPqxTcafNbjbjbjcCcaaYbTbfbdbdaobdbaZrZrxTxTPqPqPqxTWEMGDZMGMGZrZrJlEWEWEWEWZrZrZrEWZrZrMGMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrVxZrZrZrZrMGZrZrMGWEMGVxZrHVZrZrZrWEZrWEZrZrZrVxZrVxVNjqjqjJjqjqjqjJjKguZrxTaZfObhbhbhdOaZxTPqPqPqxTalalalapbUakZTZTZTZTZTZTZTaoalxTPqPqPqxTfPbjbjbjbjcCacbVbdbdbdbdaobgaYphxTxTPqPqPqPqxTMGMGMGFkVxMGZrEWEWEWEWEWZrMGZrZrZrMGSqSqoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrZrWEWEDZZrWEZrZrMGWEMGZrozZrZrZrVNVxZrZrZrYGDZMGYGMGYGhmxTxTxThmxTxTsZxTjLxTaZdbdbfQdOipaZxTPqPqPqxTalbMbNapapalaFaoaFbWZTZTZTeeelxTPqPqPqxTcafRfRfRfSfRcabVbaaYbcbcaYbaaYxTxTPqPqPqPquyrVMGZrZrMGeVZrZraaaaEWZrZrZrMGMGMGMGZrMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrZrZrZrVxCIZrZrMGWEVNMGVNZrZrZrZrFkZrZrZrZrZrZrMGYGYGYGZrMGuFuFuFbcuFuFFkFkZrxTxTbeaZbbbbbbbbbexTPqPqPqxTalalalenalalbYfTbZfDZTaoaoeeelxTPqPqPqxTfPfVfWaoaofYfPdfFkFkxTxTFkZrxTxTPqPqPqPqAGeWqUDZMGFkMGZrZrZraaEWEWZrZraVZrMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrZrZrZrVxCIZrZrMGWEVNMGVNZrZrZrZrFkZrZrZrZrZrZrMGYGYGYGZrMGuFuFuFbcuFuFFkFkZrxTxTbeaZbbbbbbbbbexTPqPqPqxTalalalenalalbYfTkgfDZTaoaoeeelxTPqPqPqxTfPfVfWaoaofYfPdfFkFkxTxTFkZrxTxTPqPqPqPqAGeWqUDZMGFkMGZrZrZraaEWEWZrZraVZrMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrMGZrZrZrZrWEWEWEMGZrZrZrZrZrZrZrZrWEWEZrZrZrZrZrZrMGWEwaeCcxbjcyuFZrZrZrxTdgxTxTxTxTxTxTxTxTPqPqPqiSakdhaoawawdiaoaoaoaoZTawaofFalxTPqPqPqxTaciCgaaoaogbcaZrZrZrxTxTZrxTxTPqPqPqPqPqxTxTMGZrVNMGZrmTEWaaaaZrZrZrZrLTZrMGMGMGMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrYGZrZrZrZrZrZrZrMGZrZrZrHVZrZrZrZrZrZrZrFkFkVxZrVxZrZruFczbjbjbjuFZrZrxTgkgcgpgtgFgpgQgpgdxTPqPqPqNkgYgZaJaKaLaMdmdndoaJaKaLaMeeelxTPqPqPqxThahbgfaoaoggcadGZrZrxTxTxTxTPqPqPqPqPqxTxTFkZrMGMGMGZrmTEWEWZrZrMGLTLTMGVxMGMGZrMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrYGWEZrZrZrZrFkZrZrZrozZrZrZrWEsSZrDZZrZrFkFkZrZrCIMGZrhchdbjbjhfhcZrxTxTZrdpdpdpdpdpdpdpdpxTPqPqPqNkgYhgaNaOaRiqdqdndqaNaOaRaSeeelxTPqPqPqxTfPgeaoaoaohhhaZrZrdIxTxTxTPqPqPqPqPqxTxTDZZrOOMGMGZrmTpCEWEWZrMGZrMGZrZrMGPnMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrZrWEWECICIDZZrOOZrZrZrZrCIZrZrZrZrVxCIZrVxZrZrWEWEDZZruFjMbjbjeHuFxTxTxTglgpgFgFgpgpgpgQgpjNPqPqPqiSalaoaoaoaoaododqdmaoaoaoaoaoalxTPqPqPqxTdBaoaognaogocaxTZrZrxTxTPqPqPqPqPqxTxTZrZrZrZrMGZrFkmTEWEWZrZrMGMGMGZrZrMGLTMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrZrZrWEZrZrCIWEZrZrZrZrVxCIZrZrZrZrWEHVWEozZrZrozZrbqbqbqbquFuFbcbcbeuFxTxTdsZrdpdpdpdpdpdpdpdpxTPqPqPqxTaldtaohihiduaUaoaUdvhjhiaodtalxTPqPqPqiDachAaohliEgocaxTZrxTxTPqPqPqPqPqxTxTdIZrZreVozZrFkEWEWEWZrZrZrMGZrWvPnMGLTLTMGMGoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrZrZrZrZrZrZrZrZrMGZrMGWEZrZrWEZrvuZrZrZrZrWEWEZruQbqFbZrWEZrZrxTxTxTjNxTdsdwdsgcgQhngQgFgpgpgdxTPqPqPqxTakalalelelalalMaalalelelakalakeBPqPqPqxTcaacachaacaccaPexTxTPqPqPqPqPqxTxTZrZrvuDZMGMGZrEWEWEWZrZrZrMGMGMGMGMGZrMGZrMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-xTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTJpfaxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTPqPqPqUrGgjNxTxTxTdzcbxTJxjWhohpxTxTeWxoPqPqPqxTxTeGXjfaWWxTxTyFxTPqPqPqPqPqxTxTZrZrZrHkMGZrZrFkEWEWZrZrZrMGZrZrMGMGMGMGZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-PqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqxVPqPqPqPqPqPqPqPqPqPqARuaxVPqPqPqPqPqPqPqPqPqPqUsPqPqPqPqPqPqPqPqPqPqfiSgPqPqDGliPqPqPqPqPqxTxTdIZrFkZrZrZrFkEWEWEWZrZrZrMGZrZroYZroYoYZrDZoYZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-PqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqMFPqPqPqPqPqPqPqPqPqPqARJjMFPqPqPqPqshMohqeRqSPqPqPqPqPqPqPqPqPqPqPqPqfilMPqPqPqARPqPqPqPqxTxTZrZrZrMGeVZrFkEWaaEWoYoYZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-PqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqAJPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqnauakJPqPqPqPqPquyuyuyPqPqPqPqPqPqPqPqPqPqOfKRPqqhhxPqPqPqtIPqPqPqxTxTZrDZZrFkZrDZZrFkEWaaaaoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-xTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTJpfaxTxTxTxTxTxTxTxTPqPqPqxTxTxTxTxTxTxTxTxTxTxTxTxTxTUrGgxTjNxTxTxTxTxTPqPqPqPqPqPqPqxTxTxTxTTKzGxTdDlfxTxTgIyFxTxTxTxTxTZrZrZrMGDZFkZrEWaaaaoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrZrZrZrZrZrZrZrZrMGZrMGWEZrZrWEZrvuZrZrZrZrWEWEZruQbqFbZrWEZrZrxTxTxTjNxTdsdwdsgcgQhngQgFgpgpgdxTPqPqPqxTakalalelelalalkfalalelelakalakeBPqPqPqxTcaacachaacaccaPexTxTPqPqPqPqPqxTxTZrZrvuDZMGMGZrEWEWEWZrZrZrMGMGMGMGMGZrMGZrMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+xTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTJpfaxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTPqPqPqknGgjNxTxTxTdzkhkikjkkhohpxTxTeWxoPqPqPqxTxTeGXjklWWxTxTyFxTPqPqPqPqPqxTxTZrZrZrHkMGZrZrFkEWEWZrZrZrMGZrZrMGMGMGMGZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+PqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqxVPqPqPqPqPqPqPqPqPqPqARkpxVPqPqPqPqPqPqPqPqPqPqUsPqPqPqPqPqPqPqPqPqPqfikqPqPqDGliPqPqPqPqPqxTxTdIZrFkZrZrZrFkEWEWEWZrZrZrMGZrZroYZroYoYZrDZoYZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+PqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqMFPqPqPqPqPqPqPqPqPqPqARkrMFPqPqPqPqshMohqeRqSPqPqPqPqPqPqPqPqPqPqPqPqfiksPqPqPqARPqPqPqPqxTxTZrZrZrMGeVZrFkEWaaEWoYoYZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+PqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqAJPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqPqnakpkJPqPqPqPqPquyuyuyPqPqPqPqPqPqPqPqPqPqOfKRPqqhhxPqPqPqtIPqPqPqxTxTZrDZZrFkZrDZZrFkEWaaaaoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+xTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTxTJpfaxTxTxTxTxTxTxTxTPqPqPqxTxTxTxTxTxTxTxTxTxTxTxTxTxTknGgxTjNxTxTxTxTxTPqPqPqPqPqPqPqxTxTxTxTTKzGxTdDlfxTxTgIyFxTxTxTxTxTZrZrZrMGDZFkZrEWaaaaoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrVxCIZrVxZrZrWEWEDZZrZrZrWEWEDZZrMGgrZrZrvuZrZrZrmTbqxTZrVxZrZrZrjNxTPqPqPqxTcacdeldBelcdcadGbebehzaZaZaZiHaZaZhrhseyjXiIPqPqXxshududWWfafaacacachtacacacgAdAdAaZaZaZhuaZaZaZaZaZZrFkFkZraaaaEWoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrZrZrDZVxozZrVxCIZrZrozZrVxCIZrZrZrZrZrZrvuvuZrvuZrZrxTaZaZbcaZaZaZxTPqPqPqxTcahvhwawhygvcaZrbeiJiKbhbeiLiMiNaZfafafafaWWjYxUhehBnoRCxuyExuaccfcghCchciacZrxTxTaZEXgwhEaZbKIBbKaZZrMGHkHkEWaaEWZrZrZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
-ZrZrozZrZrZrMGZrZrZrZrZrMGZrZrZrZrHVZrMGZrHkxTWvvuozZrokaZcxbjbjiOaZxTPqPqPqxTcagshFawawawcaxTbeiPiQiRaZbhbhdOaZhGyExuhHhIhHhxhJRCplxTZrxTxTclbhbhbhbhhKhLxTxTdIaZJrLvaoaZaoaoaoaZFkZrHkZrEWaaEWZrMGZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrZrZrDZVxozZrVxCIZrZrozZrVxCIZrZrZrZrZrZrvuvuZrvuZrZrxTaZaZbcaZaZaZxTPqPqPqxTcahvhwawhygvcaZrbeiJiKbhbeiLiMiNaZfafafafaWWjYxUhehBnokuxukvxuaccfcghCchciacZrxTxTaZEXgwhEaZbKIBbKaZZrMGHkHkEWaaEWZrZrZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
+ZrZrozZrZrZrMGZrZrZrZrZrMGZrZrZrZrHVZrMGZrHkxTWvvuozZrokaZcxbjbjiOaZxTPqPqPqxTcagshFawawawcaxTbeiPiQiRaZbhbhdOaZhGkvxukwhIkohxhJkuplxTZrxTxTclbhbhbhbhhKhLxTxTdIaZJrLvaoaZaoaoaoaZFkZrHkZrEWaaEWZrMGZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZGZrVxZrZrzxYGZrZrZrZrzxYGZrZrxTZrZrxTZrZrxTHSZrZrZrxTxTaZczcxbjbjaZxTPqPqPqxTdehMawawhNgycaxTdCiTiUiRbcbhhOiVaZjNxTxTPqPqPqPqPqxTxTZrdGZrxTaccobhcqbhcracxTxTxTBjLHLvaoSKaoaohPhuFkZrHkZraaaaEWZrZrZrMGMGMGoYZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 WEZrZrZrZrZrYGWEZrWEZrZrWEWEZrZrZrxTxTZrYGZrZrZrZrzxYGxTaZdHcxbjbjaZxTPqPqPqjNcaawawawawawcaxTaZbhbhiWaZbehzaZaZxTxTedPqPqPqPqxTeBxTxTdIdJxTacacacceacacacevxTxTaZaoaoaoaZaoaoaoaZMGZrZrZrEWEWZrZrZrZrMGMGMGMGMGMGZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY
 ZrWEDZZrWEYGYGWEZrZrCIYGWEWEWECICIZrZrZrYGacacbcacacacxTaZcxbjbjcCaZxTPqPqPqxTcagxjPhQgzhRcaxTaZaZdKaZaZdLdMdMgAdAfcsxGPPqCxeWeWxoxTevZrZrxTxTxTxTxTxTxTxTxTxTxTSKaoaojVaZaobKbKaZZrZrZrEWEWEWZrZrZrMGZrPnMGSqMGSqZrZroYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoYoY


### PR DESCRIPTION
- Whitelists UN combative roles and generally reduces UN available slots (until playerbase can play the mode properly)
- Gives negatives points for killing noncombative UN roles
- "Outcasts" UN killers from their original warband
- Gives significant points and loot for UN killers heads'
- Removes the pistol from the UN Doctor
- Partially reinforces UN defences and gives lockable doors to the Hospital (keys available in the lobby)