### PR TITLE
Feat/soil nutrition farmer check plant

### DIFF
--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -1041,7 +1041,7 @@
 			user << "\The [src] seems <b>[water_desc]</b>."
 		else if (H.getStatCoeff("farming") >= 2.2)
 			user << "[src]'s water level is at <b>[water]/[max_water]</b>."
-		if (H.getStatCoeff("farming")>= 1.3)
 			user << "[src]'s nutrition level is at <b>[plant_nutrition]/[max_plant_nutrition]</b>."
+		if (H.getStatCoeff("farming")>= 1.3)
 			if (plant_nutrition > 80)
 				user << "The plant looks good and healthy, it may give extra crops."

--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -382,6 +382,7 @@
 	var/water = 60
 	var/max_water = 60
 	var/plant_nutrition = 100
+	var/max_plant_nutrition = 150
 
 /obj/structure/farming/plant/New()
 	..()
@@ -1041,5 +1042,6 @@
 		else if (H.getStatCoeff("farming") >= 2.2)
 			user << "[src]'s water level is at <b>[water]/[max_water]</b>."
 		if (H.getStatCoeff("farming")>= 1.3)
-			if (fertilized)
-				user << "The ground is fertilized."
+			user << "[src]'s nutrition level is at <b>[plant_nutrition]/[max_plant_nutrition]</b>."
+			if (plant_nutrition > 80)
+				user << "The plant looks good and healthy, it may give extra crops."

--- a/code/game/turfs/floor_attackby.dm
+++ b/code/game/turfs/floor_attackby.dm
@@ -116,10 +116,11 @@
 			var/turf/floor/dirt/D = src
 			if (do_after(user, 60/H.getStatCoeff("farming"), src))
 				user << "You fertilize the dirt around this plot."
-				if(D.soil_nutrition + C.fertilizer_value <= D.max_soil_nutrition) // Do not let players over fertilize the dirt
-					D.soil_nutrition += C.fertilizer_value
-				else
-					D.soil_nutrition = D.max_soil_nutrition // Capped at max soil nutrition
+				for (D in range(1,src))
+					if(D.soil_nutrition + C.fertilizer_value <= D.max_soil_nutrition) // Do not let players over fertilize the dirt
+						D.soil_nutrition += C.fertilizer_value
+					else
+						D.soil_nutrition = D.max_soil_nutrition // Capped at max soil nutrition
 				if (istype(C, /obj/item/stack/dung))
 					C.amount--
 					if (C.amount <= 0)

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -265,6 +265,10 @@
 			user << "<span class='notice'>The soil looks pretty dead and the plants would have a tough time growing.</span>"
 		else
 			user << "<span class='notice'>The soil looks dead and plants would hardly grow.</span>"
+	if (ishuman(user))
+		var/mob/living/human/H = user
+		if (H.getStatCoeff("farming")>= 1.3)
+			user << "[src]'s nutrition level is at <b>[soil_nutrition]/[max_soil_nutrition]</b>."
 	return ...
 
 /turf/floor/dirt/space

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -267,7 +267,7 @@
 			user << "<span class='notice'>The soil looks dead and plants would hardly grow.</span>"
 	if (ishuman(user))
 		var/mob/living/human/H = user
-		if (H.getStatCoeff("farming")>= 1.3)
+		if (H.getStatCoeff("farming")>= 2.2)
 			user << "[src]'s nutrition level is at <b>[soil_nutrition]/[max_soil_nutrition]</b>."
 	return ...
 


### PR DESCRIPTION
- Bring back 3x3 fertilization
- Gives accurate information about soil nutrition when the farmer has 2.2 or more farmer skill
- Gives precise information about the plant's nutrition when the farmer has  2.2  or more farmer skill
- Allows you to check when a plant can yield extra crops when >=1.3 farmer skill points
-- "The plant looks good and healthy, it may give extra crops."