### PR TITLE
Feat/soil nutrition farming ballancing -> Farmers will be farmers

### DIFF
--- a/code/game/mob/living/carbon/human/shit_piss.dm
+++ b/code/game/mob/living/carbon/human/shit_piss.dm
@@ -158,7 +158,7 @@
 	decay = 120*600
 	dry_size = 6
 	dried_type = /obj/item/stack/dung
-	fertilizer_value = 20
+	fertilizer_value = 10
 	New()
 		..()
 		icon_state = pick("animal1", "animal2", "animal3")
@@ -171,7 +171,7 @@
 	value = 0
 	can_stack = TRUE
 	singular_name = "dry dung"
-	fertilizer_value = 20
+	fertilizer_value = 10
 	max_amount = 40
 
 /obj/item/weapon/reagent_containers/food/snacks/poo/throw_impact(atom/hit_atom)

--- a/code/game/mob/living/carbon/human/shit_piss.dm
+++ b/code/game/mob/living/carbon/human/shit_piss.dm
@@ -147,7 +147,7 @@
 	desc = "Makes good fertilizer at least."
 	dry_size = 6
 	dried_type = /obj/item/stack/dung
-	fertilizer_value = 5
+	fertilizer_value = 10
 	New()
 		..()
 		icon_state = pick("animal1", "animal2", "animal3")
@@ -158,7 +158,7 @@
 	decay = 120*600
 	dry_size = 6
 	dried_type = /obj/item/stack/dung
-	fertilizer_value = 10
+	fertilizer_value = 60
 	New()
 		..()
 		icon_state = pick("animal1", "animal2", "animal3")
@@ -171,7 +171,7 @@
 	value = 0
 	can_stack = TRUE
 	singular_name = "dry dung"
-	fertilizer_value = 10
+	fertilizer_value = 20
 	max_amount = 40
 
 /obj/item/weapon/reagent_containers/food/snacks/poo/throw_impact(atom/hit_atom)

--- a/code/game/mob/living/carbon/human/shit_piss.dm
+++ b/code/game/mob/living/carbon/human/shit_piss.dm
@@ -147,6 +147,7 @@
 	desc = "Makes good fertilizer at least."
 	dry_size = 6
 	dried_type = /obj/item/stack/dung
+	fertilizer_value = 5
 	New()
 		..()
 		icon_state = pick("animal1", "animal2", "animal3")
@@ -157,6 +158,7 @@
 	decay = 120*600
 	dry_size = 6
 	dried_type = /obj/item/stack/dung
+	fertilizer_value = 20
 	New()
 		..()
 		icon_state = pick("animal1", "animal2", "animal3")
@@ -169,6 +171,7 @@
 	value = 0
 	can_stack = TRUE
 	singular_name = "dry dung"
+	fertilizer_value = 20
 	max_amount = 40
 
 /obj/item/weapon/reagent_containers/food/snacks/poo/throw_impact(atom/hit_atom)

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -381,6 +381,7 @@
 	var/fertilized = FALSE
 	var/water = 60
 	var/max_water = 60
+	var/plant_nutrition = 100
 
 /obj/structure/farming/plant/New()
 	..()
@@ -916,6 +917,7 @@
 /obj/structure/farming/plant/proc/growth()
 	if (!vstatic)
 		if (stage < 12)
+			soil_nutrition_proc()
 			water_proc()
 			if (stage < readyStageMin)
 				icon_state = "[plant]-grow[stage]"
@@ -961,6 +963,10 @@
 		else // destroy
 			user << "<span class = 'bad'>You uproot the dead [name].</span>"
 			qdel(src)
+
+/obj/structure/farming/plant/proc/soil_nutrition_proc()
+	var/turf/floor/dirt/D = get_turf(loc)
+	src.plant_nutrition = D.soil_nutrition
 
 /obj/structure/farming/plant/proc/water_proc()
 	if (istype(src, /obj/structure/farming/plant/mushroom) || istype(src, /obj/structure/farming/plant/mushroompsy))

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -883,7 +883,7 @@
 		I = new fruitpath(loc, stack_amount)
 		I.radiation = radiation/2
 		if (plant_nutrition >= 80)
