### PR TITLE
fix: soil nutrition recover check for non-dirt turf calls

### DIFF
--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -242,6 +242,8 @@
 	return ...
 
 /turf/floor/dirt/proc/soil_nutrition_recover()
+	if(!istype(src, /turf/floor/dirt)) // If its not a dirt tile, do nothing and kills the recover for src
+		return
 	spawn(12000) // Every 20 minutes the soil will recover
 		if(soil_nutrition < max_soil_nutrition)
 			if (!locate(/obj/structure/farming/plant) in src) // Soil recovers when no farming plants


### PR DESCRIPTION
For some reason (maybe because of world/turf = /dirt), this proc has been called for other turfs that are not dirt, which generates runtimes.

Fixed.