### PR TITLE
makes mortar unwrenching faster

### DIFF
--- a/code/modules/1713/siege/piece.dm
+++ b/code/modules/1713/siege/piece.dm
@@ -146,7 +146,7 @@
 				return
 	else if (istype(W,/obj/item/weapon/wrench) && !can_assemble)
 		M << (anchored ? "<span class='notice'>You start unfastening \the [src] from the floor.</span>" : "<span class='notice'>You start securing \the [src] to the floor.</span>")
-		if (do_after(M, 5 SECONDS, src))
+		if (do_after(M, 2 SECONDS, src))
 			playsound(loc, 'sound/items/Ratchet.ogg', 100, TRUE)
 			M << (anchored ? "<span class='notice'>You unfasten \the [src] from the floor.</span>" : "<span class='notice'>You secure \the [src] to the floor.</span>")
 			anchored = !anchored
@@ -186,7 +186,7 @@
 			return
 	else if (istype(W,/obj/item/weapon/wrench) && !can_assemble)
 		M << (anchored ? "<span class='notice'>You start unfastening \the [src] from the floor.</span>" : "<span class='notice'>You start securing \the [src] to the floor.</span>")
-		if (do_after(M, 5 SECONDS, src))
+		if (do_after(M, 2 SECONDS, src))
 			playsound(loc, 'sound/items/Ratchet.ogg', 100, TRUE)
 			M << (anchored ? "<span class='notice'>You unfasten \the [src] from the floor.</span>" : "<span class='notice'>You secure \the [src] to the floor.</span>")
 			anchored = !anchored
@@ -243,7 +243,7 @@
 					do_html(M)
 	else if (istype(W,/obj/item/weapon/wrench))
 		M << (anchored ? "<span class='notice'>You start unfastening \the [src] from the floor.</span>" : "<span class='notice'>You start securing \the [src] to the floor.</span>")
-		if (do_after(M, 5 SECONDS, src))
+		if (do_after(M, 2 SECONDS, src))
 			playsound(loc, 'sound/items/Ratchet.ogg', 100, TRUE)
 			M << (anchored ? "<span class='notice'>You unfasten \the [src] from the floor.</span>" : "<span class='notice'>You secure \the [src] to the floor.</span>")
 			anchored = !anchored
@@ -429,7 +429,7 @@
 				if (istype(loaded, /obj/item/cannon_ball/mortar_shell/incendiary))
 					explosion = FALSE
 					incendiary = TRUE
-				
+
 				if (istype(loaded, /obj/item/cannon_ball/shell/nuclear))
 					nuclear = TRUE
 				qdel(loaded)


### PR DESCRIPTION
unreal. irl mortars are more powerfull and cause shrapnels/supress infantry alot, ingame they just make a 3X3 explosion and take alot of effort to set up, making it harder to set them up just discourages the use of them for no reason