-			I.amount *= rand(0, 2) // If the soil is fed, randomly increase production from 1 to 3
+			I.amount *= rand(1, 3) // If the soil is fed, randomly increase production from 1 to 3
 	else
 		if (condiment <> "product_name") // Routine to spawn produces when condiment
 			fruitpath = "/obj/item/weapon/reagent_containers/food/condiment/[condiment]"
@@ -892,7 +892,7 @@
 		I = new fruitpath(loc)
 		I.radiation = radiation/2
 		if (plant_nutrition >= 80) // If the soil is fed, randomly increase production from 1 to 3
-			for(rand(0, 2) > 0)
+			for(rand(0, 3) > 0)
 				I = new fruitpath(loc)
 				I.radiation = radiation/2
 

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -878,16 +878,16 @@
 /obj/structure/farming/plant/proc/spawn_produce()
 	var/fruitpath
 	var/obj/item/I
-	if (stack <> "product_name")
+	if (stack <> "product_name") // Routine to spawn produces when in stack
 		fruitpath = "/obj/item/stack/[stack]"
 		I = new fruitpath(loc, stack_amount)
 		I.radiation = radiation/2
 		if (fertilized)
 			I.amount *= 2
 	else
-		if (condiment <> "product_name")
+		if (condiment <> "product_name") // Routine to spawn produces when condiment
 			fruitpath = "/obj/item/weapon/reagent_containers/food/condiment/[condiment]"
-		else
+		else // Routine to spawn produces when fruit itself
 			fruitpath = "/obj/item/weapon/reagent_containers/food/snacks/grown/[plant]"
 		I = new fruitpath(loc)
 		I.radiation = radiation/2
@@ -935,7 +935,7 @@
 				if (src && get_area(get_turf(src)))
 					if (get_area(get_turf(src)).location == 0)
 						if (istype(src, /obj/structure/farming/plant/mushroom) || istype(src, /obj/structure/farming/plant/mushroompsy))
-							stage += 1
+							stageGrowth()
 					else
 						var/currcl = get_area(get_turf(src)).climate
 						var/count = 0
@@ -947,8 +947,14 @@
 									if (season == k)
 										count++
 						if (count > 0 || (map.ID != MAP_NOMADS_CONTINENTAL && map.ID != MAP_NOMADS_PANGEA && map.ID != MAP_NOMADS_NEW_WORLD && map.ID != MAP_NOMADS_MEDITERRANEAN && map.ID != MAP_NOMADS_EUROPE))
-							stage += 1
+							stageGrowth()
 					growth()
+
+/obj/structure/farming/plant/proc/stageGrowth()  // Uses plant_nutrition as Use the plant's nutrition as a chance to grow
+	if(plant_nutrition > 80) // Good soil, keep growing
+		stage += 1
+	else if (prob(plant_nutrition))
+		stage += 1
 
 /obj/structure/farming/plant/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/material/hatchet) || istype(W, /obj/item/weapon/attachment/bayonet) || istype(W, /obj/item/weapon/material/kitchen/utensil/knife) || istype(W, /obj/item/weapon/material/scythe))
@@ -966,6 +972,8 @@
 
 /obj/structure/farming/plant/proc/soil_nutrition_proc()
 	var/turf/floor/dirt/D = get_turf(loc)
+	var/nutrition_consumed = 5
+	D.soil_nutrition -= nutrition_consumed // Plant eats nutrition from the soil
 	src.plant_nutrition = D.soil_nutrition
 
 /obj/structure/farming/plant/proc/water_proc()

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -977,7 +977,7 @@
 
 /obj/structure/farming/plant/proc/soil_nutrition_proc()
 	var/turf/floor/dirt/D = get_turf(loc)
