### PR TITLE
Debug: Fat oil color quick fix

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -529,7 +529,7 @@
 	id = "fat_oil"
 	description = "A thick and smelling oil. Good for seasoning and lamps."
 	taste_description = "greasy"
-	color = "##9B7653"
+	color = "#9B7653"
 
 /datum/reagent/drink/fat_oil/affect_blood(var/mob/living/human/M, var/alien, var/removed)
 	..()


### PR DESCRIPTION
Removes a "#" causing runtime warnings.