### PR TITLE
Red Menace quick fixes

### DIFF
--- a/code/modules/1713/jobs/red_menace.dm
+++ b/code/modules/1713/jobs/red_menace.dm
@@ -304,7 +304,6 @@
 		uniform.attackby(mag, H)
 		var/obj/item/ammo_magazine/ak74/mag2 = new /obj/item/ammo_magazine/ak74(null)
 		uniform.attackby(mag2, H)
-	H.equip_to_slot_or_del(new /obj/item/weapon/key/soviet(H), slot_l_store)
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
 	if (prob(33))

--- a/code/modules/1713/vending.dm
+++ b/code/modules/1713/vending.dm
@@ -1018,6 +1018,30 @@ obj/structure/vending/hezammo
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen/full = 30,
 		/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/russian = 50,
 	)
+/obj/structure/vending/sovafghan/soviet/apparel/New()
+	if (map.ID != MAP_SOVAFGHAN)
+		products = list(
+			/obj/item/clothing/shoes/combat = 15,
+			/obj/item/clothing/shoes/soldiershoes = 10,
+			/obj/item/clothing/under/afghanka = 20,
+			/obj/item/clothing/accessory/armor/coldwar/plates/b3 = 20,
+			/obj/item/clothing/suit/storage/jacket/afghanka = 15,
+			/obj/item/clothing/mask/gas/russia = 15,
+			/obj/item/clothing/head/helmet/modern/ssh_68 = 20,
+			/obj/item/clothing/accessory/storage/webbing/russian = 10,
+			/obj/item/weapon/storage/belt/smallpouches/green = 10,
+			/obj/item/weapon/storage/belt/smallpouches = 10,
+			/obj/item/weapon/storage/belt/largepouches = 10,
+			/obj/item/weapon/storage/belt/largepouches/green = 10,
+			/obj/item/weapon/storage/backpack/sovpack = 20,
+			/obj/item/clothing/accessory/holster/armpit = 5,
+			/obj/item/stack/medical/bruise_pack/bint = 10,
+			/obj/item/weapon/material/shovel/trench = 10,
+			/obj/item/weapon/attachment/bayonet = 15,
+			/obj/item/flashlight/militarylight/alt = 15,
+			/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen/full = 30,
+			/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/russian = 50,
+		)
 
 /obj/structure/vending/sovafghan/soviet/weapons
 	name = "Soviet Army weapon rack"


### PR DESCRIPTION
- Removes the soviet key from Soviet soldiers
- Removes the Kandahar map from the vendor on maps that are not Sovafghan.