### PR TITLE
Removes "uses_squads" from Operation Falcon Lts

### DIFF
--- a/code/game/objects/map_metadata/forest.dm
+++ b/code/game/objects/map_metadata/forest.dm
@@ -58,9 +58,9 @@
 
 /obj/map_metadata/forest/cross_message(faction)
 	if (faction == GERMAN)
-		return "<font size = 4>The germans may cross!,</font>"
+		return "<font size = 4>The Germans may now cross!</font>"
 	else if (faction == RUSSIAN)
-		return "<font size = 4>The soviets may cross!</font>"
+		return "<font size = 4>The Soviets may now cross!</font>"
 	else
 		return ""
 

--- a/code/modules/1713/jobs/dutch.dm
+++ b/code/modules/1713/jobs/dutch.dm
@@ -554,14 +554,13 @@
 /datum/job/dutch/modern_lieutenant
 	title = "Eerste Luitenant"
 	en_meaning = "Lieutenant"
-	rank_abbreviation = "Lt"
+	rank_abbreviation = "Lt."
 	spawn_location = "JoinLateRNCap"
 
 	is_operation_falcon = TRUE
 	is_commander = TRUE
 	is_officer = TRUE
 
-	uses_squads = TRUE
 	whitelisted = TRUE
 
 	additional_languages = list("English" = 70)
@@ -611,7 +610,7 @@
 /datum/job/dutch/modern_squadleader
 	title = "Sergeant der Eerste Klasse"
 	en_meaning = "Squad Leader"
-	rank_abbreviation = "Sgt"
+	rank_abbreviation = "Sgt."
 	spawn_location = "JoinLateRN"
 
 	is_operation_falcon = TRUE
@@ -666,7 +665,7 @@
 /datum/job/dutch/modern_medic
 	title = "Veld Arts"
 	en_meaning = "Doctor"
-	rank_abbreviation = "AR"
+	rank_abbreviation = "Ar."
 	spawn_location = "JoinLateRN"
 
 	is_operation_falcon = TRUE
@@ -724,7 +723,7 @@
 /datum/job/dutch/modern_radioman
 	title = "Korporaal der Eerste Klasse"
 	en_meaning = "Radioman"
-	rank_abbreviation = "Kpl1"
+	rank_abbreviation = "Kpl1."
 	spawn_location = "JoinLateRN"
 
 	is_operation_falcon = TRUE
@@ -778,7 +777,7 @@
 /datum/job/dutch/modern_rifleman
 	title = "Soldaat der Eerste Klasse"
 	en_meaning = "Soldier First Class"
-	rank_abbreviation = "Sld1"
+	rank_abbreviation = "Sld1."
 	spawn_location = "JoinLateRN"
 
 	is_operation_falcon = TRUE
@@ -830,7 +829,7 @@
 /datum/job/dutch/modern_tanker
 	title = "Huzaar Cavalerie"
 	en_meaning = "Tanker"
-	rank_abbreviation = "Sgt"
+	rank_abbreviation = "Sgt."
 	spawn_location = "JoinLateRN"
 
 	is_operation_falcon = TRUE
@@ -927,7 +926,7 @@
 /datum/job/dutch/weapon_specialist
 	title = "Wapen Specialist"
 	en_meaning = "Weapons Specialist"
-	rank_abbreviation = "Kpl"
+	rank_abbreviation = "Kpl."
 	spawn_location = "JoinLateRN"
 
 	is_operation_falcon = TRUE

--- a/code/modules/1713/jobs/russian.dm
+++ b/code/modules/1713/jobs/russian.dm
@@ -2308,13 +2308,12 @@
 /datum/job/russian/modern_lieutenant
 	title = "Starshiy Leitenant"
 	en_meaning = "1st Lieutenant"
-	rank_abbreviation = "Stl."
+	rank_abbreviation = "St. Lt."
 
 	is_operation_falcon = TRUE
 	is_commander = TRUE
 	is_officer = TRUE
 
-	uses_squads = TRUE
 	whitelisted = TRUE
 
 	additional_languages = list("English" = 70)


### PR DESCRIPTION
- Removes "uses_squads" from Operation Falcon Lts as they spawned on Sgts
- Fixes a typo in Forest metadata