### PR TITLE
Quickfix: Portable radios removed from the SLs on Modern maps

### DIFF
--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -921,7 +921,7 @@ var/global/redirect_all_players = null
 				H.verbs += /mob/living/human/proc/Squad_Announcement
 			if (H.faction_text == map.faction1) //lets check the squads and see what is the one with the lowest ammount of members
 				if (H.original_job.is_officer || H.original_job.is_squad_leader || H.original_job.is_commander)
-					if (map.ordinal_age >= 6 && map.ordinal_age <= 8)
+					if (map.ordinal_age >= 6 && map.ordinal_age < 8)
 						if (map.ID != MAP_YELTSIN && map.ID != MAP_WACO)
 							H.equip_to_slot_or_del(new/obj/item/weapon/radio/faction1(H),slot_back)
 				if (H.original_job.is_squad_leader)


### PR DESCRIPTION
Fixes SLs spawning with a back radio on modern maps (defined by ordinal age = 8) fully. Fix wasn't implemented for faction1 radio types, now it is.