-	var/nutrition_consumed = 5
+	var/nutrition_consumed = 3
 	D.soil_nutrition -= nutrition_consumed // Plant eats nutrition from the soil
 	if(D.soil_nutrition < D.min_soil_nutrition)
 		D.soil_nutrition = D.min_soil_nutrition // Cap soil nutrition at mininum possible

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -882,8 +882,8 @@
 		fruitpath = "/obj/item/stack/[stack]"
 		I = new fruitpath(loc, stack_amount)
 		I.radiation = radiation/2
-		if (fertilized)
-			I.amount *= 2
+		if (plant_nutrition > 80)
+			I.amount *= rand(1, 3) // If the soil is fed, randomly increase production from 1 to 3
 	else
 		if (condiment <> "product_name") // Routine to spawn produces when condiment
 			fruitpath = "/obj/item/weapon/reagent_containers/food/condiment/[condiment]"
@@ -891,9 +891,11 @@
 			fruitpath = "/obj/item/weapon/reagent_containers/food/snacks/grown/[plant]"
 		I = new fruitpath(loc)
 		I.radiation = radiation/2
-		if (fertilized)
-			I = new fruitpath(loc)
-			I.radiation = radiation/2
+		if (plant_nutrition > 80) // If the soil is fed, randomly increase production from 1 to 3
+			var/extra_rand_produces = rand(1, 3)
+			for(extra_rand_produces)
+				I = new fruitpath(loc)
+				I.radiation = radiation/2
 
 //////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -954,11 +954,11 @@
 /obj/structure/farming/plant/proc/stageGrowth()  // Uses plant_nutrition as Use the plant's nutrition as a chance to grow
 	if(plant_nutrition > 80) // Good soil, keep growing
 		stage += 1
-	else if (plant_nutrition >= 25 && prob(plant_nutrition))
+	else if (plant_nutrition >= 40 && prob(plant_nutrition))
 		stage += 1
-	else if (plant_nutrition > 0 && plant_nutrition < 25 && prob(10))
+	else if (plant_nutrition > 0 && plant_nutrition < 40 && prob(40))
 		stage += 1
-	else if(prob(5))
+	else if(prob(20))
 		stage += 1
 
 /obj/structure/farming/plant/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -892,7 +892,7 @@
 		I = new fruitpath(loc)
 		I.radiation = radiation/2
 		if (plant_nutrition >= 80) // If the soil is fed, randomly increase production from 1 to 3
-			for(rand(0, 3) > 0)
+			for(var/l = 1, l <= rand(0, 2) && l > 0, l++) // If 0, no extra crops. Up to 2 extras, 3 counting with the main produce
 				I = new fruitpath(loc)
 				I.radiation = radiation/2
 

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -882,8 +882,8 @@
 		fruitpath = "/obj/item/stack/[stack]"
 		I = new fruitpath(loc, stack_amount)
 		I.radiation = radiation/2
-		if (plant_nutrition > 80)
-			I.amount *= rand(1, 3) // If the soil is fed, randomly increase production from 1 to 3
+		if (plant_nutrition >= 80)
+			I.amount *= rand(0, 2) // If the soil is fed, randomly increase production from 1 to 3
 	else
 		if (condiment <> "product_name") // Routine to spawn produces when condiment
 			fruitpath = "/obj/item/weapon/reagent_containers/food/condiment/[condiment]"
@@ -891,9 +891,8 @@
 			fruitpath = "/obj/item/weapon/reagent_containers/food/snacks/grown/[plant]"
 		I = new fruitpath(loc)
 		I.radiation = radiation/2
-		if (plant_nutrition > 80) // If the soil is fed, randomly increase production from 1 to 3
-			var/extra_rand_produces = rand(1, 3)
-			for(extra_rand_produces)
+		if (plant_nutrition >= 80) // If the soil is fed, randomly increase production from 1 to 3
+			for(rand(0, 2) > 0)
 				I = new fruitpath(loc)
 				I.radiation = radiation/2
 
