### PR TITLE
New lobby icons

### DIFF
--- a/code/game/objects/map_metadata/kursk.dm
+++ b/code/game/objects/map_metadata/kursk.dm
@@ -2,7 +2,7 @@
 /obj/map_metadata/kursk
 	ID = MAP_KURSK
 	title = "Kursk"
-	lobby_icon_state = "ww2"
+	lobby_icon_state = "kursk"
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall/temperate)
 	respawn_delay = 1200
 

--- a/code/game/objects/map_metadata/omaha.dm
+++ b/code/game/objects/map_metadata/omaha.dm
@@ -1,7 +1,7 @@
 /obj/map_metadata/omaha
 	ID = MAP_OMAHA
 	title = "Omaha Beach"
-	lobby_icon_state = "ww2"
+	lobby_icon_state = "omaha"
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall,/area/caribbean/no_mans_land/invisible_wall/one,/area/caribbean/no_mans_land/invisible_wall/two)
 	respawn_delay = 1200
 	var/victory_time = 24000

--- a/code/game/objects/map_metadata/pavlov_house.dm
+++ b/code/game/objects/map_metadata/pavlov_house.dm
@@ -1,7 +1,7 @@
 /obj/map_metadata/pavlov_house
 	ID = MAP_PAVLOV_HOUSE
 	title = "Pavlov House"
-	lobby_icon_state = "ww2"
+	lobby_icon_state = "stalingrad"
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall,/area/caribbean/no_mans_land/invisible_wall/one,/area/caribbean/no_mans_land/invisible_wall/two)
 	respawn_delay = 1200
 	no_winner ="The House stays under Soviet control, stalling the German advance."

--- a/code/game/objects/map_metadata/reichstag.dm
+++ b/code/game/objects/map_metadata/reichstag.dm
@@ -2,7 +2,7 @@
 /obj/map_metadata/reichstag
 	ID = MAP_REICHSTAG
 	title = "Reichstag"
-	lobby_icon_state = "ww2"
+	lobby_icon_state = "reichstag"
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall,/area/caribbean/no_mans_land/invisible_wall/one,/area/caribbean/no_mans_land/invisible_wall/two)
 	respawn_delay = 1200
 	no_winner ="The reichstag is under German control."

--- a/code/game/objects/map_metadata/sibersyn.dm
+++ b/code/game/objects/map_metadata/sibersyn.dm
@@ -2,7 +2,7 @@
 /obj/map_metadata/sibersyn
 	ID = MAP_SIBERSYN
 	title = "Battle of the Bridges"
-	lobby_icon_state = "ww1"
+	lobby_icon_state = "rcw"
 	no_winner ="The battle ends in stalemate."
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall/tundra)
 	respawn_delay = 600

--- a/code/game/objects/map_metadata/stalingrad.dm
+++ b/code/game/objects/map_metadata/stalingrad.dm
@@ -2,7 +2,7 @@
 /obj/map_metadata/stalingrad
 	ID = MAP_STALINGRAD
 	title = "Stalingrad"
-	lobby_icon_state = "ww2"
+	lobby_icon_state = "stalingrad"
 	no_winner ="The battle for the city is still going on."
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall/taiga,/area/caribbean/no_mans_land/invisible_wall/taiga/one,/area/caribbean/no_mans_land/invisible_wall/taiga/two)
 	respawn_delay = 0

--- a/code/game/objects/map_metadata/tsaritsyn.dm
+++ b/code/game/objects/map_metadata/tsaritsyn.dm
@@ -2,7 +2,7 @@
 /obj/map_metadata/tsaritsyn
 	ID = MAP_TSARITSYN
 	title = "Tsaritsyn"
-	lobby_icon_state = "ww1"
+	lobby_icon_state = "rcw"
 	no_winner ="The church is under Soviet control."
 	caribbean_blocking_area_types = list(/area/caribbean/no_mans_land/invisible_wall,/area/caribbean/no_mans_land/invisible_wall/one,/area/caribbean/no_mans_land/invisible_wall/two)
 	respawn_delay = 600


### PR DESCRIPTION
- Reworks the Caloocan/Phillipine-American war lobby icon
- Adds 4 new WW2 lobby icons: Omaha, Stalingrad, Kursk and Reichstag
- Adds a lobby icon for Russian Civil War maps
![stalingrad](https://user-images.githubusercontent.com/76013553/164751045-a275ca34-7508-4657-af4b-9c7f40aa1325.png)
![rcw](https://user-images.githubusercontent.com/76013553/164751069-d3750a90-d9ff-4570-9983-34838ad9c98a.png)
![kursk](https://user-images.githubusercontent.com/76013553/164751092-46004193-d394-4a99-886c-afe0fe14bd0f.png)
![omaha](https://user-images.githubusercontent.com/76013553/164751116-37151cc8-f1b5-4006-b572-88da1e983722.png)
![reichstag](https://user-images.githubusercontent.com/76013553/164751140-77cd1dbd-ed3a-41bd-aa0d-8602103ddeb1.png)

