### PR TITLE
red army update + more

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -633,7 +633,7 @@ Shinobi's unfinished welder stuff - siro*/
 	desc = "An instrument containing a magnetized pointer which shows the direction of magnetic north and bearings from it."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "compass"
-	slot_flags = SLOT_BELT | SLOT_POCKET
+	slot_flags = SLOT_BELT | SLOT_POCKET | SLOT_ID
 	w_class = 1.0
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_HARMLESS

--- a/code/modules/1713/apparel_worldwars.dm
+++ b/code/modules/1713/apparel_worldwars.dm
@@ -1462,6 +1462,116 @@ obj/item/clothing/head/ww2/cra_cap
 		hold.storage_slots = slots
 		hold.can_hold = list(/obj/item/ammo_casing, /obj/item/ammo_magazine, /obj/item/weapon/grenade, /obj/item/weapon/attachment/bayonet,/obj/item/weapon/material/shovel/trench,/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen,/obj/item/weapon/reagent_containers/food/snacks/MRE,/obj/item/stack/medical/bruise_pack)
 
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosin
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosinalt
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/weapon/grenade/modern/f1(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosin(hold)
+		new/obj/item/ammo_magazine/mosinbox(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svt
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/ammo_magazine/mosinbox(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/weapon/grenade/smokebomb(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppsh
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/ammo_magazine/c762x25_pps(hold)
+		new/obj/item/ammo_magazine/c762x25_pps(hold)
+		new/obj/item/ammo_magazine/c762x25_pps(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/weapon/grenade/smokebomb(hold)
+		new/obj/item/weapon/grenade/ww2/rgd33(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/dpgun
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/dp(hold)
+		new/obj/item/ammo_magazine/dp(hold)
+		new/obj/item/ammo_magazine/dp(hold)
+		new/obj/item/weapon/grenade/smokebomb(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/ww2/stormgroup
+	name = "Stormgroup Webbing"
+	desc = "Specially made webbing used by stormgroups."
+	slots = 9
+	New()
+		..()
+		hold.can_hold = list(/obj/item/ammo_casing, /obj/item/ammo_magazine, /obj/item/weapon/grenade, /obj/item/weapon/attachment/bayonet,/obj/item/weapon/material/shovel/trench,/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen,/obj/item/weapon/reagent_containers/food/snacks/MRE,/obj/item/stack/medical/bruise_pack,/obj/item/weapon/gun/projectile/pistol)
+
+obj/item/clothing/accessory/storage/webbing/ww1/ww2/stormgroup/svt
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/ammo_magazine/mosinbox(hold)
+		new/obj/item/ammo_magazine/svt(hold)
+		new/obj/item/weapon/grenade/smokebomb(hold)
+		new/obj/item/weapon/grenade/ww2/rgd33(hold)
+		new/obj/item/weapon/compass(hold)
+		new/obj/item/weapon/attachment/bayonet(hold)
+
+obj/item/clothing/accessory/storage/webbing/ww1/ww2/stormgroup/Scout
+	New()
+		..()
+		new/obj/item/stack/medical/bruise_pack/gauze(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/ammo_magazine/c762x25_ppsh(hold)
+		new/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars(hold)
+		new/obj/item/weapon/grenade/ww2/rgd33(hold)
+		new/obj/item/weapon/grenade/smokebomb(hold)
+		new/obj/item/weapon/compass(hold)
+		new/obj/item/weapon/attachment/bayonet(hold)
+
 /obj/item/clothing/accessory/storage/webbing/russian
 	name = "russian webbing"
 	desc = "4 green poly pouches."
@@ -1471,6 +1581,7 @@ obj/item/clothing/head/ww2/cra_cap
 	New()
 		..()
 		hold.can_hold = list(/obj/item/ammo_casing, /obj/item/ammo_magazine, /obj/item/weapon/grenade, /obj/item/weapon/attachment/bayonet,/obj/item/weapon/material/shovel/trench,/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen,/obj/item/weapon/reagent_containers/food/snacks/MRE,/obj/item/stack/medical/bruise_pack)
+
 
 /obj/item/clothing/accessory/storage/webbing/ww1/german
 	name = "german webbing"

--- a/code/modules/1713/jobs/russian.dm
+++ b/code/modules/1713/jobs/russian.dm
@@ -469,8 +469,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/soviet_fieldcap(H), slot_head)
 
 //weapons
-	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
-		H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
+	H.equip_to_slot_or_del(new /obj/item/weapon/compass(H), slot_wear_id)
 	if (map.ID == MAP_KHALKHYN_GOL)
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
 		H.equip_to_slot_or_del(new /obj/item/ammo_magazine/mosin(H), slot_r_store)
@@ -583,6 +582,10 @@
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		if (prob(50))
 			H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
+//webbing
+	var/obj/item/clothing/under/uniform = H.w_uniform
+	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/dpgun/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/dpgun(null)
+	uniform.attackby(webbing, H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a designated automatic rifleman of the Red Army. Keep the enemy pinned down!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -635,6 +638,16 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/ptrd_pouch(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/tt30(H), slot_r_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/tt30(H), slot_belt)
+	var/obj/item/clothing/under/uniform = H.w_uniform
+	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather(null)
+	uniform.attackby(webbing, H)
+	give_random_name(H)
+	webbing.attackby(new/obj/item/stack/medical/bruise_pack/bint, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, an anti-tank rifleman of the Red Army and you keep braging that your gun is bigger than your comrads'. Follow your <b>Sergeant's</b> orders!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -671,9 +684,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/heavyboots/wrappedboots(H), slot_shoes)
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/soviet(H), slot_w_uniform)
-	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
-		if (prob(40))
-			H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
+	H.equip_to_slot_or_del(new /obj/item/weapon/compass(H), slot_wear_id)
 //head
 	if (prob(50))
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/soviet(H), slot_head)
@@ -682,21 +693,31 @@
 //weapons
 	if (map.ID == MAP_STALINGRAD || map.ID == MAP_SMALLSIEGEMOSCOW || map.ID == MAP_KARELIA)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/sovcoat(H), slot_wear_suit)
-	else
-		if (prob(40))
+	var/obj/item/clothing/under/uniform = H.w_uniform
+	var/randimpw = rand(1,5)
+	switch(randimpw)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin(null)
+			uniform.attackby(webbing, H)
+		if (2)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_shoulder)
-		else
-			if (prob(10))
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
-			else
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault(null)
+			uniform.attackby(webbing, H)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault(null)
+			uniform.attackby(webbing, H)
+
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/ptrd_box(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/ptrd_box/ap(H), slot_r_store)
-	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather(null)
-	uniform.attackby(webbing, H)
+//Extra AT weapon
+	if (prob(50))
+		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/molotov(H), slot_l_hand)
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/grenade/antitank/rpg40(H), slot_l_hand)
 	give_random_name(H)
-	H.add_note("Role", "You are a <b>[title]</b>, an anti-tank rifleman of the Red Army and you keep braging that your gun is bigger than your comrads'. Follow your <b>Sergeant's</b> orders!")
+	H.add_note("Role", "You are a <b>[title]</b>, an anti-tank assistant, find your Anti-tank gunner and assist him. Follow your <b>Sergeant's</b> orders!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
 	H.setStat("crafting", STAT_MEDIUM_LOW)
 	H.setStat("rifle", STAT_NORMAL)
@@ -735,6 +756,7 @@
 //weapons
 	H.equip_to_slot_or_del(new /obj/item/weapon/flamethrower/roks2(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/glass/flamethrower/roks2/filled(H), slot_back)
+	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/tt30(H), slot_belt)
 
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
@@ -742,13 +764,19 @@
 	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather(null)
 	uniform.attackby(webbing, H)
 	give_random_name(H)
-	H.add_note("Role", "You are a <b>[title]</b>, a flamethrower for the Red Army. Follow your <b>Sergeant's</b> orders!")
+	webbing.attackby(new/obj/item/stack/medical/bruise_pack/bint, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	webbing.attackby(new/obj/item/ammo_magazine/tt30, H)
+	H.add_note("Role", "You are a <b>[title]</b>, a flamethrower solider of the red army, Assault enemy positions and tanks with your flamethrower. Follow your <b>Sergeant's</b> orders!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
 	H.setStat("crafting", STAT_MEDIUM_LOW)
 	H.setStat("rifle", STAT_NORMAL)
 	H.setStat("dexterity", STAT_NORMAL)
 	H.setStat("swords", STAT_NORMAL)
-	H.setStat("pistol", STAT_NORMAL)
+	H.setStat("pistol", STAT_HIGH)
 	H.setStat("bows", STAT_NORMAL)
 	H.setStat("medical", STAT_MEDIUM_LOW)
 
@@ -793,6 +821,9 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/sov_ushanka(H), slot_head)
 //weapons
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30/sniper(H), slot_shoulder)
+	var/obj/item/clothing/under/uniform = H.w_uniform
+	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin(null)
+	uniform.attackby(webbing, H)
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		if (prob(50))
 			H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
@@ -844,25 +875,27 @@
 //weapons
 	if (map.ID == MAP_STALINGRAD || map.ID == MAP_SMALLSIEGEMOSCOW || map.ID == MAP_KARELIA)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/sovcoat(H), slot_wear_suit)
-	if (map.ID == MAP_REICHSTAG)
-		if (prob(15))
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_belt)
-		else
-			if (prob(15))
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
-			else
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
-	else
-		if (prob(10))
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_shoulder)
-		else
-			if (prob(10))
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
-			else
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+//weapon
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather(null)
-	uniform.attackby(webbing, H)
+	var/randimpw = rand(1,4)
+	switch(randimpw)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosin/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosin(null)
+			uniform.attackby(webbing, H)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppd(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppsh/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppsh(null)
+			uniform.attackby(webbing, H)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svt/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svt(null)
+			uniform.attackby(webbing, H)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosinalt/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosinalt(null)
+			uniform.attackby(webbing, H)
+
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a simple soldier of the Red Army. Follow your <b>Sergeant's</b> orders!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -1504,8 +1537,6 @@
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
-	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather(null)
-	uniform.attackby(webbing, H)
 	give_random_name(H)
 
 	H.add_note("Role", "You are a <b>[title]</b>, the leader of a squad of Soviet Guards Mechanized Infantry. Coordinate with the Tanks and defeat the enemy!")
@@ -1548,18 +1579,22 @@
 
 //head
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/soviet(H), slot_head)
-//back
-	if (prob(30))
-		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
-	else
-		if (prob(70))
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/pps(H), slot_belt)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_shoulder)
-
+//weapon
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/storage/webbing/ww1/leather/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather(null)
-	uniform.attackby(webbing, H)
+	var/randimpw = rand(1,5)
+	switch(randimpw)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/pps(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault(null)
+			uniform.attackby(webbing, H)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault(null)
+			uniform.attackby(webbing, H)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault(null)
+			uniform.attackby(webbing, H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a member of the Soviet Guards Mechanized Infantry. Follow your commander's orders and coordinate with the Tanks!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -1615,7 +1650,7 @@
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
 	give_random_name(H)
-	H.add_note("Role", "You are a <b>[title]</b>, a sapper of the Guards. Place mines, sandbags, barbed wire, and help repair the vehicles!")
+	H.add_note("Role", "You are a <b>[title]</b>, a sapper of the Guards. Place mines or remove them, sandbags, barbed wire,destroy enemy tanks and positions, and help repair the vehicles!")
 	H.setStat("strength", STAT_HIGH)
 	H.setStat("crafting", STAT_VERY_HIGH)
 	H.setStat("rifle", STAT_NORMAL)
@@ -1734,7 +1769,7 @@
 
 		if (2)
 			if (prob(60))
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_l_hand)
+				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppd(H), slot_l_hand)
 				H.equip_to_slot_or_del(new /obj/item/ammo_magazine/c762x25_ppsh(H), slot_r_hand)
 			else
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_l_hand)
@@ -1766,15 +1801,15 @@
 	else if (randsuits == 6)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/soviet(H), slot_wear_suit)
 
