### PR TITLE
Adds vehicle_type var for vehicle axis (used for roof and frame layers)

### DIFF
--- a/code/modules/1713/machinery/modular_vehicles/frame_icons.dm
+++ b/code/modules/1713/machinery/modular_vehicles/frame_icons.dm
@@ -362,8 +362,10 @@
 				ticon = broken_icon
 			else
 				ticon = normal_icon
-
-		roof = image(icon=icon, loc=src, icon_state=replacetext(src.icon_state,"frame","roof"), layer=10.1)
+		if (axis.vehicle_type == "apc")
+			roof = image(icon=icon, loc=src, icon_state=replacetext(src.icon_state,"frame","roof"), layer=10.1)// This code parts needs adjustment in case layering issues re-appear
+		else
+			roof = image(icon=icon, loc=src, icon_state=replacetext(src.icon_state,"frame","roof"), layer=9.9)
 
 		if (override_roof_icon)
 			roof.icon_state = override_roof_icon

--- a/code/modules/1713/machinery/vehicles.dm
+++ b/code/modules/1713/machinery/vehicles.dm
@@ -17,6 +17,7 @@
 	icon = 'icons/obj/vehicles/vehicleparts.dmi'
 	icon_state = "axis_powered"
 	var/vehicle_size = "3x4"
+	var/vehicle_type = "car"
 	var/list/wheels = list()
 	var/currentspeed = 0
 	var/speeds = 5
@@ -49,6 +50,7 @@
 	speedlist = list(1=3,2=2,3=1)
 	reg_number = ""
 	turntimer = 5
+	vehicle_type = "bike"
 
 /obj/structure/vehicleparts/axis/carriage
 	name = "carriage axis"
@@ -58,6 +60,7 @@
 	speedlist = null
 	reg_number = ""
 	turntimer = 5
+	vehicle_type = "carriage"
 
 /obj/structure/vehicleparts/axis/boat
 	name = "boat rudder control"
@@ -66,6 +69,7 @@
 	maxpower = 40
 	speedlist = list(1=8,2=6,3=4)
 	reg_number = ""
+	vehicle_type = "boat"
 
 /obj/structure/vehicleparts/axis/heavy
 	name = "heavy vehicle axis"
@@ -75,6 +79,7 @@
 	speeds = 3
 	maxpower = 2500
 	speedlist = list(1=12,2=8,3=6)
+	vehicle_type = "tank"
 
 /obj/structure/vehicleparts/axis/heavy/is3
 	name = "IS-3"
@@ -149,6 +154,7 @@
 	color = "#4a5243"
 	turret_type = "none"
 	vehicle_size = "2x4"
+	vehicle_type = "apc"
 	New()
 		..()
 		var/pickedname = pick(tank_names_soviet)
@@ -163,6 +169,7 @@
 	turret_type = "none"
 	vehicle_size = "3x4"
 	color = "#939276"
+	vehicle_type = "apc"
 	New()
 		..()
 		var/pickedname = pick(tank_names_usa)
@@ -177,6 +184,7 @@
 	color = "#787859"
 	turret_type = "bmd2_turret"
 	vehicle_size = "2x4"
+	vehicle_type = "apc"
 	New()
 		..()
 		var/pickedname = pick(tank_names_soviet)
@@ -191,6 +199,7 @@
 	color = "#787859"
 	turret_type = "bmd2_turret"
 	vehicle_size = "2x3"
+	vehicle_type = "apc"
 	New()
 		..()
 		var/pickedname = pick(tank_names_soviet)
@@ -426,6 +435,7 @@
 	maxpower = 800
 	speedlist = list(1=8,2=6,3=4,4=3,5=2)
 	turntimer = 8
+	vehicle_type = "car"
 
 /obj/structure/vehicleparts/axis/proc/get_speed()
 	if (currentspeed <= 0)


### PR DESCRIPTION
Adds the "vehicle_type" var for vehicle axis as a solution to fix roof and frame layering issues.

Our classic cars have their "frames" (actually walls, doors, windos) over the roof layer. Meanwhile, recent APCs have overlapping frame and roof icons, causing a line messing up the roof sprites. This should fix most of the issues encountered. This var can of course be extended for other functions.