@@ -955,7 +954,11 @@
 /obj/structure/farming/plant/proc/stageGrowth()  // Uses plant_nutrition as Use the plant's nutrition as a chance to grow
 	if(plant_nutrition > 80) // Good soil, keep growing
 		stage += 1
-	else if (prob(plant_nutrition))
+	else if (plant_nutrition >= 25 && prob(plant_nutrition))
+		stage += 1
+	else if (plant_nutrition > 0 && plant_nutrition < 25 && prob(10))
+		stage += 1
+	else if(prob(5))
 		stage += 1
 
 /obj/structure/farming/plant/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -976,6 +979,8 @@
 	var/turf/floor/dirt/D = get_turf(loc)
 	var/nutrition_consumed = 5
 	D.soil_nutrition -= nutrition_consumed // Plant eats nutrition from the soil
+	if(D.soil_nutrition < D.min_soil_nutrition)
+		D.soil_nutrition = D.min_soil_nutrition // Cap soil nutrition at mininum possible
 	src.plant_nutrition = D.soil_nutrition
 
 /obj/structure/farming/plant/proc/water_proc()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -27,6 +27,8 @@
 	var/amount = 1
 	var/value = 0 //the cost of an item.
 
+	var/fertilizer_value = 0 // the value as fertilizer
+
 	var/sharpness = 0
 
 	var/heat_protection = FALSE //flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm

--- a/code/game/turfs/floor_attackby.dm
+++ b/code/game/turfs/floor_attackby.dm
@@ -109,14 +109,17 @@
 				"<span class='notice'>[user] washes \a [C] using \the [src].</span>", \
 				"<span class='notice'>You wash \a [C] using \the [src].</span>")
 
-	if (istype(src, /turf/floor/dirt/ploughed))
-		if ((istype(C, /obj/item/weapon/reagent_containers/food/snacks/poo/animal) || istype(C, /obj/item/weapon/reagent_containers/food/snacks/poo/fertilizer) || istype(C, /obj/item/stack/dung)))
-			user << "You start fertilizing the ploughed field..."
+	if (istype(src, /turf/floor/dirt))
+		if (C.fertilizer_value > 0)
+			user << "You start fertilizing the dirt..."
 			var/mob/living/human/H = user
+			var/turf/floor/dirt/D = src
 			if (do_after(user, 60/H.getStatCoeff("farming"), src))
-				user << "You fertilize the ploughed field around this plot."
-				for (var/obj/structure/farming/plant/P in range(1,src))
-					P.fertilized = TRUE
+				user << "You fertilize the dirt around this plot."
+				if(D.soil_nutrition + C.fertilizer_value <= D.max_soil_nutrition) // Do not let players over fertilize the dirt
+					D.soil_nutrition += C.fertilizer_value
+				else
+					D.soil_nutrition = D.max_soil_nutrition // Capped at max soil nutrition
 				if (istype(C, /obj/item/stack/dung))
 					C.amount--
 					if (C.amount <= 0)

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -232,6 +232,9 @@
 	may_become_muddy = TRUE
 	available_dirt = 3
 	is_diggable = TRUE
+	var/soil_nutrition = 50
+	var/max_soil_nutrition = 200
+	var/min_soil_nutrition = 0
 	initial_flooring = /decl/flooring/dirt
 
 /turf/floor/dirt/space

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -432,12 +432,30 @@
 	else
 		ChangeTurf(/turf/floor/dirt)
 
+/turf/floor/dirt/fertile
+	soil_nutrition = 100
+
+/turf/floor/dirt/medium_fertile
+	soil_nutrition = 50
+
+/turf/floor/dirt/infertile
+	soil_nutrition = 0
+
 /turf/floor/dirt/ploughed
 	name = "ploughed field"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "dirt_ploughed"
 	is_plowed = TRUE
 	initial_flooring = null
