### PR TITLE
Hotfix for large maps 

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -16,6 +16,7 @@ var/global/list/faction_list_red = list()
 var/global/list/faction_list_blue = list()
 var/global/list/craftlist_lists = list("global" = list())
 var/global/list/dictionary_list = list()
+world/loop_checks=0
 /*
 	Pre-map initialization stuff should go here.
 */


### PR DESCRIPTION
This is a bad fix, but it is a proper one for the time being until we optimize our code better. Large maps are simple too large for procs like lighting to complete without DreamDaemon thinking it's an infinite loop as it exceeds built-in safety thresholds.