### PR TITLE
Automatically fits the viewport on login (+ makes it togglable in preferences)

### DIFF
--- a/code/game/mob/login.dm
+++ b/code/game/mob/login.dm
@@ -60,3 +60,6 @@
 
 	//set macro to normal incase it was overriden.
 	winset(client, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
+
+	if (client.is_preference_enabled(/datum/client_preference/fit_viewport))
+		client.fit_viewport()

--- a/code/game/mob/new_player/login.dm
+++ b/code/game/mob/new_player/login.dm
@@ -26,6 +26,9 @@
 
 	new_player_panel()
 
+	if (client.is_preference_enabled(/datum/client_preference/fit_viewport))
+		client.fit_viewport()
+
 	spawn (10)
 		if (client)
 			client.playtitlemusic()

--- a/code/modules/client/fullscreen.dm
+++ b/code/modules/client/fullscreen.dm
@@ -2,6 +2,8 @@ client/New()
 	..()
 	winset(src, "mainwindow", "can-resize=true;titlebar=true;menu=menu")
 	winset(src, "mainwindow.mainvsplit", "splitter=75")
+	if(is_preference_enabled(/datum/client_preference/fit_viewport))
+		fit_viewport()
 
 client/verb/updateFullscreen()
 	set name = "updateFullscreen"

--- a/code/modules/client/preferencesSQLite/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preferencesSQLite/preference_setup/global/setting_datums.dm
@@ -146,6 +146,12 @@ var/list/_client_preferences_by_type
 	enabled_description = "Show"
 	disabled_description = "Hide"
 
+/datum/client_preference/fit_viewport
+	description = "Auto-adjust game screen"
+	key = "FIT_VIEWPORT"
+	enabled_description = "Yes"
+	disabled_description = "No"
+
 /********************
 * Admin Preferences *
 ********************/

--- a/code/modules/client/preferencesSQLite/preferences.dm
+++ b/code/modules/client/preferencesSQLite/preferences.dm
@@ -71,7 +71,7 @@ var/list/preferences_datums = list()
 	var/list/preferences_enabled = list("CHAT_OVERLAY","CHAT_TIPS","SOUND_MIDI", "SOUND_LOBBY", "SOUND_AMBIENCE",
 		"CHAT_GHOSTEARS", "CHAT_GHOSTSIGHT", "CHAT_GHOSTRADIO", "CHAT_SHOWICONS",
 		"SHOW_TYPING", "CHAT_OOC", "CHAT_LOOC", "CHAT_DEAD", "SHOW_PROGRESS",
-		"CHAT_DEBUGLOGS", "CHAT_PRAYER", "SOUND_ADMINHELP")
+		"FIT_VIEWPORT", "CHAT_DEBUGLOGS", "CHAT_PRAYER", "SOUND_ADMINHELP")
 
 	var/list/preferences_disabled = list("CHAT_TTS")
 


### PR DESCRIPTION
Game screen and chatbox should now fit automatically on login. 
It can be toggled on/off in Global Preferences (OOC tab > Character & Preferences Setup > Global > Auto-adjust game screen).