### PR TITLE
nerfs PPD-40, rebalances ww2 smgs

### DIFF
--- a/code/modules/1713/apparel_worldwars.dm
+++ b/code/modules/1713/apparel_worldwars.dm
@@ -1601,12 +1601,23 @@ obj/item/clothing/accessory/storage/webbing/ww1/ww2/stormgroup/Scout
 		new/obj/item/ammo_magazine/gewehr98(hold)
 		new/obj/item/ammo_magazine/gewehr98(hold)
 
+/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mg34
+	New()
+		..()
+		new/obj/item/ammo_magazine/mg34(hold)
+		new/obj/item/ammo_magazine/mg34(hold)
+		new/obj/item/ammo_magazine/mg34(hold)
+		new/obj/item/ammo_magazine/mg34(hold)
+		new/obj/item/weapon/grenade/smokebomb(hold)
+
 /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98/sniper
 	New()
 		..()
 		new/obj/item/ammo_magazine/gewehr98(hold)
 		new/obj/item/ammo_magazine/gewehr98(hold)
 		new/obj/item/ammo_magazine/gewehr98box(hold)
+		new/obj/item/weapon/grenade/smokebomb(hold)
+
 /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mauser
 	New()
 		..()
@@ -1623,6 +1634,15 @@ obj/item/clothing/accessory/storage/webbing/ww1/ww2/stormgroup/Scout
 		new/obj/item/ammo_magazine/mp40(hold)
 		new/obj/item/ammo_magazine/mp40(hold)
 
+/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40assault
+	New()
+		..()
+		new/obj/item/ammo_magazine/mp40(hold)
+		new/obj/item/ammo_magazine/mp40(hold)
+		new/obj/item/ammo_magazine/mp40(hold)
+		new/obj/item/ammo_magazine/mp40(hold)
+		new/obj/item/weapon/grenade/ww2/stg1924(hold)
+
 /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43
 	New()
 		..()
@@ -1630,6 +1650,16 @@ obj/item/clothing/accessory/storage/webbing/ww1/ww2/stormgroup/Scout
 		new/obj/item/ammo_magazine/g43(hold)
 		new/obj/item/ammo_magazine/g43(hold)
 		new/obj/item/ammo_magazine/g43(hold)
+
+/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/stg
+	New()
+		..()
+		new/obj/item/ammo_magazine/stg(hold)
+		new/obj/item/ammo_magazine/stg(hold)
+		new/obj/item/ammo_magazine/stg(hold)
+		new/obj/item/ammo_magazine/stg(hold)
+		new/obj/item/weapon/grenade/modern/stg1915(hold)
+		new/obj/item/weapon/grenade/antitank/stg24_bundle(hold)
 
 /obj/item/clothing/accessory/storage/webbing/ww1/french
 	name = "french webbing"

--- a/code/modules/1713/jobs/german.dm
+++ b/code/modules/1713/jobs/german.dm
@@ -524,19 +524,24 @@
 	else
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/german_fieldcap(H), slot_head)
 //back
