### PR TITLE
Fixes runtime in barbwire.dm

### DIFF
--- a/code/modules/1713/barbwire.dm
+++ b/code/modules/1713/barbwire.dm
@@ -56,7 +56,8 @@
 				H.updatehealth()
 				if (!(H.species && (H.species.flags)))
 					H.Weaken(1)
-				M << "<span class = 'red'><b>Your [affecting.name] gets cut by \the [src]!</b></span>"
+				if (affecting)
+					M << "<span class = 'red'><b>Your [affecting.name] gets cut by \the [src]!</b></span>"
 			else
 				playsound(loc, 'sound/effects/glass_step.ogg', 50, TRUE)
 				var/obj/item/organ/external/affecting = H.get_organ(pick("l_foot", "r_foot", "l_leg", "r_leg"))
@@ -65,7 +66,8 @@
 				H.updatehealth()
 				if (!(H.species && (H.species.flags)))
 					H.Weaken(1)
-				M << "<span class = 'red'><b>Your [affecting.name] gets deeply cut by \the [src]!</b></span>"
+				if (affecting)
+					M << "<span class = 'red'><b>Your [affecting.name] gets deeply cut by \the [src]!</b></span>"
 			// stop crawling until we're up to prevent buggy crawling
 			H.scrambling = TRUE
 			spawn (35)


### PR DESCRIPTION
[19:56:03] Runtime in barbwire.dm,59: Cannot read null.name
   Caught by process: throwing
   proc name: Crossed (/obj/structure/barbwire/Crossed)
   src: Shi. Gui Yu (the dry dirt) (35,74,1) (/turf/floor/dirt/dust) ()
   src.loc: Shi. Gui Yu (the dry dirt) (35,74,1) (/turf/floor/dirt/dust) ()
   src.loc: the dry dirt (35,74,1) (/turf/floor/dirt/dust)
   call stack:
   the barbwire (/obj/structure/barbwire): Crossed(Shi. Gui Yu (/mob/living/human))
   Shi. Gui Yu (/mob/living/human): forceMove(the dry dirt (35,74,1) (/turf/floor/dirt/dust), null)
   Shi. Gui Yu (/mob/living/human): forceMove(the dry dirt (35,74,1) (/turf/floor/dirt/dust), null)
   Shi. Gui Yu (/mob/living/human): forceMove nondenseturf(the dry dirt (35,74,1) (/turf/floor/dirt/dust), null)
   throwing (/process/throwing): fire()
   throwing (/process/throwing): process()
   /processScheduler (/processScheduler): relayProcess(throwing (/process/throwing), /list (/list))
   /processScheduler (/processScheduler): runQueuedProcesses()
   /processScheduler (/processScheduler): process()
   /processScheduler (/processScheduler): start()