### PR TITLE
Loop_checks disabled only if it's Nomads Persistence, re-enables Bank Robbery

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -865,6 +865,7 @@
 		icon_state = base_icon
 	else
 		icon_state = "[base_icon]_empty"
+	return
 
 /obj/item/weapon/reagent_containers/food/drinks/can/monster
 	icon_state = "monster"

--- a/code/processes/mapswap.dm
+++ b/code/processes/mapswap.dm
@@ -159,7 +159,7 @@
 				MAP_WACO = 0,
 				MAP_YELTSIN = 6,
 				MAP_GROZNY = 6,
-				//MAP_BANK_ROBBERY = 0,
+				MAP_BANK_ROBBERY = 0,
 				MAP_DRUG_BUST = 0,
 				MAP_ARAB_TOWN = 0,
 				MAP_ARAB_TOWN_2 = 0,

--- a/code/world.dm
+++ b/code/world.dm
@@ -16,7 +16,6 @@ var/global/list/faction_list_red = list()
 var/global/list/faction_list_blue = list()
 var/global/list/craftlist_lists = list("global" = list())
 var/global/list/dictionary_list = list()
-world/loop_checks=0
 /*
 	Pre-map initialization stuff should go here.
 */
@@ -65,6 +64,8 @@ var/world_is_open = TRUE
 #define RECOMMENDED_VERSION 512
 /world/New()
 
+	if (map && istype(map,/obj/map_metadata/nomads_persistence_beta))
+		loop_checks = FALSE
 	config.post_load()
 
 	if (config && config.server_name != null && config.server_suffix && world.port > 0)


### PR DESCRIPTION
- world.loop_checks is only disabled if it's Nomads Persistence Beta
- Puts back Bank Robbery into rotation
- Possible empty can fix