### PR TITLE
Allow persistence without saving

### DIFF
--- a/code/datums/configuration.dm
+++ b/code/datums/configuration.dm
@@ -146,6 +146,7 @@ var/list/gamemode_cache = list()
 
 	var/daynight_on = TRUE
 	var/seasons_on = TRUE
+	var/skip_persistence_saving = FALSE
 /datum/configuration/proc/load(filename, type = "config") //the type can also be game_options, in which case it uses a different switch. not making it separate to not copypaste code - Urist
 
 	var/list/Lines = file2list(filename)
@@ -438,6 +439,10 @@ var/list/gamemode_cache = list()
 
 				if ("redirect_all_players")
 					redirect_all_players = value
+				
+				if ("skip_persistence_saving")
+					config.skip_persistence_saving = TRUE
+
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -309,19 +309,19 @@ var/world_topic_spam_protect_time = world.timeofday
 
 var/global/nextsave = 0
 /proc/start_persistence_loop()
-	spawn(300)
-		if (map && map.persistence)
-			var/minsleft = 60-text2num(time2text(world.realtime,"mm"))
-			var/secsleft = 60-text2num(time2text(world.realtime,"ss"))
-			var/hr = (text2num(time2text(world.realtime,"hh")) & 0x1) //only odd hours
-			if (minsleft <= 2 && hr)
-				world << "<font color='yellow' size=4><b>Attention - Round will be saved in approximately <b>[minsleft-1] minutes</b> and <b>[secsleft-1] seconds</b>. Game might lag up to a couple of minutes.</b></font>"
-			if (nextsave <= world.realtime)
-				nextsave = world.realtime + 216000
-				spawn(0)
-					ticker.savemap()
-
-		start_persistence_loop()
+	if (! config.skip_persistence_saving)
+		spawn(300)
+			if (map && map.persistence)
+				var/minsleft = 60-text2num(time2text(world.realtime,"mm"))
+				var/secsleft = 60-text2num(time2text(world.realtime,"ss"))
+				var/hr = (text2num(time2text(world.realtime,"hh")) & 0x1) //only odd hours
+				if (minsleft <= 2 && hr)
+					world << "<font color='yellow' size=4><b>Attention - Round will be saved in approximately <b>[minsleft-1] minutes</b> and <b>[secsleft-1] seconds</b>. Game might lag up to a couple of minutes.</b></font>"
+				if (nextsave <= world.realtime)
+					nextsave = world.realtime + 216000
+					spawn(0)
+						ticker.savemap()
+			start_persistence_loop()
 
 /proc/start_messaging_loop()
 	spawn while (1)

--- a/config/config.txt
+++ b/config/config.txt
@@ -214,3 +214,6 @@ DISABLE_FOV
 
 #if uncommented, redirects all players to the target server
 #REDIRECT_ALL_PLAYERS byond://civ13.com:1714
+
+#if uncommented, does not automatically save persistence rounds to file
+SKIP_PERSISTENCE_SAVING


### PR DESCRIPTION
Saving files can take a long time and requires at least twice as much memory as is currently allocated, which can force DreamDaemon to run out of memory when otherwise it would not, effectively making it impossible to have long running rounds.

This can be merged immediately.