+
+/turf/floor/dirt/ploughed/fertile
+	soil_nutrition = 100
+
+/turf/floor/dirt/ploughed/medium_fertile
+	soil_nutrition = 50
+
+/turf/floor/dirt/ploughed/infertile
+	soil_nutrition = 0
 
 /turf/floor/dirt/ploughed/flooded
 	name = "ploughed field"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -237,6 +237,18 @@
 	var/min_soil_nutrition = 0
 	initial_flooring = /decl/flooring/dirt
 
+/turf/floor/dirt/examine(mob/user)
+	if (get_dist(src, user) <= 1)
+		if (soil_nutrition >= 80)
+			user << "<span class='notice'>The soil looks alive and in good condition, plants would grow very well here.</span>"
+		else if (soil_nutrition >= 25)
+			user << "<span class='notice'>The soil seems half dead and the plants would not develop as well as they should here.</span>"
+		else if (soil_nutrition > 0)
+			user << "<span class='notice'>The soil here looks pretty dead and the plants would have a tough time growing here.</span>"
+		else
+			user << "<span class='notice'>The soil looks dead and plants would hardly grow here.</span>"
+	return ...
+
 /turf/floor/dirt/space
 	name = "space"
 	icon = 'icons/turf/floors.dmi'

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -232,8 +232,8 @@
 	may_become_muddy = TRUE
 	available_dirt = 3
 	is_diggable = TRUE
-	var/soil_nutrition = 50
-	var/max_soil_nutrition = 200
+	var/soil_nutrition = 25
+	var/max_soil_nutrition = 100
 	var/min_soil_nutrition = 0
 	initial_flooring = /decl/flooring/dirt
 

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -233,20 +233,22 @@
 	available_dirt = 3
 	is_diggable = TRUE
 	var/soil_nutrition = 25
-	var/max_soil_nutrition = 100
+	var/max_soil_nutrition = 150
 	var/min_soil_nutrition = 0
 	initial_flooring = /decl/flooring/dirt
 
 /turf/floor/dirt/examine(mob/user)
 	if (get_dist(src, user) <= 1)
-		if (soil_nutrition >= 80)
-			user << "<span class='notice'>The soil looks alive and in good condition, plants would grow very well here.</span>"
+		if (soil_nutrition >= 130)
+			user << "<span class='notice'>The soil looks very alive and the plants will grow very easily.</span>"
+		else if (soil_nutrition >= 80)
+			user << "<span class='notice'>The soil looks alive, plants would grow very well.</span>"
 		else if (soil_nutrition >= 25)
-			user << "<span class='notice'>The soil seems half dead and the plants would not develop as well as they should here.</span>"
+			user << "<span class='notice'>The soil seems half dead and the plants would not develop as well as they should.</span>"
 		else if (soil_nutrition > 0)
-			user << "<span class='notice'>The soil here looks pretty dead and the plants would have a tough time growing here.</span>"
+			user << "<span class='notice'>The soil looks pretty dead and the plants would have a tough time growing.</span>"
 		else
-			user << "<span class='notice'>The soil looks dead and plants would hardly grow here.</span>"
+			user << "<span class='notice'>The soil looks dead and plants would hardly grow.</span>"
 	return ...
 
 /turf/floor/dirt/space
@@ -433,7 +435,7 @@
 		ChangeTurf(/turf/floor/dirt)
 
 /turf/floor/dirt/fertile
-	soil_nutrition = 100
+	soil_nutrition = 150
 
 /turf/floor/dirt/medium_fertile
 	soil_nutrition = 50
@@ -449,7 +451,7 @@
 	initial_flooring = null
 
 /turf/floor/dirt/ploughed/fertile
-	soil_nutrition = 100
+	soil_nutrition = 150
 
 /turf/floor/dirt/ploughed/medium_fertile
 	soil_nutrition = 50

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -237,6 +237,10 @@
 	var/min_soil_nutrition = 0
 	initial_flooring = /decl/flooring/dirt
 
