### PR TITLE
Cocoa standardization

### DIFF
--- a/code/modules/1713/snacks.dm
+++ b/code/modules/1713/snacks.dm
@@ -9,7 +9,7 @@
 		reagents.add_reagent("pervitin", TRUE)
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("sugar", 2)
-		reagents.add_reagent("coco", 2)
+		reagents.add_reagent("cocoa", 2)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chocolatebar
@@ -22,6 +22,6 @@
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("sugar", 2)
-		reagents.add_reagent("coco", 2)
+		reagents.add_reagent("cocoa", 2)
 		bitesize = 4
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -107,10 +107,10 @@
 	new /obj/effect/decal/cleanable/flour(T)
 /datum/reagent/nutriment/barleyflour/touch_turf(var/turf/T)
 	new /obj/effect/decal/cleanable/flour(T)
-/datum/reagent/nutriment/coco
-	name = "Coco Powder"
-	id = "coco"
-	description = "A fatty, bitter paste made from coco beans."
+/datum/reagent/nutriment/cocoa
+	name = "Cocoa Powder"
+	id = "cocoa"
+	description = "A fatty, bitter paste made from cocoa beans."
 	taste_description = "bitterness"
 	taste_mult = 1.3
 	reagent_state = SOLID

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -768,7 +768,7 @@ datum/admins/proc/print_chemical_reactions()
 	name = "Hot Coco"
 	id = "hot_coco"
 	result = "hot_coco"
-	required_reagents = list("water" = 5, "coco" = 1)
+	required_reagents = list("water" = 5, "cocoa" = 1)
 	result_amount = 5
 
 /datum/chemical_reaction/cheesewheel


### PR DESCRIPTION
Renames all instance of "coco" to "cocoa" to avoid confusion with coconuts.