### PR TITLE
Shift + Middle click, Forks as retractor alternatives

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -34,6 +34,9 @@
 	var/icon_y = text2num(modifiers["icon-y"])
 	if (modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
+		return
+	if (modifiers["shift"] && modifiers["middle"])
+		ShiftMiddleClickOn(A)
 		return 
 	if (modifiers["middle"])
 		MiddleClickOn(A)
@@ -340,6 +343,7 @@
 /atom/proc/ShiftMiddleClick(var/mob/living/user)
 	if (istype(user, /mob/living))
 		user.pointed(src)
+	return
 
 
 // In case of use break glass

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -73,6 +73,7 @@
 		2 = list("/obj/item/weapon/surgery/retractor/bronze",85),
 		3 = list("/obj/item/weapon/crowbar",70),
 		4 = list("/obj/item/weapon/material/handle",60),
+		5 = list("/obj/item/weapon/material/kitchen/utensil/fork",50)
 	)
 
 	min_duration = 30
@@ -131,7 +132,8 @@
 		1 = list("/obj/item/weapon/surgery/retractor",100),
 		2 = list("/obj/item/weapon/surgery/retractor/bronze",85),
 		3 = list("/obj/item/weapon/crowbar",70),
-		4 = list("/obj/item/weapon/material/handle",60)
+		4 = list("/obj/item/weapon/material/handle",60),
+		5 = list("/obj/item/weapon/material/kitchen/utensil/fork",50)
 	)
 
 	min_duration = 20


### PR DESCRIPTION
- Shift + Middle click is now a working shortcut for pointing.
- Forks are now alternatives for retractors in encasing (ribcage opening/closing) surgery.