+/turf/floor/dirt/New()
+	soil_nutrition = rand(25, 150)
+	return ...
+
 /turf/floor/dirt/examine(mob/user)
 	if (get_dist(src, user) <= 1)
 		if (soil_nutrition >= 130)

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -232,14 +232,26 @@
 	may_become_muddy = TRUE
 	available_dirt = 3
 	is_diggable = TRUE
-	var/soil_nutrition = 25
+	var/soil_nutrition = 150
 	var/max_soil_nutrition = 150
 	var/min_soil_nutrition = 0
 	initial_flooring = /decl/flooring/dirt
 
 /turf/floor/dirt/New()
-	soil_nutrition = rand(25, 150)
+	soil_nutrition_recover() // Starts soil nutrition recover
 	return ...
+
+/turf/floor/dirt/proc/soil_nutrition_recover()
+	spawn(12000) // Every 20 minutes the soil will recover
+		if(soil_nutrition < max_soil_nutrition)
+			if (!locate(/obj/structure/farming/plant) in src) // Soil recovers when no farming plants
+				var/nutrition_to_be_recovered = rand(20, 40)
+				if(soil_nutrition + nutrition_to_be_recovered > max_soil_nutrition)
+					soil_nutrition = max_soil_nutrition
+				else
+					soil_nutrition += nutrition_to_be_recovered
+		soil_nutrition_recover();
+		return
 
 /turf/floor/dirt/examine(mob/user)
 	if (get_dist(src, user) <= 1)


### PR DESCRIPTION
It adds soil nutrition mechanics, which defines the speed and quantity of the harvest.
Talking to people in the development channel, we aligned that it would be better to maintain a growth, albeit a very slow one, even when nutrition is zero.

For more information, check below.

**General info:**
  Maximum soil nutrition: 150
  Minimum soil nutrient: 0
  Standard initial soil nutrition: 150(maxed, will help by not giving unnecessary load to the soil recovery subsystem).
  Nutrition at which the production can be up to 3 times higher (random, bonus from 0 to 3): 80

**Consumption of soil nutrition by the plant:**
  For every tick of plant growth, it will consume 3 of soil nutrition.

**Fertilizers:**
  /obj/item/weapon/reagent_containers/food/snacks/poo/animal = 10
  /obj/item/stack/dung = 20
  /obj/item/weapon/reagent_containers/food/snacks/poo/fertilizer = 60

**Growth:**
When soil nutrition is,
above 80: Guaranteed growth.
greater than or equal to 40: Growth probability equal to soil fertility.
greater than 0 and less than 40: 40% growth probability.
equal to zero: 20% chance of growth

**To examine the soil, stand close to it and examine it.** 
  When it is at or above 130:
    "The soil looks very alive and the plants will grow very easily."
  When it is at or above 80:
    "The soil looks alive, plants would grow very well."
  When it is above or equal to 25:
    "The soil seems half dead and the plants would not develop as well as they should."
  When it is greater than 0 and less than 25:
    "The soil looks pretty dead and the plants would have a tough time growing."
  When it is 0:
    "The soil looks dead and plants would hardly grow."

**Practical test of time and nutrition consumed in the plantations:**
  Planted in, initially,
    150 of nutrition:
      Ready harvest, on average, 6 minutes
      Final nutrition, on average, 129 nutrition

  100 of nutrition:
    Harvest ready, on average, 6 minutes
    Final nutrition, on average, 79 nutrition
   

 **Soil will recover itself if you dont farm on it**
Every 20 minutes, it will recover randomly from 20 to 40 nutrition.
Which means that you can let your soil rest a bit. If you leave it alone for an hour, you'll have 60 to 120 nutrition.

The recovery subsystem will take only a bit of processing. Wont be laggy.
If the soil it already maxed, it will pass through and just call itself for another waiting.
If its not maxed, it will look for crops planted. If there are any, it will do nothing but call itself.
If there are no plants, it will recover the nutrition.
    
    