-	if (prob(30))
-		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g43(H), slot_shoulder)
-	else
-		if (prob(70))
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_belt)
-		else
+	var/obj/item/clothing/under/uniform = H.w_uniform
+	var/randimpw = rand(1,3)
+	switch(randimpw)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g43(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43(null)
+			uniform.attackby(webbing, H)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40assault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40assault(null)
+			uniform.attackby(webbing, H)
+		if (3)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/stg(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/stg/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/stg(null)
+			uniform.attackby(webbing, H)
 
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
-	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/storage/webbing/ww1/german/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german(null)
-	uniform.attackby(webbing, H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a member of the Waffen-SS tasked with defending the Reichstag to the last man. Surrendering is not an option!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -578,20 +583,29 @@
 	else
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/german_fieldcap(H), slot_head)
 //back
-	if (prob(15))
-		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_belt)
-	else
-		if (prob(10))
+	var/obj/item/clothing/under/uniform = H.w_uniform
+	var/randimpw = rand(1,4)
+	switch(randimpw)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g41(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98/sniper/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98/sniper(null)
+			uniform.attackby(webbing, H)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40(null)
+			uniform.attackby(webbing, H)
+		if (3)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g43(H), slot_shoulder)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/gewehr98/karabiner98k(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43(null)
+			uniform.attackby(webbing, H)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/gewehr98(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98(null)
+			uniform.attackby(webbing, H)
 
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		if (prob(50))
 			H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
-	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/storage/webbing/ww1/german/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german(null)
-	uniform.attackby(webbing, H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a simple soldier of the Wehrmacht forces. Follow your <b>Sergeant's</b> orders!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -954,19 +968,25 @@
 	else
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/german_fieldcap(H), slot_head)
 //back
+//back
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	if (prob(15))
-		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_belt)
-		var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40(null)
-		uniform.attackby(webbing, H)
-	else
-		if (prob(10))
+	var/randimpw = rand(1,4)
+	switch(randimpw)
+		if (1)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g43(H), slot_shoulder)
 			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43(null)
 			uniform.attackby(webbing, H)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/gewehr98/karabiner98k(H), slot_shoulder)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40(null)
+			uniform.attackby(webbing, H)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/gewehr98(H), slot_shoulder)
 			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98(null)
+			uniform.attackby(webbing, H)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g41(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98/sniper/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/gewehr98/sniper(null)
 			uniform.attackby(webbing, H)
 
 	H.equip_to_slot_or_del(new /obj/item/weapon/attachment/bayonet(H), slot_l_store)
@@ -1020,7 +1040,6 @@
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/mg34(H), slot_shoulder)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/waltherp38(H), slot_l_hand)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/mg34belt(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun_cleaning_kit(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/mg34(H), slot_r_store)
 
@@ -1030,8 +1049,8 @@
 	if (map.ID == MAP_STALINGRAD)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/german(H), slot_wear_suit)
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
-	uniform.attackby(holsterh, H)
+	var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mg34/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mg34(null)
+	uniform.attackby(webbing, H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a machine gunner of the Wehrmacht forces.Provide suppressing fire, support your comrades, and follow your <b>Sergeant's</b> orders!")
 	H.setStat("strength", STAT_HIGH)
@@ -1434,19 +1453,24 @@
 //head
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/ss(H), slot_head)
 //back
