### PR TITLE
Makes all officers able to do announcement + Removes whitelist from UN doctors and engineers

### DIFF
--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -721,7 +721,7 @@ var/global/redirect_all_players = null
 		var/mob/living/human/H = character
 		if (H.original_job_title == "FBI officer" || H.original_job_title == "KGB officer")
 			H.verbs += /mob/living/human/proc/find_hvt
-		if (H.original_job.is_commander)
+		if (H.original_job.is_commander || H.original_job.is_officer)
 			H.verbs += /mob/living/human/proc/Commander_Announcement
 		if (map && map.ID == MAP_THE_ART_OF_THE_DEAL)
 			if (H.original_job_title == "Rednikov Industries CEO" || H.original_job_title == "Giovanni Blu Stocks CEO" || H.original_job_title == "Kogama Kraftsmen CEO" || H.original_job_title == "Goldstein Solutions CEO" || H.original_job_title == "McKellen Manager" || H.original_job_title == "Police Supervisor")

--- a/code/modules/1713/jobs/civilian.dm
+++ b/code/modules/1713/jobs/civilian.dm
@@ -2744,6 +2744,7 @@
 	min_positions = 2
 	max_positions = 4
 	additional_languages = list("Zulu" = 20)
+	whitelisted = FALSE
 
 /datum/job/civilian/unitednations/doctor/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
@@ -2783,6 +2784,7 @@
 	can_be_female = FALSE
 	selection_color = "#53ADD0"
 	additional_languages = list("Zulu" = 10)
+	whitelisted = FALSE
 
 	min_positions = 2
 	max_positions = 2


### PR DESCRIPTION
- All roles defined as officer are able to do faction announcements (may need a few tweaks in the future)
- UN doctors and engineers are no longer whitelisted