-	H.add_note("Role", "You are a <b>[title]</b>, you volunteered to defend Moscow. Good luck, comrade!")
+	H.add_note("Role", "You are a <b>[title]</b>, you were conscripted or volunteered to fight for the soviet union,with minimal training you will defend fascism!")
 
 	give_random_name(H)
-	H.setStat("strength", STAT_NORMAL)
+	H.setStat("strength", STAT_MEDIUM_HIGH)
 	H.setStat("crafting", STAT_MEDIUM_HIGH)
 	H.setStat("rifle", STAT_NORMAL)
 	H.setStat("dexterity", STAT_NORMAL)
 	H.setStat("swords", STAT_NORMAL)
-	H.setStat("pistol", STAT_HIGH)
+	H.setStat("pistol", STAT_NORMAL)
 	H.setStat("bows", STAT_NORMAL)
 	H.setStat("medical", STAT_MEDIUM_LOW)
 	return TRUE

--- a/code/modules/1713/tools.dm
+++ b/code/modules/1713/tools.dm
@@ -143,6 +143,7 @@
 	desc = "A shovel used specifically for digging trenches."
 	icon_state = "trench_shovel"
 	var/dig_speed = 7
+	force = 35
 	usespeed = 0.8
 
 /obj/item/weapon/material/shovel/trench/foldable

