### PR TITLE
Mapswap update to address Highpop + Extra

### DIFF
--- a/code/processes/mapswap.dm
+++ b/code/processes/mapswap.dm
@@ -12,6 +12,7 @@
 		//"Imperial Age (1650-1780)" = 0,
 		//"Industrial Age (1850-1895)" = 0,
 		//"Early Modern Era (1896-1930)" = 0,
+		"PVE (Voyage, Hunt, Colony, Wasteland, Etc)" = 0,
 		"Early Fire Arms (1650-1930)" = 0,
 		"World War II (1931-1948)" = 0,
 		//"Cold War Era (1949-1984)" = 0,
@@ -46,16 +47,29 @@
 			var/obj/map_metadata/voyage/nmap = map
 			nmap.show_stats()
 		if (config.allowedgamemodes == "TDM")
-			epochs = list(
-				"Pre-Firearms (3000 B.C-1650 A.D.)" = 0,
-				"Early Fire Arms (1650-1930)" = 0,
-				"World War II (1931-1948)" = 0,
-				"Modern Fire Arms (1949-2021)" = 0,
-				"HRP TDM (Gulag, Voyage, Occupation, etc)" = 10,
-//				"Chad Mode" = 0,
-				"Battle Royale" = 6,
-				"Fiction" = 0,
-			)
+			if (clients.len > 26)
+				epochs = list(
+					"Pre-Firearms (3000 B.C-1650 A.D.)" = 0,
+					"Early Fire Arms (1650-1930)" = 0,
+					"World War II (1931-1948)" = 0,
+					"Modern Fire Arms (1949-2021)" = 0,
+					"Fiction" = 0,
+					"Battle Royale" = 6,
+					"Chad Mode" = 30,
+				)
+			else
+				epochs = list(
+					"Pre-Firearms (3000 B.C-1650 A.D.)" = 0,
+					"Early Fire Arms (1650-1930)" = 0,
+					"World War II (1931-1948)" = 0,
+					"Modern Fire Arms (1949-2021)" = 0,
+					"PVE (Voyage, Hunt, Colony, Wasteland, Etc)" = 0,
+					"Fiction" = 0,
+					"Battle Royale" = 6,
+					"HRP TDM (Gulag, Voyage, Occupation, etc)" = 10,
+//					"Chad Mode" = 0,
+
+				)
 		else if (config.allowedgamemodes == "RP")
 			epochs = list(
 				//"The Art of the Deal" = 10,
@@ -121,6 +135,8 @@
 				MAP_ROAD_TO_DAK_TO = 0,
 				MAP_COMPOUND = 6,
 				MAP_HUE = 15,
+				MAP_AFRICAN_WARLORDS = 6,
+				MAP_TADOJSVILLE = 12,
 				MAP_MAGISTRAL = 10,
 				MAP_HILL_3234 = 12,
 				MAP_ALLEYWAY = 0,
@@ -129,8 +145,6 @@
 				MAP_GROZNY = 6,
 				MAP_BANK_ROBBERY = 0,
 				MAP_DRUG_BUST = 0,
-				//MAP_FACTORY = 15,
-				//MAP_AFRICAN_WARLORDS = 10,
 				MAP_ARAB_TOWN = 0,
 				MAP_ARAB_TOWN_2 = 0,
 				MAP_HOSTAGES = 0,
@@ -152,9 +166,9 @@
 				MAP_KURSK = 10,
 				MAP_STALINGRAD = 10,
 				MAP_OMAHA = 20,
-//				MAP_IWO_JIMA = 70,
+//				MAP_IWO_JIMA = 40,
 				MAP_FOREST = 20,
-//				MAP_KARELINA = 14,
+				MAP_KARELIA = 14,
 				MAP_INTRAMUROS = 14,
 				MAP_WAKE_ISLAND = 14,
 				MAP_BERLIN = 20,
@@ -175,7 +189,6 @@
 				MAP_MISSIONARY_RIDGE = 10,
 				MAP_NAVAL = 0,
 		//		MAP_SKULLISLAND = 0,
-				MAP_CURSED_ISLAND = 0,
 				MAP_SUPPLY_RAID = 0,
 				MAP_BRIDGE = 0,
 				MAP_RECIFE = 10,
@@ -210,15 +223,26 @@
 		else if (epoch == "HRP TDM (Gulag, Voyage, Occupation, etc)")
 			maps = list(
 //				MAP_FOOTBALL = 8,
-				MAP_GULAG13 = 0,
-				MAP_HUNT = 0,
+				MAP_GULAG13 = 6,
 //				MAP_ABASHIRI = 6,
-				MAP_VOYAGE = 6,
 //				MAP_RIVER_KWAI = 0,
-				MAP_LITTLE_CREEK = 10,
+				MAP_LITTLE_CREEK = 6,
 				MAP_OCCUPATION = 10,
-				MAP_THE_ART_OF_THE_DEAL = 20,
-
+				MAP_THE_ART_OF_THE_DEAL = 18,
+			)
+		else if (epoch == "PVE (Voyage, Hunt, Colony, Wasteland, Etc)")
+			maps = list(
+				MAP_HUNT = 0,
+				MAP_CURSED_ISLAND = 0,
+				MAP_COLONY = 0,
+				MAP_JUNGLE_COLONY = 0,
+				MAP_PIONEERS = 0,
+				MAP_PIONEERS_WASTELAND_2 = 0,
+				MAP_NOMADS_WASTELAND = 0,
+				MAP_NOMADS_WASTELAND_2 = 0,
+				MAP_VOYAGE = 6,
+				MAP_BOHEMIA = 6,
+//				MAP_FOUR_COLONIES = 20,
 			)
 		else if (epoch == "Civilization 13 (Nomads)")
 			maps = list(


### PR DESCRIPTION
- Adds a highpop mode to the tdm mapswap list to address sheer mass of players overcoming the set pop requirements. At  26 players HRP and PVE vote options switched for a chad mode option that opens at 30 players. HRP maps can be swapped to by admins if there is an actual interest in playing them at highpop.
- Splits HRP (still directly competitive team modes with unique rules and high roleplay standards) and PVE maps (maps where all players are on a single team or split into neutral teams and the focus is on player VS the map.) into two separate map vote options.
- Reorders Fiction and BR vote options in the lists slightly because of pop requirements.
- Readds Kerelia and African Warlords to mapswap and adds Tadojsville.