### PR TITLE
Reworking batons

### DIFF
--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -231,6 +231,49 @@
 	force_divisor = 0.8 // 32 with hardness 40 (wood)
 	thrown_force_divisor = 1.6 // 29 with weight 18 (wood)
 
+/obj/item/weapon/material/classic_baton
+	name = "baton"
+	desc = "A wooden truncheon for beating criminal scum."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "baton"
+	item_state = "classic_baton"
+	block_chance = 27
+	force_divisor = 5
+	thrown_force_divisor = 3
+	force = 1
+	slot_flags = SLOT_BELT | SLOT_BACK
+	value = 0
+	cooldownw = 8
+	flammable = TRUE
+	attack_verb = list("thwacked", "hit", "clonked", "batted", "slammed", "smacked", "poked", "slapped")
+	hitsound = 'sound/weapons/kick.ogg'
+	drawsound = 'sound/items/unholster_sword01.ogg'
+	sharp = FALSE
+	edge = FALSE
+	default_material = "softwood"
+
+/obj/item/weapon/material/classic_baton/guard
+	name = "baton"
+	desc = "A Heavy wooden truncheon for beating criminal scum this one is made of harder wood material."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "baton"
+	item_state = "classic_baton"
+	block_chance = 27
+	force_divisor = 5
+	thrown_force_divisor = 3
+	force = 1
+	slot_flags = SLOT_BELT | SLOT_BACK
+	value = 0
+	cooldownw = 8
+	flammable = TRUE
+	attack_verb = list("thwacked", "hit", "clonked", "batted", "slammed", "smacked", "poked", "slapped")
+	hitsound = 'sound/weapons/kick.ogg'
+	drawsound = 'sound/items/unholster_sword01.ogg'
+	sharp = FALSE
+	edge = FALSE
+	default_material = "hardwood"
+
+
 /obj/item/weapon/material/quarterstaff
 	name = "quarterstaff"
 	sharp = FALSE

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -231,6 +231,7 @@
 	force_divisor = 0.8 // 32 with hardness 40 (wood)
 	thrown_force_divisor = 1.6 // 29 with weight 18 (wood)
 
+//New batons
 /obj/item/weapon/material/classic_baton
 	name = "baton"
 	desc = "A wooden truncheon for beating criminal scum."
@@ -238,7 +239,7 @@
 	icon_state = "baton"
 	item_state = "classic_baton"
 	block_chance = 27
-	force_divisor = 5
+	force_divisor = 1
 	thrown_force_divisor = 3
 	force = 1
 	slot_flags = SLOT_BELT | SLOT_BACK
@@ -246,32 +247,25 @@
 	cooldownw = 8
 	flammable = TRUE
 	attack_verb = list("thwacked", "hit", "clonked", "batted", "slammed", "smacked", "poked", "slapped")
-	hitsound = 'sound/weapons/kick.ogg'
-	drawsound = 'sound/items/unholster_sword01.ogg'
+	hitsound = 'sound/weapons/pierce.ogg'
+	drawsound = 'sound/weapons/hiddenblade_deploy.ogg'
 	sharp = FALSE
 	edge = FALSE
 	default_material = "softwood"
 
 /obj/item/weapon/material/classic_baton/guard
-	name = "baton"
 	desc = "A Heavy wooden truncheon for beating criminal scum this one is made of harder wood material."
-	icon = 'icons/obj/weapons.dmi'
-	icon_state = "baton"
-	item_state = "classic_baton"
-	block_chance = 27
-	force_divisor = 5
-	thrown_force_divisor = 3
-	force = 1
-	slot_flags = SLOT_BELT | SLOT_BACK
-	value = 0
-	cooldownw = 8
-	flammable = TRUE
-	attack_verb = list("thwacked", "hit", "clonked", "batted", "slammed", "smacked", "poked", "slapped")
-	hitsound = 'sound/weapons/kick.ogg'
-	drawsound = 'sound/items/unholster_sword01.ogg'
-	sharp = FALSE
-	edge = FALSE
 	default_material = "hardwood"
+	force_divisor = 1
+	block_chance = 27
+	cooldownw = 8
+
+/obj/item/weapon/material/classic_baton/guard/metal
+	desc = "A Heavy metal truncheon for beating criminal scum this one is made of iron and likely to injure someone quckily aim anywhere but the head!."
+	default_material = "iron"
+	force_divisor = 1
+	block_chance = 27
+	cooldownw = 10
 
 
 /obj/item/weapon/material/quarterstaff

--- a/code/modules/1713/apparel_earlymodern.dm
+++ b/code/modules/1713/apparel_earlymodern.dm
@@ -625,7 +625,7 @@
 /obj/item/weapon/storage/belt/jap/abashiri_guard
 /obj/item/weapon/storage/belt/jap/abashiri_guard/New()
 	..()
-	new /obj/item/weapon/melee/classic_baton/guard(src)
+	new /obj/item/weapon/material/classic_baton/guard(src)
 	new /obj/item/weapon/handcuffs(src)
 	new /obj/item/weapon/handcuffs(src)
 	new /obj/item/weapon/handcuffs(src)
@@ -637,7 +637,7 @@
 /obj/item/weapon/storage/belt/jap/camp_guard_SS/New()
 	..()
 	new /obj/item/weapon/whistle(src)
-	new /obj/item/weapon/melee/classic_baton/guard(src)
+	new /obj/item/weapon/material/classic_baton/guard(src)
 	new /obj/item/weapon/handcuffs(src)
 	new /obj/item/weapon/handcuffs(src)
 	new /obj/item/weapon/handcuffs(src)

--- a/code/modules/1713/apparel_worldwars.dm
+++ b/code/modules/1713/apparel_worldwars.dm
@@ -2782,7 +2782,7 @@ obj/item/clothing/head/ww2/chicap2
 
 /obj/item/weapon/storage/belt/gulagguard/filled/New()
 	..()
-	new /obj/item/weapon/melee/classic_baton(src)
+	new /obj/item/weapon/material/classic_baton(src)
 	new /obj/item/stack/medical/bruise_pack/bint(src)
 	new /obj/item/weapon/handcuffs(src)
 	new /obj/item/weapon/handcuffs(src)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -583,6 +583,7 @@ var/list/name_to_material
 	integrity = 175
 	icon_base = "wood"
 	icon_colour = null
+	weight = 12
 
 /material/wood/soft
 	name = "softwood"
@@ -590,6 +591,7 @@ var/list/name_to_material
 	integrity = 80
 	door_icon_base = "wood"
 	icon_colour = "#D2BA9C"
+	weight = 5
 
 /material/bamboo
 	name = "bamboo"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -583,7 +583,8 @@ var/list/name_to_material
 	integrity = 175
 	icon_base = "wood"
 	icon_colour = null
-	weight = 12
+	weight = 13
+
 
 /material/wood/soft
 	name = "softwood"
@@ -591,7 +592,7 @@ var/list/name_to_material
 	integrity = 80
 	door_icon_base = "wood"
 	icon_colour = "#D2BA9C"
-	weight = 5
+	weight = 10
 
 /material/bamboo
 	name = "bamboo"


### PR DESCRIPTION
Changed weight of softwood and hardwood materials from materials.dm
Added 2 /obj/item/weapon/material/ baton types a heavy version and a normal version
to the misc folder


Goal of this is to make batons a better to use and with hem having a chance to parry and block attacks making them much better Self defense weapon and more useful for guards and police so they  can rely more on there weapon not being disarmed as often

this PR was codded at 1 AM gonna be needing feedback on this one this PR IS NOT done



