### PR TITLE
Surgery fix part 1

### DIFF
--- a/civ13.dme
+++ b/civ13.dme
@@ -1048,6 +1048,7 @@
 #include "code\modules\reagents\reagent_containers\glass\bottle.dm"
 #include "code\modules\surgery\_defines.dm"
 #include "code\modules\surgery\bones.dm"
+#include "code\modules\surgery\encased.dm"
 #include "code\modules\surgery\face.dm"
 #include "code\modules\surgery\generic.dm"
 #include "code\modules\surgery\implant.dm"

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -962,6 +962,7 @@ proc/is_hot(obj/item/W as obj)
 	istype(W, /obj/item/weapon/surgery/hemostat)		||	\
 	istype(W, /obj/item/weapon/surgery/retractor)		||	\
 	istype(W, /obj/item/weapon/surgery/cautery)			||	\
+	istype(W, /obj/item/weapon/surgery/bone_saw)			||	\
 	istype(W, /obj/item/weapon/surgery/bonesetter)
 	)
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -62,7 +62,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if (!ismob(user))
 		return FALSE
 	if (can_operate(src) && do_surgery(src,user,I)) //Surgery
-		return TRUE
+		if (I.can_do_surgery(src,user))
+			return TRUE
+		else 
+			return FALSE
 	var/tgt = user.targeted_organ
 	if (user.targeted_organ == "random")
 		tgt = pick("l_foot","r_foot","l_leg","r_leg","chest","groin","l_arm","r_arm","l_hand","r_hand","eyes","mouth","head")

--- a/code/game/mob/living/living_defense.dm
+++ b/code/game/mob/living/living_defense.dm
@@ -75,7 +75,7 @@
 
 	//"Stun-like" beams (used in tasers)
 	if(P.taser_effect)
-		stun_effect_act(0, P.agony, def_zone, P)
+		stun_effect_act(P.stun, P.agony, def_zone, P)
 
 	//Armor
 	var/absorb = run_armor_check(def_zone, P.check_armor, P.armor_penetration, damage_source = P)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -52,52 +52,56 @@
 		var/mob/living/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.targeted_organ)
 
