### PR TITLE
Roof fix for "new" tanks and MT-LB.

### DIFF
--- a/code/game/mob/living/carbon/human/human_helpers.dm
+++ b/code/game/mob/living/carbon/human/human_helpers.dm
@@ -263,7 +263,7 @@
 	var/obj/structure/vehicleparts/frame/found = null
 
 	for (var/image/tmpimg in client.images)
-		if (tmpimg.icon == 'icons/obj/vehicles/vehicleparts.dmi' || tmpimg.icon == 'icons/obj/vehicles/vehicles96x96.dmi')
+		if (tmpimg.icon == 'icons/obj/vehicles/vehicleparts.dmi' || tmpimg.icon == 'icons/obj/vehicles/vehicles96x96.dmi' || tmpimg.icon == 'icons/obj/vehicles/vehicles128x128.dmi' || tmpimg.icon == 'icons/obj/vehicles/apcparts.dmi' || tmpimg.icon == 'icons/obj/vehicles/tankparts.dmi')
 			client.images.Remove(tmpimg)
 	for (var/obj/structure/vehicleparts/frame/FRL in loc)
 		found = FRL


### PR DESCRIPTION
An exception wasn't made in human_helpers.dm for roofs to disappear for this type of vehicle sprites, causing the roof not to disappear on some apc/tank types (for instance the "T-72s" on Sovafghan, the MT-LB).