--- a/code/modules/1713/vending.dm
+++ b/code/modules/1713/vending.dm
@@ -602,6 +602,8 @@ obj/structure/vending/sofammo
 		/obj/item/flashlight/militarylight/alt = 15,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen/ww2/rus = 30,
 		/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/russian = 50,
+		/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars = 1,
+		/obj/item/weapon/compass = 1,
 
 	)
 
@@ -621,6 +623,8 @@ obj/structure/vending/sofammo
 		/obj/item/flashlight/militarylight/alt = 15,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen/full = 30,
 		/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/german = 50,
+		/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars = 1,
+		/obj/item/weapon/compass = 1,
 
 	)
 
@@ -640,6 +644,8 @@ obj/structure/vending/sofammo
 		/obj/item/flashlight/militarylight/alt = 15,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen/full = 30,
 		/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/german = 50,
+		/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars = 2,
+		/obj/item/weapon/compass = 1,
 
 	)
 
@@ -659,7 +665,8 @@ obj/structure/vending/sofammo
 		/obj/item/flashlight/militarylight/alt = 15,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/canteen/full = 10,
 		/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/german = 20,
-
+		/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars = 2,
+		/obj/item/weapon/compass = 2,
 	)
 
 /obj/structure/vending/wehrmachtweapons

