### PR TITLE
Nerfs the PMC Mob

### DIFF
--- a/code/game/mob/living/simple_animal/hostile/pmc.dm
+++ b/code/game/mob/living/simple_animal/hostile/pmc.dm
@@ -14,8 +14,8 @@
 	speed = 6
 	move_to_delay = 3
 	stop_automated_movement_when_pulled = 0
-	maxHealth = 300
-	health = 300
+	maxHealth = 250
+	health = 250
 	move_to_delay = 4
 	harm_intent_damage = 10
 	melee_damage_lower = 35
@@ -29,7 +29,7 @@
 	faction = PIRATES
 	ranged = 1
 	rapid = 2
-	projectiletype = /obj/item/projectile/bullet/rifle/a577
+	projectiletype = /obj/item/projectile/bullet/rifle/a762x51
 	casingtype = null
 
 	New()


### PR DESCRIPTION
this mob can instakill in 1 shot almost always, very op and annoying especially on the wasteland map, this merge nerfs their health by 50 and downgrades their fired projectile into 762x51