### PR TITLE
Rpd/Rpk74 fix

### DIFF
--- a/code/modules/1713/_magsmodern.dm
+++ b/code/modules/1713/_magsmodern.dm
@@ -217,7 +217,7 @@
 	name = "rpk74 drum (7.62x39)"
 	icon_state = "rpk74"
 	mag_type = MAGAZINE
-	caliber = "a762x39"
+	caliber = "a556x39"
 	w_class = 3
 
 	ammo_type = /obj/item/ammo_casing/a762x39
@@ -228,7 +228,7 @@
 	name = "rpk74 magazine (7.62x39)"
 	icon_state = "rpk74mag"
 	mag_type = MAGAZINE
-	caliber = "a762x39"
+	caliber = "a556x39"
 	w_class = 3
 
 	ammo_type = /obj/item/ammo_casing/a762x39

--- a/code/modules/1713/weapons/guns/mg/lmg.dm
+++ b/code/modules/1713/weapons/guns/mg/lmg.dm
@@ -300,12 +300,13 @@
 	load_delay = 50
 	slowdown = 0.8
 
-/obj/item/weapon/gun/projectile/automatic/rpd
+
+
 	name = "RPD machine gun"
 	desc = "A soviet machinegun chambered in 7.62x39 rounds."
-	icon_state = "rpk"
-	item_state = "rpk"
-	base_icon = "rpk"
+	icon_state = "rpd"
+	item_state = "rpd"
+	base_icon = "rpd"
 	caliber = "a762x39"
 	magazine_type = /obj/item/ammo_magazine/rpd
 	good_mags = list(/obj/item/ammo_magazine/rpd)
@@ -322,12 +323,12 @@
 	slowdown = 0.6
 
 /obj/item/weapon/gun/projectile/automatic/rpk74
-	name = "RPK74 maching gun"
+	name = "RPK74 machine gun"
 	desc = "A soviet machinegun chambered in 7.62x39 rounds."
-	icon_state = "rpd"
-	item_state = "rpd"
-	base_icon = "rpd"
-	caliber = "a762x39"
+	icon_state = "rpk74"
+	item_state = "rpk74"
+	base_icon = "rpk74"
+	caliber = "a556x39"
 	magazine_type = /obj/item/ammo_magazine/rpk74
 	good_mags = list(/obj/item/ammo_magazine/rpk74, /obj/item/ammo_magazine/rpk74mag, /obj/item/ammo_magazine/ak74)
 	weight = 5

--- a/code/modules/1713/weapons/guns/mg/lmg.dm
+++ b/code/modules/1713/weapons/guns/mg/lmg.dm
@@ -300,8 +300,8 @@
 	load_delay = 50
 	slowdown = 0.8
 
-
-
+/obj/item/weapon/gun/projectile/automatic/rpd
+	
 	name = "RPD machine gun"
 	desc = "A soviet machinegun chambered in 7.62x39 rounds."
 	icon_state = "rpd"


### PR DESCRIPTION
fixed the code for the rpk's ammo type and put in the correct code in for both gun's sprites.