### PR TITLE
Updates simple_animal/hostile FindTarget range

### DIFF
--- a/code/game/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/game/mob/living/simple_animal/hostile/hostile.dm
@@ -7,7 +7,7 @@
 /mob/living/simple_animal/proc/FindTarget()
 	var/atom/T = null
 	stop_automated_movement = FALSE
-	var/list/the_targets = ListTargets(13)
+	var/list/the_targets = ListTargets(7) // range that simple_animal will look for targets
 	if (behaviour == "hostile")
 		stance = HOSTILE_STANCE_ATTACK
 		for(var/mob/living/ML in the_targets)


### PR DESCRIPTION
Previous range was about two times the range of player's range without scopes.
Even if animals can really realize dangers before most of us can, this leads to hyper aggressive behavior #913 .

The choosen value, 7, is the same as player's range.

with PR #1254 
closes #913 