### PR TITLE
Removes "Fagerberg" from Old Norse names

### DIFF
--- a/config/names/last_oldnorse.txt
+++ b/config/names/last_oldnorse.txt
@@ -33,8 +33,7 @@ Ericson
 Erling 
 Eskelson 
 Eskildsen 
-Estenson 
-Fagerberg 
+Estenson
 Falk 
 Nyberg 
 Nybo 


### PR DESCRIPTION
In order for players to not get banned by the bot incorrectly.