-	if (prob(30))
-		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g43(H), slot_shoulder)
-	else
-		if (prob(70))
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_belt)
-		else
+	var/obj/item/clothing/under/uniform = H.w_uniform
+	var/randimpw = rand(1,3)
+	switch(randimpw)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/g43(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/g43(null)
+			uniform.attackby(webbing, H)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/mp40(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40assault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/mp40assault(null)
+			uniform.attackby(webbing, H)
+		if (3)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/stg(H), slot_shoulder)
+			var/obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/stg/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german/ww2/stg(null)
+			uniform.attackby(webbing, H)
 
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
-	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/storage/webbing/ww1/german/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/german(null)
-	uniform.attackby(webbing, H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a member of the Waffen-SS Mechanized Infantry Corps. Follow your commander's orders and coordinate with the Panzers!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)

--- a/code/modules/1713/jobs/russian.dm
+++ b/code/modules/1713/jobs/russian.dm
@@ -879,7 +879,7 @@
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/randimpw = rand(1,4)
 	switch(randimpw)
-		if (4)
+		if (1)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
 			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosin/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/mosin(null)
 			uniform.attackby(webbing, H)

--- a/code/modules/1713/weapons/guns/mg/smg.dm
+++ b/code/modules/1713/weapons/guns/mg/smg.dm
@@ -205,7 +205,7 @@
 	full_auto = TRUE
 	equiptimer = 12
 	firemodes = list(
-		list(name="full auto",	burst=1, burst_delay=1.1, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
+		list(name="full auto",	burst=1, burst_delay=1.1, recoil=0, move_delay=3, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
 		)
 
 	sel_mode = 1
@@ -220,7 +220,7 @@
 	weight = 4.12
 	equiptimer = 10
 	firemodes = list(
-		list(name="full auto",    burst=1.2, burst_delay=1.4, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.4)),
+		list(name="full auto",    burst=1.2, burst_delay=1.4, recoil=0, move_delay=3, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.4)),
 		)
 	sel_mode = 1
 	effectiveness_mod = 0.95
@@ -337,7 +337,7 @@
 	slot_flags = SLOT_BELT|SLOT_SHOULDER
 	equiptimer = 7
 	firemodes = list(
-		list(name="full auto",	burst=1, burst_delay=1.4, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
+		list(name="full auto",	burst=1, burst_delay=1.4, recoil=0, move_delay=3, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
 		)
 
 	sel_mode = 1
@@ -358,7 +358,7 @@
 	slot_flags = SLOT_BELT|SLOT_SHOULDER
 	equiptimer = 8
 	firemodes = list(
-		list(name="full auto",	burst=1, burst_delay=1.2, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
+		list(name="full auto",	burst=1, burst_delay=1.2, recoil=0, move_delay=3, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
 		)
 
 	sel_mode = 1
@@ -400,7 +400,7 @@
 	full_auto = TRUE
 	equiptimer = 12
 	firemodes = list(
-		list(name="full auto",	burst=1, burst_delay=1.3, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
+		list(name="full auto",	burst=1, burst_delay=1.3, recoil=0, move_delay=3, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
 		)
 
 	sel_mode = 1
@@ -444,7 +444,7 @@
 	equiptimer = 14
 	firemodes = list(
 		list(name="semi auto",	burst=1, burst_delay=0.5, recoil=0, move_delay=1, dispersion = list(0.2, 0.4, 0.4, 0.4, 0.5)),
-		list(name="full auto",	burst=1, burst_delay=1.2, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
+		list(name="full auto",	burst=1, burst_delay=1.2, recoil=0, move_delay=4, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
 		)
 
 	sel_mode = 1
@@ -463,14 +463,14 @@
 	weight = 3.04
 	equiptimer = 10
 	firemodes = list(
-		list(name="full auto",	burst=1, burst_delay=1.1, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
+		list(name="full auto",	burst=1, burst_delay=1.1, recoil=0, move_delay=3, dispersion = list(0.7, 1.2, 1.2, 1.3, 1.5)),
 		)
 
 	sel_mode = 1
 
 /obj/item/weapon/gun/projectile/submachinegun/ppd
 	name = "PPD-40"
-	desc = "Soviet submachinegun typically equipped with drum magazines. Chambered in 7.62x25mm Tokarev."
+	desc = "Early Soviet submachinegun typically equipped with drum magazines. Chambered in 7.62x25mm Tokarev."
 	icon_state = "ppd"
 	item_state = "ppsh"
 	base_icon = "ppd"
@@ -481,7 +481,7 @@
 	good_mags = list(/obj/item/ammo_magazine/c762x25_ppsh, /obj/item/ammo_magazine/c762x25_pps)
 	weight = 3.7
 	equiptimer = 15
-	effectiveness_mod = 0.96
+	effectiveness_mod = 0.82
 	firemodes = list(
 		list(name="semi auto",	burst=1, burst_delay=0.5, recoil=0, move_delay=1, dispersion = list(0.3, 0.4, 0.5, 0.5, 0.6)),
 		list(name="full auto",	burst=1, burst_delay=1.2, recoil=0, move_delay=5, dispersion = list(0.7, 1.2, 1.3, 1.4, 1.6)),

--- a/maps/1943/pavlov_house.dmm
+++ b/maps/1943/pavlov_house.dmm
@@ -458,7 +458,7 @@
 "iP" = (/obj/structure/closet/cabinet,/obj/item/clothing/mask/gas/japanese,/obj/item/clothing/mask/gas/japanese,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "iQ" = (/obj/structure/closet/crate/ww2/ppsh,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "iR" = (/obj/structure/closet/crate/ww2/mosin,/turf/floor/wood,/area/caribbean/roofed/temperate)
-"iS" = (/obj/random/mine/ap,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"iS" = (/obj/item/mine/ap/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "iT" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 1},/obj/structure/barricade/horizontal,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "iU" = (/obj/structure/closet/coffin,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "iV" = (/obj/structure/closet/coffin,/turf/floor/plating/cobblestone/vertical,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
@@ -472,7 +472,7 @@
 "jd" = (/obj/structure/closet/fridge/icebox,/obj/item/weapon/reagent_containers/food/snacks/meatsteak,/obj/item/weapon/reagent_containers/food/snacks/meatsteak,/turf/floor/plating/steel,/area/caribbean/roofed/temperate)
 "je" = (/obj/structure/sink/kitchen{dir = 8; icon_state = "sink_alt"},/turf/floor/plating/steel,/area/caribbean/roofed/temperate)
 "jf" = (/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 1},/turf/floor/wood,/area/caribbean/roofed/temperate)
-"jg" = (/obj/random/mine/ap,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"jg" = (/obj/item/mine/ap/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "jh" = (/obj/covers/brick_wall,/obj/structure/sign/flag/sov,/obj/covers/brick_wall,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "ji" = (/obj/structure/closet/crate/empty,/obj/item/weapon/flamethrower/roks2,/obj/item/weapon/flamethrower/roks2,/obj/item/weapon/reagent_containers/glass/flamethrower/roks2/filled,/obj/item/weapon/reagent_containers/glass/flamethrower/roks2/filled,/obj/item/clothing/gloves/thick/firefighter,/obj/item/clothing/gloves/thick/firefighter,/obj/item/clothing/mask/gas/soviet,/obj/item/clothing/mask/gas/soviet,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "jj" = (/obj/structure/curtain/open/privacy,/turf/floor/plating/white,/area/caribbean/roofed/temperate)
@@ -554,25 +554,25 @@
 "kH" = (/obj/structure/window/barrier/sandbag,/obj/structure/table/modern/table,/obj/item/weapon/telephone/wireless,/turf/floor/wood/fancywood,/area/caribbean/no_mans_land/capturable/one)
 "kI" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/obj/structure/table/modern/flipped{dir = 1},/turf/floor/wood/fancywood,/area/caribbean/no_mans_land/capturable/one)
 "kJ" = (/obj/structure/window/barrier/sandbag,/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/obj/structure/table/modern/table,/obj/structure/radio/transmitter_receiver/nopower/faction2{name = "soviet radio"; transmitter_on = 0},/turf/floor/wood/fancywood,/area/caribbean/no_mans_land/capturable/one)
-"kK" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/random/mine/ap,/obj/item/flashlight/flare/alwayson,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kK" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/item/mine/ap/armed,/obj/item/flashlight/flare/alwayson,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "kL" = (/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/wood/fancywood,/area/caribbean/no_mans_land/capturable/one)
 "kM" = (/obj/structure/bed/chair/wood,/turf/floor/wood/fancywood,/area/caribbean/no_mans_land/capturable/one)
 "kN" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/obj/structure/table/modern/table,/obj/item/ammo_magazine/c762x25_ppsh,/obj/item/ammo_magazine/c762x25_ppsh,/obj/item/ammo_magazine/c762x25_ppsh,/obj/item/ammo_magazine/c762x25_ppsh,/obj/item/weapon/gun/projectile/submachinegun/ppsh,/turf/floor/wood/fancywood,/area/caribbean/no_mans_land/capturable/one)
-"kO" = (/obj/random/mine/ap,/obj/random/mine/ap,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kO" = (/obj/item/mine/ap/armed,/obj/item/mine/ap/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "kP" = (/obj/covers/brick_wall,/obj/structure/window/barrier/sandbag,/turf/wall/brick,/area/caribbean/roofed/temperate)
 "kQ" = (/obj/effect/decal/cleanable/generic,/turf/floor/plating/cobblestone/vertical,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "kR" = (/obj/effect/decal/cleanable/generic,/turf/floor/plating/road,/area/caribbean/no_mans_land/invisible_wall/two{ambience = list("sound/ambience/battle1.ogg")})
 "kS" = (/obj/effect/decal/cleanable/generic,/turf/floor/plating/road,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"kT" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/random/mine/ap,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kT" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/item/mine/ap/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "kU" = (/obj/effect/decal/cleanable/generic,/turf/floor/plating/road,/area/caribbean/no_mans_land/invisible_wall)
-"kV" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/random/mine/ap,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"kW" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/random/mine/ap,/obj/item/mine/at/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"kX" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/random/mine/ap,/turf/floor/winter/grass,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"kY" = (/obj/random/mine/ap,/turf/floor/winter/grass,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"kZ" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/random/mine/ap,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kV" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/item/mine/ap/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kW" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/item/mine/ap/armed,/obj/item/mine/at/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kX" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/item/mine/ap/armed,/turf/floor/winter/grass,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kY" = (/obj/item/mine/ap/armed,/turf/floor/winter/grass,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"kZ" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/item/mine/ap/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "la" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/turf/floor/plating/cobblestone/vertical,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"lb" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/random/mine/ap,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"lc" = (/obj/structure/barbwire,/obj/random/mine/ap,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"lb" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/item/mine/ap/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"lc" = (/obj/structure/barbwire,/obj/item/mine/ap/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "ld" = (/obj/item/mine/boobytrap,/turf/floor/plating/road,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "le" = (/obj/effect/decal/cleanable/generic,/obj/item/mine/boobytrap,/turf/floor/plating/road,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "lf" = (/obj/item/mine/boobytrap,/turf/floor/plating/road,/area/caribbean/no_mans_land/invisible_wall)
@@ -653,6 +653,7 @@
 "mC" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/turf/floor/wood,/area/caribbean/roofed/temperate)
 "mD" = (/obj/structure/iv_drip,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "mE" = (/obj/structure/table/wood,/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 8},/obj/item/violin,/turf/floor/carpet/redcarpet,/area/caribbean/roofed/temperate)
+"mF" = (/obj/structure/closet/cabinet,/obj/item/weapon/reagent_containers/food/drinks/bottle/molotov,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "mG" = (/obj/item/weapon/storage/ammo_can/german_mg,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "mH" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/turf/floor/wood,/area/caribbean/roofed/temperate)
 "mI" = (/obj/structure/simple_door/key_door/anyone/wood,/obj/structure/window/barrier/sandbag,/obj/structure/barricade/steel,/obj/structure/barricade/horizontal,/obj/structure/barbwire,/turf/floor/wood,/area/caribbean/roofed/temperate)
@@ -716,6 +717,7 @@
 "nO" = (/turf/floor/carpet/whitecarpet,/area/caribbean/roofed/temperate)
 "nP" = (/obj/structure/closet/cabinet,/turf/floor/carpet/whitecarpet,/area/caribbean/roofed/temperate)
 "nQ" = (/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 8},/turf/floor/carpet/orangecarpet,/area/caribbean/roofed/temperate)
+"nR" = (/obj/item/weapon/reagent_containers/food/drinks/bottle/molotov,/obj/item/weapon/reagent_containers/food/drinks/bottle/molotov,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "nS" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 1},/obj/structure/bed/bedroll,/turf/floor/carpet/tealcarpet,/area/caribbean/roofed/temperate)
 "nT" = (/obj/item/weapon/bedsheet,/obj/structure/bed/wood,/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 8},/turf/floor/carpet/whitecarpet,/area/caribbean/roofed/temperate)
 "nU" = (/obj/structure/closet/cabinet,/turf/floor/carpet/orangecarpet,/area/caribbean/roofed/temperate)
@@ -723,6 +725,7 @@
 "nW" = (/obj/structure/lamp/lamp_big/alwayson{dir = 4; icon_state = "tube"},/obj/structure/bed/bedroll,/turf/floor/carpet/tealcarpet,/area/caribbean/roofed/temperate)
 "nX" = (/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 1},/turf/floor/carpet/orangecarpet,/area/caribbean/roofed/temperate)
 "nY" = (/obj/structure/closet/crate/empty,/obj/item/weapon/storage/box/canned,/obj/item/weapon/storage/box/canned,/obj/item/weapon/storage/ww2,/obj/item/weapon/storage/ww2,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/turf/floor/wood,/area/caribbean/roofed/temperate)
+"nZ" = (/obj/structure/cannon/modern/tank/german88/field{anchored = 0; dir = 1},/turf/floor/plating/road,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oa" = (/obj/covers/brick_wall,/obj/covers/brick_wall,/obj/item/weapon/fire_extinguisher/ww2,/turf/wall/brick,/area/caribbean/roofed/temperate)
 "ob" = (/obj/item/weapon/fire_extinguisher/ww2,/turf/floor/wood/fancywood,/area/caribbean/no_mans_land/capturable/one)
 "oc" = (/obj/structure/table/wood,/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 8},/obj/item/weapon/storage/ww2,/turf/floor/carpet/pinkcarpet,/area/caribbean/roofed/temperate)
@@ -747,18 +750,18 @@
 "ov" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/item/mine/at/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "ow" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/item/mine/at/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "ox" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/item/mine/at/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"oy" = (/obj/structure/barbwire,/obj/random/mine/ap,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"oy" = (/obj/structure/barbwire,/obj/item/mine/ap/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oz" = (/obj/structure/window/classic/brickfull,/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 8},/obj/structure/barricade/steel,/obj/item/mine/at/armed,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "oA" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 1},/obj/structure/window/classic/brickfull,/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/structure/barricade/steel,/obj/item/mine/at/armed,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "oB" = (/obj/structure/barbwire,/obj/item/mine/at/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oC" = (/obj/structure/barbwire,/obj/item/mine/at/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"oD" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/random/mine/ap,/turf/floor/winter/grass,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"oD" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/item/mine/ap/armed,/turf/floor/winter/grass,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oE" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/item/mine/at/armed,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oF" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/item/mine/at/armed,/turf/floor/winter/grass,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oG" = (/obj/structure/window/classic/brickfull,/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/structure/barricade,/obj/structure/barricade/steel,/obj/item/mine/at/armed,/turf/floor/plating/white,/area/caribbean/roofed/temperate)
 "oH" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/item/flashlight/flare/alwayson,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oI" = (/obj/item/flashlight/flare/alwayson,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
-"oJ" = (/obj/random/mine/ap,/obj/item/mine/at/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
+"oJ" = (/obj/item/mine/ap/armed,/obj/item/mine/at/armed,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oK" = (/obj/item/flashlight/flare/alwayson,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oL" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 4},/obj/item/flashlight/flare/alwayson,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oM" = (/obj/structure/barbwire{icon_state = "barbwire"; dir = 8},/obj/item/flashlight/flare/alwayson,/turf/floor/dirt,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
@@ -771,7 +774,6 @@
 "oT" = (/obj/item/weapon/storage/backpack/duffel,/obj/item/weapon/storage/backpack/duffel,/obj/item/weapon/storage/backpack/duffel,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oU" = (/obj/item/weapon/storage/ammo_can,/obj/item/weapon/storage/ammo_can,/obj/item/weapon/storage/ammo_can,/obj/item/weapon/storage/ammo_can,/obj/item/weapon/storage/ammo_can,/obj/item/weapon/storage/ammo_can,/turf/floor/trench,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oV" = (/obj/item/ammo_magazine/ptrd_pouch,/obj/structure/table/modern/table,/obj/item/weapon/gun/projectile/boltaction/singleshot/ptrd{gun_safety = 0},/turf/floor/wood,/area/caribbean/roofed/temperate)
-"oW" = (/obj/structure/cannon/modern/tank/german88/field{dir = 1},/turf/floor/plating/road,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
 "oX" = (/obj/item/ammo_magazine/ptrd_pouch,/obj/item/ammo_magazine/ptrd_pouch,/obj/item/ammo_magazine/ptrd_pouch,/obj/item/weapon/gun/projectile/boltaction/singleshot/ptrd{gun_safety = 0},/obj/structure/closet/crate/empty,/turf/floor/wood,/area/caribbean/roofed/temperate)
 "oY" = (/obj/covers/brick_wall,/obj/structure/window/barrier/sandbag,/obj/structure/sign/portrait/stalin,/turf/wall/brick,/area/caribbean/roofed/temperate)
 "oZ" = (/obj/structure/props/engineprops/dieselgeni,/turf/floor/winter,/area/caribbean/nomads{ambience = list("sound/ambience/battle1.ogg")})
@@ -809,7 +811,7 @@ euaoaoaoafaoaoaoaoaoaocDcDcDcDcDcDcPafafaofTdulkajajajaffNduafaoaoaocDcDcDcDcDcD
 afaoaoafaoaoaoafaoaocPhAhAhAhAhAgTcDcDaoaofNduafjLjLjLoZfTcBaoaoaocDgTgTgTgTgTgTgTgTcDaoafafaoafaoeuaoaofTcBaoaoaoafapapaqaqaqaqaqaqapapafaf
 euafafafafaoafaobSdEdEdEezezezezezdEdEdEdEdEdEdEeBeBeBeHeHdEdEdEeLeLeLeLeLeLeLeLeLeLeQafafafaoiSoIeuafaofTduafaoaoafapapaqaqaqaqaqaqapapafaf
 euoKafafafaoafbSdEdEnbeSeSeSeSeSeSeSdEdEdEdEeVeVfcfcfcfdfddEdEdEeLeLnceLeLeLeLeLeLdEdEeQafafafaocBafotaofNduafaoaoafapapaqaqaqaqaqaqapapaoaf
-afafafafafaoafdEdEdEfhfcfcfcfcfcfcfcfjeHeHdEeVfcfcfcfcfcfndEdEdEftftfcgrgtgugvgwfjdEdEdEafaoaofNcBaffNkTfNduaoafaoafapapaqaqaqaqaqaqapapafeG
+afafafafafaoafdEdEdEfhfcfcfcfcfcfcfcmFeHeHdEeVfcfcfcfcfcfndEdEdEftftfcgrgtgugvgwfjdEdEdEafaoaofNcBaffNkTfNduaoafaoafapapaqaqaqaqaqaqapapafeG
 aoafaoaoaoaofNdEdEfjfcfcfcfcfcfcfcfcfcgAgCgDeVfcfcfcfcfcfceVdEdEftgEgEgEgFgIgEgEfcgJdEdEafaoaofNduiSfVcBaoaofNoLaoafapapaqaqaqaqaqaqapapafaf
 afaoaoafaffTgqgKgOfcfcfcgQfcgQgRgQfcfcgAfcgDeVfcgwgwgwfcfceVdEgSgUgEgEgEgXgIgEgEgEfcgJeHduaoaofNduaffNcBaoafkVcBaoafapapaqaqaqaqaqaqapapbzao
 aoafafaoaffTgqgKgOfcfcdEnbhedEdEdEgSfcfcfcgZfcfcfcfcfcfcfceVdEdEhcgEhdgEgEhegEgEgEgEhfhggWcBaffTduafowcBaoaffToxafafapapaqaqaqaqaqaqapapafaJ
@@ -868,16 +870,17 @@ aobbafcRcRcRcScScTcRcRcRcUcVcRcRcWcXevcRcRcReDakhHavfobybIapapaqaqaqaqaqaqapapaf
 aoeIcHcRdbdcdddecTcRdfdgdedhcYdidjdkdcdldmdnafakalajajamexapapaqaqogohaqaqapapafeJjTajajdpanafafafeKafafeKaoaoafaoafaoafafaoaoaoaoaoafafafaf
 aSaocHdrdbcTcTcTcTcRdscTcTcTcTcTcTcTcTcTcTdtduakalajajdYexapapaqoiojokaqaqapapafafafafcIcIbqcIcIbqcIcIbqafeOafafafcDcDcPcPcPcPcDcDcPcDcDcPcP
 afcYdvdwdbcTcTcTcTcTcTcTcTcTcTdxcTcTcTcTcTdydueJalajajamexapapaqaqolomaqaqapapafbgafakdMavfkflflflavavdOanafafafdvcJcKfefefefefefefefefecKcL
-afafeNdzcYcTcTcTcTdAcTcTcTcTcTcTcTcTcTcTgPcRduaJafafafafafonapaqaqpfooaqaqapapafePafcMdSajfpfmfmajfpajdUbTafafeRcHfgasefefefmgmambawawmsaLcN
+afafeNdzcYcTcTcTcTdAcTcTcTcTcTcTcTcTcTcTgPcRduaJnRafafafafonapaqaqpfooaqaqapapafePafcMdSajfpfmfmajfpajdUbTafafeRcHfgasefefefmgmambawawmsaLcN
 afbgdvcRcYdBcTcTdCcRcTcTcTdDiKdFcYdfdGdHdHcRduafafafeGafafapapaqaqaqaqaqaqapapafafaoakdZbHfqbHfqajbHbHeabTaoeDaodvcOejaNfSfSfSfSfSfSfSelfucN
 afafafdIcYcRcRdJcYcYcYcYcYcRdgdgcRcRcRdKdjcRduafaoaoafafafapapaqaqaqaqaqaqapapafeGafafcQcbcbcQcQajcQcQdaaopbafafdvjCbFfSfSfSfSfzfSfSfSfSfAaQ
 afafafafafdLdLdLdLafafafafdLdLdLdLdLdLdLdLdLafaoaoafafafhEapapaqaqaqaqaqaqapapafafajajajajajajajajajajajajajajajajfwfSfSfSfSfziffzfSfSfSfAaQ
-afafafaoafaoafafafafafeueueueuafafafafafafafafaoafeueuafafapapaqaqoWaqaqaqapapafafafaocIbqbqcIdPajlubqbqiGiHhFaohajDbFfSfSfSfSfzfSfSiglzlVaQ
+afafafaoafaoafafafafafeueueueuafafafafafafafafaoafeueuafafapapaqaqnZaqaqaqapapafafafaocIbqbqcIdPajlubqbqiGiHhFaohajDbFfSfSfSfSfzfSfSiglzlVaQ
 afafaoafafaoafafeueueuafafafeuafaoaoafaoafafafafeueuafaoaoapapaqaqpcpepgaqapapaJafcCakegavehehavajavaveilwaJbzdRhaariifSfSfSfSfSfSfSijaNfAcN
 afaoaoafafaoafeueuafafafeueuaoaoafafafafaoaoafeudNcoaoaophapapaqaqaqaqaqaqapapafafeTcMalajajajajajajajamlweGaoaooQaKikaNfSlUlPmflOfSfSfSfAcN
 afaoafafeueuaoeueuaoeuaoaoaoaoaoaoaoaoaoaoeuaoafdTcrafaopaapapaqaqaqaqaqaqapiViUbgaoakalajajajajajajajamandWaodWafarildXedlQlRlRlQedlYedimaQ
 bpafaoaoaoafafafafaoeueueueuafafafafafafaoaoafafdTcsmGafecapapaqaqaqaqaqaqiViViUiUafcMenbcaGaTaFbdajbceogMgLgNcnhbepbRbRbRekeklTlTbRbRememes
 "}
+
 (1,1,2) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
if a smg is only full auto its move delay is set to 30, if its full auto it keeps its delay, smgs were made to assault enemy positions in ww2 so thats why i decreased the move delay also nerfed Ppd40 as soviets have a high chance to get equipped with it right now