### PR TITLE
Admin Faction Announcements

### DIFF
--- a/code/game/objects/items/stacks/civ_recipes.dm
+++ b/code/game/objects/items/stacks/civ_recipes.dm
@@ -89,7 +89,7 @@
 /material/proc/generate_recipes_civs(var/list/current_res = list(0,0,0), faction = "global")
 
 	recipes = list()
-	var chosen_list = craftlist_lists[faction]
+	var/chosen_list = craftlist_lists[faction]
 	if (hardness>=40 && current_res[1] > 8 && (map && map.ID != MAP_GULAG13))
 		recipes += new/datum/stack_recipe("[display_name] fork", /obj/item/weapon/material/kitchen/utensil/fork, TRUE, _on_floor = TRUE, _supplied_material = "[name]")
 		recipes += new/datum/stack_recipe("[display_name] spoon", /obj/item/weapon/material/kitchen/utensil/spoon, TRUE, _on_floor = TRUE, _supplied_material = "[name]")

--- a/code/game/objects/map_metadata/the_art_of_the_deal.dm
+++ b/code/game/objects/map_metadata/the_art_of_the_deal.dm
@@ -63,13 +63,13 @@
 	..()
 	spawn(3000)
 		score()
-	var/newnamea = list("Rednikov Industries" = list(230,230,230,null,0,"sun","#7F0000","#7F7F7F",0,0))
-	var/newnameb = list("Giovanni Blu Stocks" = list(230,230,230,null,0,"sun","#00007F","#7F7F7F",0,0))
-	var/newnamec = list("Kogama Kraftsmen" = list(230,230,230,null,0,"sun","#007F00","#7F7F7F",0,0))
-	var/newnamed = list("Goldstein Solutions" = list(230,230,230,null,0,"sun","#E5E500","#7F7F7F",0,0))
-	var/newnamee = list("Sheriff Office" = list(230,230,230,null,0,"star","#E5E500","#00007F",0,0))
-	var/newnamef = list("Paramedics" = list(230,230,230,null,0,"cross","#7F0000","#FFFFFF",0,0))
-	var/newnameg = list("Government" = list(230,230,230,null,0,"star","#E3E3E3", "#3e57a8",0,0))
+	var/newnamea = list("Rednikov Industries" = list(0,0,0,null,0,"sun","#7F0000","#7F7F7F",0,0))
+	var/newnameb = list("Giovanni Blu Stocks" = list(0,0,0,null,0,"sun","#00007F","#7F7F7F",0,0))
+	var/newnamec = list("Kogama Kraftsmen" = list(0,0,0,null,0,"sun","#007F00","#7F7F7F",0,0))
+	var/newnamed = list("Goldstein Solutions" = list(0,0,0,null,0,"sun","#E5E500","#7F7F7F",0,0))
+	var/newnamee = list("Sheriff Office" = list(0,0,0,null,0,"star","#E5E500","#00007F",0,0))
+	var/newnamef = list("Paramedics" = list(0,0,0,null,0,"cross","#7F0000","#FFFFFF",0,0))
+	var/newnameg = list("Government" = list(0,0,0,null,0,"star","#E3E3E3", "#3e57a8",0,0))
 	custom_civs += newnamea
 	custom_civs += newnameb
 	custom_civs += newnamec

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -336,6 +336,33 @@ proc/admin_notice(var/message, var/rights)
 		world << "<big><span class=notice><b>[messaget]</b></big><p style='text-indent: 30px'>[message]</p></span>"
 		log_admin("Announce: [key_name(usr)] - [messaget] : [message]")
 
+/datum/admins/proc/custom_faction_announce()
+	set category = "Special"
+	set name = "Custom Faction Announcement"
+	set desc = "Announce events for a specific faction."
+	if (!check_rights(0))	return
+
+	if (!map.civilizations)
+		var/list/choicelist = list("Cancel")
+		for (var/i in map.faction_organization)
+			choicelist += i
+		var/faction_choice = WWinput(src, "Which faction to announce?", "Custom Faction Announcement", "Cancel", choicelist)
+		if (faction_choice == "Cancel")
+			return
+		else
+			var/messaget = input("Message Title:", "Custom Faction Announcement", null, null)
+			var/message = input("Global message to send:", "Custom Faction Announcement", null, null)
+			if (message)
+				if (!check_rights(R_SERVER,0))
+					message = sanitize(message, 500, extra = FALSE)
+				message = replacetext(message, "\n", "<br>") // required since we're putting it in a <p> tag
+				for (var/mob/living/human/M)
+					if (faction_choice == M.faction_text)
+						M.show_message("<big><span class=notice><b>[messaget]</b></big><p style='text-indent: 10px'>[message]</p></span>", 2)
+						log_admin("Custom Faction Announcement: [key_name(usr)] - [messaget] : [message]")
+	else
+		return
+
 
 /datum/admins/proc/toggleooc()
 	set category = "Server"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -58,6 +58,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_change_custom_event,
 	/client/proc/allow_character_respawn,	// Allows a ghost to respawn ,
 	/datum/admins/proc/ic_announce,
+	/datum/admins/proc/custom_faction_announce, //Allows for a custom faction announcement on TDM maps.
 	/client/proc/change_human_appearance_admin,	// Allows an admin to change the basic appearance of human-based mobs ,
 	/client/proc/change_human_appearance_self,	// Allows the human-based mob itself change its basic appearance ,
 	/client/proc/view_chemical_reaction_logs,
@@ -96,6 +97,7 @@ var/list/admin_verbs_trialadmin = list(
 	/client/proc/Jump,
 	/client/proc/jumptocoord,
 	/datum/admins/proc/ic_announce,
+	/datum/admins/proc/custom_faction_announce,
 	/client/proc/start_epochswap_vote,
 	)
 


### PR DESCRIPTION
- Makes admins able to do a specific faction announcement on TDM instead of only global ones
- Lowers all AOTD civilization's research levels to 0 (Test-run, seeing how that method of restricting crafting will affect gameplay)
- Typo fix in civ_recipes.dm