### PR TITLE
Fix/soil recover and lighting

### DIFF
--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -242,9 +242,9 @@
 	return ..()
 
 /turf/floor/dirt/proc/soil_nutrition_recover()
-	if(!istype(src, /turf/floor/dirt)) // If its not a dirt tile, do nothing and kills the recover for src
-		return
 	spawn(12000) // Every 20 minutes the soil will recover
+		if(!istype(src, /turf/floor/dirt)) // It could be that the turf has ceased to be dirt during the wait
+			return
 		if(soil_nutrition < max_soil_nutrition)
 			if (!locate(/obj/structure/farming/plant) in src) // Soil recovers when no farming plants
 				var/nutrition_to_be_recovered = rand(20, 40)
@@ -252,7 +252,7 @@
 					soil_nutrition = max_soil_nutrition
 				else
 					soil_nutrition += nutrition_to_be_recovered
-		soil_nutrition_recover();
+		soil_nutrition_recover()
 		return
 
 /turf/floor/dirt/examine(mob/user)

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -239,7 +239,7 @@
 
 /turf/floor/dirt/New()
 	soil_nutrition_recover() // Starts soil nutrition recover
-	return ...
+	return ..()
 
 /turf/floor/dirt/proc/soil_nutrition_recover()
 	if(!istype(src, /turf/floor/dirt)) // If its not a dirt tile, do nothing and kills the recover for src


### PR DESCRIPTION
After some more feedback and with the help of the tutors and admins, I could see that the undefined var soil_nutrition problem continued.

After some more testing, I also realized that the problem happened when a tile was some kind of /dirt and, during the waiting period, it stopped being a /dirt and turned into something different. Resulting in runtime when trying to read the soil_nutrition variable in soil recovery.

Also fixes the lighting bug.