-		if (affecting && affecting.open == FALSE)
-			if (affecting.is_bandaged())
-				user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>"
-				return TRUE
-			else
-				user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
-									 "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
-				var/used = FALSE
-				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
-						continue
-					if (W.bandaged)
-						continue
-					if (used == amount)
-						break
-					if (!do_mob(user, M, W.damage/5))
-						user << "<span class='notice'>You must stand still to bandage wounds.</span>"
-						break
-
-					if (W.current_stage <= W.max_bleeding_stage)
-						user.visible_message("<span class='notice'>\The [user] bandages \a [W.desc] on [M]'s [affecting.name].</span>", \
-													  "<span class='notice'>You bandage \a [W.desc] on [M]'s [affecting.name].</span>" )
-						//H.add_side_effect("Itch")
-					else if (W.damage_type == BRUISE)
-						user.visible_message("<span class='notice'>\The [user] places a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
-													  "<span class='notice'>You place a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					else
-						user.visible_message("<span class='notice'>\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>", \
-													  "<span class='notice'>You place a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					W.bandage()
-					used++
-				affecting.update_damages()
-				if (used == amount)
-					if (affecting.is_bandaged())
-						user << "<span class='warning'>\The [src] is used up.</span>"
-					else
-						user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
-				use(used)
-				H.update_bandaging(0)
+		if(!affecting)
+			return
+		if (affecting.open)
+			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
+			return
+		if (affecting.is_bandaged())
+			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>"
+			return TRUE
 		else
+			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
+									"<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
+			var/used = FALSE
+			for (var/datum/wound/W in affecting.wounds)
+				if (W.internal)
+					continue
+				if (W.bandaged)
+					continue
+				if (used == amount)
+					break
+				if (!do_mob(user, M, W.damage/5))
+					user << "<span class='notice'>You must stand still to bandage wounds.</span>"
+					break
+
+				if (W.current_stage <= W.max_bleeding_stage)
+					user.visible_message("<span class='notice'>\The [user] bandages \a [W.desc] on [M]'s [affecting.name].</span>", \
+													"<span class='notice'>You bandage \a [W.desc] on [M]'s [affecting.name].</span>" )
+					//H.add_side_effect("Itch")
+				else if (W.damage_type == BRUISE)
+					user.visible_message("<span class='notice'>\The [user] places a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
+													"<span class='notice'>You place a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				else
+					user.visible_message("<span class='notice'>\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>", \
+													"<span class='notice'>You place a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				W.bandage()
+				used++
+			affecting.update_damages()
+			if (used == amount)
+				if (affecting.is_bandaged())
+					user << "<span class='warning'>\The [src] is used up.</span>"
+				else
+					user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
+			use(used)
+			H.update_bandaging(1)
+		/*else
 			if (can_operate(H))		//Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src))
 					return
 			else
 				if (affecting)
-					user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+					user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"*/
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "trauma kit"
@@ -117,51 +121,55 @@
 		var/mob/living/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.targeted_organ)
 
-		if (affecting && (affecting.open == FALSE || (affecting.open && !affecting.is_disinfected())))
-			if (affecting.is_bandaged() && affecting.is_disinfected())
-				user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>"
-				return TRUE
-			else
-				user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
-									 "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
-				var/used = 0
-				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
-						continue
-					if (W.bandaged && W.disinfected)
-						continue
-					if (used == amount)
-						break
-					if (!do_mob(user, M, W.damage/5))
-						user << "<span class='notice'>You must stand still to bandage wounds.</span>"
-						break
-					if (W.current_stage <= W.max_bleeding_stage)
-						user.visible_message("<span class='notice'>\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and covers it with a bandage.</span>", \
-											 "<span class='notice'>You clean and cover \a [W.desc] on [M]'s [affecting.name].</span>" )
-					else if (W.damage_type == BRUISE)
-						user.visible_message("<span class='notice'>\The [user] places a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
-													  "<span class='notice'>You place a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					else
-						user.visible_message("<span class='notice'>\The [user] smears some ointment over \a [W.desc] on [M]'s [affecting.name].</span>", \
-													  "<span class='notice'>You smear some ointment over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					W.bandage()
-					W.disinfect()
-					W.heal_damage(heal_brute)
-					used++
-				affecting.update_damages()
-				if (used == amount)
-					if (affecting.is_bandaged())
-						user << "<span class='warning'>\The [src] is used up.</span>"
-					else
-						user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
-				use(used)
+		if(!affecting)
+			return
+		if (affecting.open)
+			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
+			return
+		if (affecting.is_bandaged() && affecting.is_disinfected())
+			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>"
+			return TRUE
 		else
-			if (can_operate(H))		//Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
-					return
-			else
-				if (affecting)
-					user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
+								"<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
+			var/used = 0
+			for (var/datum/wound/W in affecting.wounds)
+				if (W.internal)
+					continue
+				if (W.bandaged && W.disinfected)
+					continue
+				if (used == amount)
+					break
+				if (!do_mob(user, M, W.damage/5))
+					user << "<span class='notice'>You must stand still to bandage wounds.</span>"
+					break
+				if(affecting.is_bandaged() && affecting.is_disinfected()) // We do a second check after the delay, in case it was bandaged after the first check.
+					to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>")
+					return TRUE
+				if(used >= src.amount)
+					to_chat(user, "<span class='warning'>You run out of [src]!</span>")
+					break
+				if (W.current_stage <= W.max_bleeding_stage)
+					user.visible_message("<span class='notice'>\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and covers it with a bandage.</span>", \
+										"<span class='notice'>You clean and cover \a [W.desc] on [M]'s [affecting.name].</span>" )
+				else if (W.damage_type == BRUISE)
+					user.visible_message("<span class='notice'>\The [user] places a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
+												"<span class='notice'>You place a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				else
+					user.visible_message("<span class='notice'>\The [user] smears some ointment over \a [W.desc] on [M]'s [affecting.name].</span>", \
+												"<span class='notice'>You smear some ointment over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				W.bandage()
+				W.disinfect()
+				W.heal_damage(heal_brute)
+				used++
+			affecting.update_damages()
+			if (used == amount)
+				if (affecting.is_bandaged())
+					user << "<span class='warning'>\The [src] is used up.</span>"
+				else
+					user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
+			use(used)
+			H.update_bandaging(1)
 
 		var/mob/living/human/H_user = user
 		if (istype(H_user) && H_user.getStatCoeff("medical") >= GET_MIN_STAT_COEFF(STAT_VERY_HIGH))
@@ -190,46 +198,44 @@
 		var/mob/living/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.targeted_organ)
 
-		if (affecting)
-			if (affecting.is_salved() && affecting.is_disinfected())
-				user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>"
-				return TRUE
+		if(!affecting)
+			return
+			
+		if (affecting.open)
+			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than some healing herbs!</span>"
 
-			if (!affecting.is_disinfected() || !affecting.is_salved())
-				user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
-									 "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
-				var/used = 0
-				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
-						continue
-					if (W.salved && W.disinfected)
-						continue
-					if (used == amount)
-						break
-					if (!do_mob(user, M, W.damage/5))
-						user << "<span class='notice'>You must stand still to bandage wounds.</span>"
-						break
+		if (affecting.is_salved() && affecting.is_disinfected())
+			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>"
+			return TRUE
 
-					user.visible_message("<span class='notice'>\The [user] rub some healing herbs over \a [W.desc] on [M]'s [affecting.name].</span>", \
-													  "<span class='notice'>You rub some healing herbs over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					W.disinfect()
-					W.salve()
-					W.heal_damage(heal_brute)
-					used++
-				affecting.update_damages()
+		if (!affecting.is_disinfected() || !affecting.is_salved())
+			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
+								"<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
+			var/used = 0
+			for (var/datum/wound/W in affecting.wounds)
+				if (W.internal)
+					continue
+				if (W.salved && W.disinfected)
+					continue
 				if (used == amount)
-					if (affecting.is_bandaged())
-						user << "<span class='warning'>\The [src] is used up.</span>"
-					else
-						user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
-				use(used)
-		else
-			if (can_operate(H))		//Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
-					return
-			else
-				if (affecting)
-					user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than some healing herbs!</span>"
+					break
+				if (!do_mob(user, M, W.damage/5))
+					user << "<span class='notice'>You must stand still to bandage wounds.</span>"
+					break
+
+				user.visible_message("<span class='notice'>\The [user] rub some healing herbs over \a [W.desc] on [M]'s [affecting.name].</span>", \
+												"<span class='notice'>You rub some healing herbs over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				W.disinfect()
+				W.salve()
+				W.heal_damage(heal_brute)
+				used++
+			affecting.update_damages()
+			if (used == amount)
+				if (affecting.is_bandaged())
+					user << "<span class='warning'>\The [src] is used up.</span>"
+				else
+					user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
+			use(used)
 
 		var/mob/living/human/H_user = user
 		if (istype(H_user) && H_user.getStatCoeff("medical") >= GET_MIN_STAT_COEFF(STAT_VERY_HIGH))

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -7,43 +7,42 @@
  *		Bone Saw
  */
 
+
+/obj/item/weapon/surgery
+	name = "surgery tool (do not use)"
+	desc = "This object shouldn't be here. Contact a developer."
+	icon = 'icons/obj/surgery.dmi'
+	flags = CONDUCT
+	w_class = ITEM_SIZE_SMALL
+
+/obj/item/weapon/surgery/attack(mob/M as mob, mob/living/user as mob)
+	if	(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
+		return FALSE
+	..()
 /*
  * Retractor
  */
 /obj/item/weapon/surgery/retractor
 	name = "retractor"
 	desc = "Retracts stuff."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "retractor"
-	flags = CONDUCT
-	w_class = ITEM_SIZE_SMALL
 
 /obj/item/weapon/surgery/retractor/bronze
 	name = "bronze retractor"
-	desc = "Retracts stuff."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bronze_retractor"
-	flags = CONDUCT
-	w_class = ITEM_SIZE_SMALL
+
 /*
  * Hemostat
  */
 /obj/item/weapon/surgery/hemostat
 	name = "hemostat"
 	desc = "Pinches veins. Prevents bleeding."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "hemostat"
-	flags = CONDUCT
-	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "pinched")
 
 /obj/item/weapon/surgery/hemostat/bronze
 	name = "bronze hemostat"
-	desc = "Pinches veins. Prevents bleeding."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bronze_hemostat"
-	flags = CONDUCT
-	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "pinched")
 /*
  * Cautery
@@ -51,19 +50,13 @@
 /obj/item/weapon/surgery/cautery
 	name = "cautery"
 	desc = "A hot iron. Closes wounds and stops bleeding."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "cautery"
-	flags = CONDUCT
-	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("burnt")
 
 /obj/item/weapon/surgery/cautery/bronze
 	name = "bronze cautery"
 	desc = "A hot bronze clamp. Closes wounds and stops bleeding."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bronze_cautery"
-	flags = CONDUCT
-	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("burnt")
 /*
  * Scalpel
@@ -71,9 +64,7 @@
 /obj/item/weapon/surgery/scalpel
 	name = "scalpel"
 	desc = "Cut, cut, and once more cut."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
-	flags = CONDUCT
 	force = WEAPON_FORCE_DANGEROUS
 	sharp = TRUE
 	edge = TRUE
@@ -86,29 +77,15 @@
 
 /obj/item/weapon/surgery/scalpel/bronze
 	name = "bronze scalpel"
-	desc = "Cut, cut, and once more cut."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bronze_scalpel"
-	flags = CONDUCT
-	force = WEAPON_FORCE_DANGEROUS
-	sharp = TRUE
-	edge = TRUE
-	w_class = ITEM_SIZE_TINY
-	slot_flags = SLOT_EARS
-	throwforce = 5.0
-	throw_speed = WEAPON_FORCE_WEAK
-	throw_range = 5
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 /*
  * Circular Saw
  */
 /obj/item/weapon/surgery/bone_saw
 	name = "bone saw"
 	desc = "For heavy duty cutting."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "saw"
 	hitsound = 'sound/weapons/circsawhit.ogg'
-	flags = CONDUCT
 	force = WEAPON_FORCE_ROBUST
 	w_class = ITEM_SIZE_NORMAL
 	throwforce = WEAPON_FORCE_WEAK
@@ -120,28 +97,15 @@
 
 /obj/item/weapon/surgery/bone_saw/bronze
 	name = "bronze bone saw"
-	desc = "For heavy duty cutting."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bronze_bonesaw"
-	hitsound = 'sound/weapons/circsawhit.ogg'
-	flags = CONDUCT
-	force = WEAPON_FORCE_ROBUST
-	w_class = ITEM_SIZE_NORMAL
-	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 3
-	throw_range = 5
-	attack_verb = list("attacked", "slashed", "sawed", "cut")
-	sharp = TRUE
-	edge = TRUE
+
 //misc, formerly from code/defines/weapons.dm
 
 /obj/item/weapon/surgery/surgicaldrill
 	name = "surgical drill"
 	desc = "You can drill using this item. You dig?"
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "drill"
 	hitsound = 'sound/weapons/circsawhit.ogg'
-	flags = CONDUCT
 	force = WEAPON_FORCE_DANGEROUS
 	w_class = ITEM_SIZE_NORMAL
 	attack_verb = list("drilled")
@@ -149,23 +113,13 @@
 /obj/item/weapon/surgery/bonesetter
 	name = "bone setter"
 	desc = "To set bones in place."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bone setter"
 	force = WEAPON_FORCE_NORMAL
 	throwforce = WEAPON_FORCE_NORMAL
 	throw_speed = 3
 	throw_range = 5
-	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "hit", "bludgeoned")
 
 /obj/item/weapon/surgery/bonesetter/bronze
 	name = "bronze bone setter"
-	desc = "To set bones in place."
-	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bronze_bonesetter"
-	force = WEAPON_FORCE_NORMAL
-	throwforce = WEAPON_FORCE_NORMAL
-	throw_speed = 3
-	throw_range = 5
-	w_class = ITEM_SIZE_SMALL
-	attack_verb = list("attacked", "hit", "bludgeoned")

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -79,7 +79,7 @@
 	var/atom/movable/applied_pressure
 	var/burn_ratio = 0
 	var/brute_ratio = 0
-	var/encased = ""
+	var/encased
 	var/cavity_name = ""
 
 /obj/item/organ/external/New()
@@ -1385,7 +1385,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(brute_dam + force < min_broken_damage/5)	//no papercuts moving bones
 		return
 	if(internal_organs.len && prob(brute_dam + force))
-		owner.custom_pain("A piece of bone in your [name] moves painfully!", 50)
+		owner.custom_pain("A piece of bone in your [encased ? encased : name] moves painfully!", 50)
 		var/obj/item/organ/I = pick(internal_organs)
 		I.take_damage(rand(3,5))
 

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -12,7 +12,7 @@
 			return FALSE
 
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return affected && affected.encased && affected.open >= 1
+		return affected && affected.encased && affected.open >= 2
 
 
 /datum/surgery_step/open_encased/saw
@@ -31,7 +31,7 @@
 		if (!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return ..() && affected && affected.open == 1
+		return ..() && affected && affected.open == 2
 
 	begin_step(mob/user, mob/living/human/target, target_zone, obj/item/tool)
 
@@ -52,7 +52,7 @@
 
 		user.visible_message("<span class = 'notice'>[user] has cut [target]'s [affected.encased] open with \the [tool].</span>",		\
 		"<span class = 'notice'>You have cut [target]'s [affected.encased] open with \the [tool].</span>")
-		affected.open = 1.5
+		affected.open = 2.5
 
 	fail_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 
@@ -78,13 +78,13 @@
 	min_duration = 30
 	max_duration = 40
 
-	can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
+	can_use(mob/living/human/user, mob/living/human/target, target_zone, obj/item/tool)
 		if (!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return ..() && affected && affected.open == 1.5
+		return ..() && affected && affected.open == 2.5
 
-	begin_step(mob/user, mob/living/human/target, target_zone, obj/item/tool)
+	begin_step(mob/living/human/user, mob/living/human/target, target_zone, obj/item/tool)
 
 		if (!hasorgans(target))
 			return
@@ -96,7 +96,7 @@
 		target.custom_pain("Something hurts horribly in your [affected.name]!",120)
 		..()
 
-	end_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
+	end_step(mob/living/human/user, mob/living/human/target, target_zone, obj/item/tool)
 
 		if (!hasorgans(target))
 			return
@@ -106,11 +106,12 @@
 		var/self_msg = "<span class = 'notice'>You force open [target]'s [affected.encased] with \the [tool].</span>"
 		user.visible_message(msg, self_msg)
 
-		affected.open = 2
+		affected.open = 3
 
-		// Whoops!
-		if (prob(10))
-			affected.fracture()
+		// Now it's based on the medical skill
+		if (user.getStatCoeff("medical") < GET_MIN_STAT_COEFF(STAT_MEDIUM_HIGH))
+			if (prob(15))
+				affected.fracture()
 
 	fail_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 
@@ -141,7 +142,7 @@
 		if (!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return ..() && affected && affected.open == 2.5
+		return ..() && affected && affected.open == 3
 
 	begin_step(mob/user, mob/living/human/target, target_zone, obj/item/tool)
 
@@ -165,7 +166,7 @@
 		var/self_msg = "<span class = 'notice'>You bend [target]'s [affected.encased] back into place with \the [tool].</span>"
 		user.visible_message(msg, self_msg)
 
-		affected.open = 1
+		affected.open = 2
 
 	fail_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -5,6 +5,7 @@
 
 /datum/surgery_step/face
 	priority = 2
+	req_open = FALSE
 	can_infect = FALSE
 	can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		if (!hasorgans(target))

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -17,8 +17,6 @@
 			return FALSE
 		if (affected.is_stump())
 			return FALSE
-		if (affected.is_stump())
-			return FALSE
 		return TRUE
 
 /datum/surgery_step/generic/cut_open
@@ -33,10 +31,12 @@
 	min_duration = 90
 	max_duration = 110
 
+	req_open = FALSE
+
 	can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		if (..())
 			var/obj/item/organ/external/affected = target.get_organ(target_zone)
-			return affected && affected.open == FALSE && target_zone != "mouth"
+			return affected && affected.open == 0 && target_zone != "mouth"
 
 	begin_step(mob/user, mob/living/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -49,7 +49,7 @@
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("<span class = 'notice'>[user] has made an incision on [target]'s [affected.name] with \the [tool].</span>", \
 		"<span class = 'notice'>You have made an incision on [target]'s [affected.name] with \the [tool].</span>",)
-		affected.open = TRUE
+		affected.open = 1
 
 		if (istype(target) && !(target.species.flags & NO_BLOOD))
 			affected.status |= ORGAN_BLEEDING
@@ -114,7 +114,7 @@
 	can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		if (..())
 			var/obj/item/organ/external/affected = target.get_organ(target_zone)
-			return affected && affected.open == TRUE //&& !(affected.status & ORGAN_BLEEDING)
+			return affected && affected.open == 1 //&& !(affected.status & ORGAN_BLEEDING)
 
 	begin_step(mob/user, mob/living/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -205,6 +205,8 @@
 	min_duration = 110
 	max_duration = 160
 
+	req_open = FALSE
+
 	can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		if (target_zone == "eyes")	//there are specific steps for eye surgery
 			return FALSE
@@ -229,11 +231,11 @@
 		user.visible_message("<span class = 'notice'>[user] amputates [target]'s [affected.name] at the [affected.amputation_point] with \the [tool].</span>", \
 		"<span class = 'notice'>You amputate [target]'s [affected.name] with \the [tool].</span>")
 		affected.droplimb(1,DROPLIMB_EDGE)
-		affected.nationality = target.nationality
+		affected.nationality = target.nationality // For Warlords and Tadojsville head-collecting mechanic
 
 	fail_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("<span class = 'red'>[user]'s hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>", \
-		"<span class = 'red'>Your hand slips, sawwing through the bone in [target]'s [affected.name] with \the [tool]!</span>")
+		"<span class = 'red'>Your hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(CUT, 30)
 		affected.fracture()

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -5,22 +5,22 @@
 //////////////////////////////////////////////////////////////////
 
 /datum/surgery_step/cavity
-	priority = TRUE
+	priority = 1
 	can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		if(!hasorgans(target))
 			return FALSE
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return affected && affected.open == 2 && !(affected.status & ORGAN_BLEEDING)
+		return affected && affected.open == (affected.encased ? 3 : 2) && !(affected.status & ORGAN_BLEEDING)
 
 	proc/get_max_wclass(var/obj/item/organ/external/affected)
 		switch (affected.name)
 			if ("head")
-				return TRUE
+				return 1
 			if ("upper body")
 				return 3
 			if ("lower body")
 				return 2
-		return FALSE
+		return 0
 
 	proc/get_cavity(var/obj/item/organ/external/affected)
 		switch (affected.name)
@@ -59,13 +59,13 @@
 		user.visible_message("[user] starts making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].", \
 		"You start making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool]." )
 		target.custom_pain("The pain in your chest is living hell!",1)
-		affected.cavity = TRUE
 		..()
 
 	end_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 		user.visible_message("<span class = 'notice'>[user] makes some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].</span>", \
 		"<span class = 'notice'>You make some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].</span>" )
+		affected.cavity = 1
 
 /datum/surgery_step/cavity/close_space
 	priority = TRUE
@@ -89,16 +89,16 @@
 		user.visible_message("[user] starts mending [target]'s [get_cavity(affected)] cavity wall with \the [tool].", \
 		"You start mending [target]'s [get_cavity(affected)] cavity wall with \the [tool]." )
 		target.custom_pain("The pain in your chest is living hell!",1)
-		affected.cavity = FALSE
 		..()
 
 	end_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 		user.visible_message("<span class = 'notice'>[user] mends [target]'s [get_cavity(affected)] cavity walls with \the [tool].</span>", \
 		"<span class = 'notice'>You mend [target]'s [get_cavity(affected)] cavity walls with \the [tool].</span>" )
+		affected.cavity = FALSE
 
 /datum/surgery_step/cavity/place_item
-	priority = FALSE
+	priority = 0
 	allowed_tools = list(
 		1 = list("/obj/item",100),
 	)
@@ -168,7 +168,7 @@
 	end_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 
-		var/find_prob = FALSE
+		var/find_prob = 0
 
 		if (affected.implants.len)
 

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -5,6 +5,7 @@
 
 /datum/surgery_step/limb
 	priority = 3 // Must be higher than /datum/surgery_step/internal
+	req_open = FALSE
 	can_infect = FALSE
 	can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		if (!hasorgans(target))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -10,7 +10,7 @@
 		return FALSE
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.open == 1
+	return affected && affected.open == (affected.encased ? 3 : 2)
 
 //////////////////////////////////////////////////////////////////
 //				CHEST INTERNAL ORGAN SURGERY					//
@@ -49,7 +49,8 @@
 		if (!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-
+		if(!affected || affected.open < 2)
+			return
 		for (var/obj/item/organ/I in affected.internal_organs)
 			if (I && I.damage > 0)
 				user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
@@ -68,7 +69,8 @@
 		if (!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-
+		if(!affected || affected.open < 2)
+			return
 		for (var/obj/item/organ/I in affected.internal_organs)
 			if (I && I.damage > 0)
 				user.visible_message("<span class='notice'>[user] treats damage to [target]'s [I.name] with [tool_name].</span>", \
@@ -167,6 +169,7 @@
 		2 = list("/obj/item/weapon/surgery/hemostat/bronze",85),
 		3 = list("/obj/item/weapon/material/kitchen/utensil/fork",20),
 		4 = list("/obj/item/weapon/material/kitchen/utensil/knife/bone",70),
+		5 = list("/obj/item/weapon/material/kitchen/utensil/knife/",50),
 	)
 
 	min_duration = 60

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -10,7 +10,8 @@
 	allowed_tools = list(
 		1 = list("/obj/item/weapon/surgery/hemostat",100),
 		2 = list("/obj/item/weapon/surgery/hemostat/bronze",85),
-		3 = list("/obj/item/stack/material/rope",50),
+		3 = list("/obj/item/stack/cable_coil",75),
+		4 = list("/obj/item/stack/material/rope",50),
 	)
 	can_infect = TRUE
 	blood_level = TRUE
@@ -29,7 +30,7 @@
 			internal_bleeding = TRUE
 			break
 
-		return affected.open == 2 && internal_bleeding
+		return affected.open == (affected.encased ? 3 : 2) && internal_bleeding
 
 	begin_step(mob/user, mob/living/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -95,6 +96,7 @@
 		user.visible_message("<span class = 'notice'>[user] has cut away necrotic tissue in [target]'s [affected.name] with \the [tool].</span>", \
 			"<span class = 'notice'>You have cut away necrotic tissue in [target]'s [affected.name] with \the [tool].</span>")
 		affected.status &= ~ORGAN_DEAD
+		affected.open = 3
 		playsound(target.loc, 'sound/effects/squelch1.ogg', 50, TRUE)
 
 	fail_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
@@ -179,12 +181,17 @@
 	priority = 2
 	allowed_tools = list(
 		1 = list("/obj/item/stack/medical/advanced/sulfa",100),
-		2 = list("/obj/item/stack/medical/advanced/bruise_pack",75),
-		3 = list("/obj/item/stack/medical/advanced/ointment",55),
-		4 = list("/obj/item/weapon/reagent_containers/glass/bucket",30),
+		2 = list("/obj/item/weapon/reagent_containers/spray", 100),
+		3 = list("/obj/item/stack/medical/advanced/bruise_pack",50),
+		4 = list("/obj/item/stack/medical/advanced/ointment",60),
+		5 = list("/obj/item/weapon/reagent_containers/glass/bucket",30),
+		6 = list("/obj/item/weapon/reagent_containers/food/drinks/bottle",75),
+		7 = list("/obj/item/weapon/reagent_containers/food/drinks/flask/", 80),
+		8 = list("/obj/item/weapon/reagent_containers/glass/beaker",75),
+		9 = list("/obj/item/weapon/reagent_containers/glass/bottle", 90),
 	)
 
-	can_infect = 0
+	can_infect = FALSE
 	blood_level = 0
 
 	min_duration = 50
@@ -192,24 +199,24 @@
 
 /datum/surgery_step/sterilize/can_use(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 	if(!hasorgans(target))
-		return 0
+		return FALSE
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(!istype(affected))
-		return 0
+		return FALSE
 	if(affected.is_disinfected())
-		return 0
+		return FALSE
 	var/obj/item/weapon/reagent_containers/container = tool
 	if(!istype(container))
-		return 0
+		return FALSE
 	if(!container.is_open_container())
-		return 0
+		return FALSE
 	var/datum/reagent/ethanol/booze = locate() in container.reagents.reagent_list
 	if(istype(booze) && booze.strength >= 40)
 		to_chat(user, "<span class='warning'>[booze] is too weak, you need something of higher proof for this...</span>")
-		return 0
+		return FALSE
 	if(!istype(booze) && !container.reagents.has_reagent("sterilizine"))
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /datum/surgery_step/sterilize/begin_step(mob/user, mob/living/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -2,7 +2,7 @@
 
 /datum/surgery_step
 	var/priority = FALSE	//steps with higher priority would be attempted first
-
+	var/req_open = TRUE		// TRUE means the part must be cut open, FALSE means it doesn't
 	// type path referencing tools that can be used for this step, and how well are they suited for it
 	var/list/allowed_tools = list(1 = list("/obj/item/cursedtreasure",100)) //so its not used
 	// type paths referencing races that this step applies to.
@@ -10,13 +10,13 @@
 	var/list/disallowed_species = null
 
 	// duration of the step
-	var/min_duration = FALSE
-	var/max_duration = FALSE
+	var/min_duration = 0
+	var/max_duration = 0
 
 	// evil infection stuff that will make everyone hate me
 	var/can_infect = FALSE
-	//How much blood this step can get on surgeon. TRUE - hands, 2 - full body.
-	var/blood_level = FALSE
+	//How much blood this step can get on surgeon. 1 - hands, 2 - full body.
+	var/blood_level = 0
 
 	//returns how well the tool is suited for this step. from 1 to 100 (to be used as a prob of suceeding)
 	proc/tool_quality(obj/item/TT, var/mob/living/human/user)
@@ -76,6 +76,18 @@
 	// stuff that happens when the step fails
 	proc/fail_step(mob/living/user, mob/living/human/target, target_zone, obj/item/tool)
 		return null
+
+/obj/item/proc/can_do_surgery(mob/living/M, mob/living/user)
+	if(!ishuman(M))
+		return TRUE
+		
+	var/mob/living/human/H = M
+	var/obj/item/organ/external/affected = H.get_organ(user.targeted_organ)
+	if(affected)
+		for(var/datum/surgery_step/S in surgery_steps)
+			if(!affected.open && S.req_open)
+				return FALSE
+	return FALSE
 
 proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/human/user)
 	if (!istype(user) || !istype(E)) return


### PR DESCRIPTION
**Surgery**

- Refactors code for the surgery tools
- Activates "encased" surgery (sawing, opening and closing ribcage/skull)
- Adds a "safety check" for surgical tools (if on help intent, you won't harm your patient)
- Low medical skill can have a 15% to fracture a ribcage when opening it (probability may be tweaked later)
- Surgery steps now should be similar to old Bay (For instance: internal organs surgery was: Scalpel > Brute kit > Cautery, creating unseen internal bleeding; now it's in the correct order: Scalpel > Retractor/Bleeders > Retractor/Bleeders > Saw > Retractor > Brute kit > Retractor > Cautery

**Misc**

- Makes the "taser effect" dependent on the stun value