--- a/code/modules/1713/weapons/zoom.dm
+++ b/code/modules/1713/weapons/zoom.dm
@@ -12,7 +12,7 @@ Parts of code courtesy of Super3222
 	var/zoomed = FALSE
 	var/datum/action/toggle_scope/azoom
 	attachment_type = ATTACH_SCOPE
-	slot_flags = SLOT_POCKET|SLOT_BELT
+	slot_flags = SLOT_POCKET|SLOT_BELT|SLOT_ID
 	value = 15
 
 /obj/item/weapon/attachment/scope/Destroy()


### PR DESCRIPTION
you can put a compass and the binooculars into you ID slot now the red army has been overhauled
they have webbings with ammo and equipment including smokes and more both wermacht and soviets appareal racks get a single compass and a single binoocular i also added in 2 "stormgroup" webbings incase we need some webbings for events or whatever
changelog summed up:
soviet flamethrower gets a TT pistol + ammo for it in webbing
soviet SL gets a compass in his ID Slot
Soviet infantry gets webbings with their ammo filled in alongside bandages and rarely frags
soviet infantry gets a PPD on spawn instead of a ppsh (balance)
soviet mechanized infantry gets webbings with their ammo filled in alongside smokes and frags
soviet snipers get a webbing now..
PTRD assistant gets a AT AT grenade/molotov on spawning

there also have been some changes to some of the role descriptions 


