### PR TITLE
fix: plant growth when the soil is no longer ploughed dirt

### DIFF
--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -917,7 +917,11 @@
 		return TRUE
 
 /obj/structure/farming/plant/proc/growth()
-	if (!vstatic)
+	var/turf/floor/dirt/D = get_turf(loc)
+	if(!istype(D, /turf/floor/dirt/ploughed))
+		water_proc() // Plant will still consume resources and respond to the climate, but will not be able to develop
+		return // Stops plant growth if the soil is no longer ploughed
+	else if (!vstatic)
 		if (stage < 12)
 			soil_nutrition_proc()
 			water_proc()


### PR DESCRIPTION
During the change of seasons, the soil may cease to be ploughed and become some other turf. If this happens, the plant will not be able to develop, although it will continue to consume water and respond to the changing climate.

If the farmer gets back to tending the soil in time, he may be able to save his plant.