### PR TITLE
Removing warlords from mapswap

### DIFF
--- a/code/processes/mapswap.dm
+++ b/code/processes/mapswap.dm
@@ -131,7 +131,7 @@
 				MAP_HUE = 15,
 				MAP_RETREAT = 6,
 				//MAP_FACTORY = 15,
-				MAP_AFRICAN_WARLORDS = 10,
+				//MAP_AFRICAN_WARLORDS = 10,
 				MAP_WACO = 0,
 			)
 		else if (epoch == "World War II (1931-1948)")


### PR DESCRIPTION
- Removing warlords from mapswap as the gameplay, team balance, and end of round are broken.