### PR TITLE
Potential warlords machete fix + Temp epoch swap rights for trialmins

### DIFF
--- a/code/game/mob/living/carbon/human/human_defense.dm
+++ b/code/game/mob/living/carbon/human/human_defense.dm
@@ -82,15 +82,6 @@ bullet_act
 					last_harmed = H
 					H.civilization = "Killer"
 
-	else if (map.ID == MAP_AFRICAN_WARLORDS)
-		var/mob/living/human/H = user
-		if (W.sharp && !istype(W, /obj/item/weapon/reagent_containers) && istype(W))
-			if (src.stat != DEAD && H.civilization != "CIVILIAN")
-				if (H.civilization == "CIVILIAN")
-					return ..(W, user)
-				else
-					last_harmed = H
-
 	else
 		return ..(W, user)
 

--- a/code/game/objects/map_metadata/port_arthur.dm
+++ b/code/game/objects/map_metadata/port_arthur.dm
@@ -33,12 +33,12 @@
 /obj/map_metadata/port_arthur/job_enabled_specialcheck(var/datum/job/J)
 	..()
 	if (istype(J, /datum/job/japanese))
-		if (J.is_coldwar || J.is_ww2|| J.is_prison || J.is_yakuza || J.is_samurai == TRUE)
+		if (J.is_coldwar || J.is_ww2 || J.is_prison || J.is_yakuza || J.is_samurai == TRUE)
 			. = FALSE
 		else
 			. = TRUE
 	if (istype(J, /datum/job/russian))
-		if (J.is_ww2 || J.is_rcw || (J.is_prison || J.is_yeltsin || J.is_grozny || J.is_modernday))
+		if (J.is_ww2 || J.is_rcw || J.is_prison || J.is_yeltsin || J.is_grozny || J.is_modernday || J.is_ukrainerussowar)
 			. = FALSE
 		else
 			. = TRUE

--- a/code/modules/admin/verbs/vote.dm
+++ b/code/modules/admin/verbs/vote.dm
@@ -16,7 +16,7 @@
 /client/proc/start_epochswap_vote()
 	set category = "Server"
 	set name = "Start Epoch Vote"
-	if (!check_rights(R_ADMIN))
+	if (!check_rights(R_TRIALADMIN)) //Temporary solution, change back to R_ADMIN when enough true "Knight" staff.
 		return
 	if (processes.epochswap)
 		processes.epochswap.admin_triggered = TRUE


### PR DESCRIPTION
- Machete bug was likely caused in human_defense.dm, which would need be corrected in the future in order to prevent killing UN with a machete to avoid consequences.

- Makes trialmins able to trigger an epoch swap in game for when it bugs. Should be reverted when more full admins are avaiable. It's only a temporary solution until there's more full staff on the server and/or the epochswap bug gets fixed
