### PR TITLE
Big waco update

### DIFF
--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -597,7 +597,7 @@ var/global/redirect_all_players = null
 			WWalert(usr,"There is an administrative lock on entering the game!", "Error")
 			return
 
-		if (map && map.has_occupied_base(job_flag) && map.ID != MAP_WACO && map.ID != MAP_CAPITOL_HILL && map.ID != MAP_CAMP && map.ID != MAP_HILL_203 && map.ID != MAP_CALOOCAN && map.ID != MAP_YELTSIN && map.ID != MAP_HOTEL && map.ID != MAP_OASIS)
+		if (map && map.has_occupied_base(job_flag) && map.ID != MAP_CAPITOL_HILL && map.ID != MAP_CAMP && map.ID != MAP_HILL_203 && map.ID != MAP_CALOOCAN && map.ID != MAP_YELTSIN && map.ID != MAP_HOTEL && map.ID != MAP_OASIS)
 			WWalert(usr,"The enemy is currently occupying your base! You can't be deployed right now.", "Error")
 			return
 

--- a/code/game/objects/map_metadata/waco.dm
+++ b/code/game/objects/map_metadata/waco.dm
@@ -19,7 +19,7 @@
 	ordinal_age = 7
 	faction_distribution_coeffs = list(CIVILIAN = 0.3, AMERICAN = 0.7)
 	battle_name = "Siege of Mount Carmel"
-	mission_start_message = "<font size=4>All factions have <b>5 minutes</b> to prepare before the ceasefire ends!<br>The ATF will win if they capture the <b>Davidian leader's rooms inside the compound</b>. The Davidians will win if they manage to defend their home for <b>20 minutes!</b></font>"
+	mission_start_message = "<font size=4>All factions have <b>5 minutes</b> to prepare before the ceasefire ends!<br>The ATF will win if they capture the <b>north third story tower</b>. The Davidians will win if they manage to defend their home for <b>20 minutes!</b></font>"
 	faction1 = CIVILIAN
 	faction2 = AMERICAN
 	grace_wall_timer = 3000

--- a/code/modules/1713/jobs/waco.dm
+++ b/code/modules/1713/jobs/waco.dm
@@ -31,6 +31,8 @@
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
+	var/obj/item/clothing/accessory/armor/coldwar/pasgt/pasgt_armor = new /obj/item/clothing/accessory/armor/coldwar/pasgt(null)
+	uniform.attackby(pasgt_armor, H)
 	give_random_name(H)
 	H.civilization = "ATF"
 	H.add_note("Role", "You are a <b>[title]</b>. You are in charge of the whole operation. Organize your troops accordingly!")
@@ -81,8 +83,8 @@
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
 	//armor
-	var/obj/item/clothing/accessory/armor/nomads/civiliankevlar/under/armor = new /obj/item/clothing/accessory/armor/nomads/civiliankevlar/under(null)
-	uniform.attackby(armor, H)
+	var/obj/item/clothing/accessory/armor/coldwar/pasgt/pasgt_armor = new /obj/item/clothing/accessory/armor/coldwar/pasgt(null)
+	uniform.attackby(pasgt_armor, H)
 
 	give_random_name(H)
 	H.civilization = "ATF"
@@ -121,8 +123,8 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/atf(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/armor/nomads/civiliankevlar/under/armor = new /obj/item/clothing/accessory/armor/nomads/civiliankevlar/under(null)
-	uniform.attackby(armor, H)
+	var/obj/item/clothing/accessory/armor/coldwar/pasgt/pasgt_armor = new /obj/item/clothing/accessory/armor/coldwar/pasgt(null)
+	uniform.attackby(pasgt_armor, H)
 
 //head
 	if (prob(30))
@@ -235,8 +237,8 @@
 	uniform.attackby(medicalarm, H)
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
-	var/obj/item/clothing/accessory/armor/coldwar/plates/interceptor/ocp/ocp_armor = new /obj/item/clothing/accessory/armor/coldwar/plates/interceptor/ocp(null)
-	uniform.attackby(ocp_armor, H)
+	var/obj/item/clothing/accessory/armor/coldwar/pasgt/pasgt_armor = new /obj/item/clothing/accessory/armor/coldwar/pasgt(null)
+	uniform.attackby(pasgt_armor, H)
 	give_random_name(H)
 	H.civilization = "ATF"
 	H.add_note("Role", "You are a <b>[title]</b>. Keep your fellow ATF healthy!")
@@ -343,16 +345,8 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/modern3(H), slot_w_uniform)
 //armor
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/randarm = rand(1,2)
-	if (randarm == 1)
-		var/obj/item/clothing/accessory/armor/coldwar/pasgt/khaki/pasgt_armor = new /obj/item/clothing/accessory/armor/coldwar/pasgt/khaki(null)
-		uniform.attackby(pasgt_armor, H)
-	else if (randarm == 2)
-		var/obj/item/clothing/accessory/armor/coldwar/plates/platecarrierblack/plate_armor = new /obj/item/clothing/accessory/armor/coldwar/plates/platecarrierblack(null)
-		uniform.attackby(plate_armor, H)
-	else if (randarm == 3)
-		var/obj/item/clothing/accessory/armor/coldwar/plates/platecarriergreen/plate_armor = new /obj/item/clothing/accessory/armor/coldwar/plates/platecarriergreen(null)
-		uniform.attackby(plate_armor, H)
+	var/obj/item/clothing/accessory/armor/nomads/civiliankevlar/under/armor = new /obj/item/clothing/accessory/armor/nomads/civiliankevlar/under(null)
+	uniform.attackby(armor, H)
 
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction1(H), slot_wear_id)
 //head
@@ -406,6 +400,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/farmer_outfit(H), slot_w_uniform)
 
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction1(H), slot_wear_id)
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/modern2(H), slot_belt)
 //head
 	if (prob(25))
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/cowboyhat(H), slot_head)
@@ -419,7 +414,7 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/shotgun/pump/remington870(H), slot_shoulder)
 	else
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/shotgun/pump(H), slot_shoulder)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/shellbox/slug(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/shellbox/slug(H), slot_l_store)
 
 	H.civilization = "Faithful"
 	H.add_note("Role", "You are a <b>[title]</b>, Protecting your home from the goverment scum!")

--- a/maps/1969/waco.dmm
+++ b/maps/1969/waco.dmm
@@ -1,47 +1,61 @@
-"ae" = (/obj/effect/landmark{icon_state = "x1"; name = "JoinLateRU"},/turf/floor/wood,/area/caribbean)
 "af" = (/obj/covers/sidewalk,/turf/floor/grass,/area/caribbean)
+"ah" = (/obj/structure/table/wood/flipped{dir = 4},/obj/item/weapon/gun/projectile/revolver/smithwesson,/turf/floor/wood,/area/caribbean/houses)
+"aj" = (/obj/covers/wood_wall/adjustable,/turf/wall/wood,/area/caribbean/houses)
 "an" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/american,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/american,/turf/floor/wood,/area/caribbean/houses)
-"ao" = (/obj/structure/wild/rock,/turf/floor/grass,/area/caribbean)
-"az" = (/obj/structure/table/wood/flipped{dir = 8},/obj/structure/lamp/lamp_small/alwayson,/turf/floor/wood,/area/caribbean/houses)
 "aE" = (/obj/structure/closet/crate/empty,/turf/floor/plating/concrete,/area/caribbean/houses)
+"aJ" = (/obj/covers/wood_wall/adjustable,/turf/wall/wood,/area/caribbean/british/land/inside/objective)
 "aK" = (/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/wood,/area/caribbean/houses)
-"aM" = (/obj/structure/lamp/lamp_small/alwayson{dir = 8},/turf/floor/wood,/area/caribbean/houses)
 "aP" = (/obj/structure/table/modern/table,/obj/structure/closet/cabinet/ceiling{pixel_y = 14},/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/kitchen/plate,/obj/item/kitchen/plate,/obj/item/kitchen/plate,/obj/item/kitchen/plate,/obj/item/kitchen/plate,/obj/item/kitchen/plate,/turf/floor/plating/marble/tile,/area/caribbean/houses)
+"aQ" = (/obj/structure/window/barrier/sandbag/incomplete{dir = 8},/turf/floor/wood,/area/caribbean/houses)
+"aU" = (/obj/item/weapon/gun/projectile/semiautomatic/barrett,/obj/item/weapon/gun/projectile/semiautomatic/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/turf/floor/grass,/area/caribbean)
 "aV" = (/obj/structure/multiz/ladder/ww2/stairsdown{dir = 1; explosion_resistance = 1e+006},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"bb" = (/obj/structure/closet/crate/empty,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/turf/floor/plating/concrete,/area/caribbean/houses)
+"bc" = (/obj/covers/sidewalk,/obj/structure/multiz/ladder/ww2/up,/turf/floor/grass,/area/caribbean)
 "bd" = (/obj/structure/closet/fridge,/obj/item/weapon/reagent_containers/food/drinks/can/milk,/obj/item/weapon/reagent_containers/food/snacks/meatballsoup,/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza,/obj/item/weapon/reagent_containers/food/snacks/fishfingers/chickenbucket,/obj/effect/floor_decal/spline/plain{dir = 8},/obj/item/weapon/storage/fancy/egg_box,/turf/floor/plating/marble/tile,/area/caribbean/houses)
-"bh" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/mac10,/obj/item/weapon/gun/projectile/submachinegun/mac10,/obj/item/ammo_magazine/mac10,/obj/item/ammo_magazine/mac10,/obj/item/ammo_magazine/mac10,/obj/item/ammo_magazine/mac10,/turf/floor/wood,/area/caribbean/houses)
-"bx" = (/turf/floor/dirt/dust,/area/caribbean/no_mans_land/invisible_wall/one)
+"be" = (/turf/floor/dirt/dust,/area/caribbean/no_mans_land/invisible_wall/one)
+"bh" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/mac10,/obj/item/weapon/gun/projectile/submachinegun/mac10,/turf/floor/wood,/area/caribbean/houses)
+"bm" = (/turf/floor/dirt,/area/caribbean/no_mans_land/invisible_wall/one)
+"bt" = (/obj/structure/table/wood/flipped,/obj/structure/curtain/closed{pixel_y = -32},/turf/floor/wood,/area/caribbean/houses)
 "by" = (/obj/covers/sidewalk,/turf/floor/dirt,/area/caribbean)
 "bB" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 8},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
-"bE" = (/turf/floor/dirt,/area/caribbean/no_mans_land/invisible_wall/two)
+"bH" = (/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall/two)
+"bP" = (/obj/structure/lamp/lamp_small/alwayson{dir = 1},/obj/structure/window/barrier/sandbag{dir = 8; icon_state = "sandbag"},/turf/floor/wood,/area/caribbean/houses)
 "bR" = (/obj/structure/vehicleparts/frame/car/falcon/lf{icon_state = "frame_steel_corner_lf"; dir = 1; w_front = list("smc_falcon_front_leftU",1,1,55,90,0,0)},/obj/structure/engine/internal/diesel/premade{dir = 1},/obj/structure/vehicleparts/axis/car/falcon/police{name = "SMC Falcon Swat Van"; color = "#3b3f41"; dir = 1},/obj/structure/vehicleparts/license_plate/us/centered/front{dir = 1},/turf/floor/grass,/area/caribbean)
 "bU" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/shotgun/pump/remington870/brown,/obj/item/ammo_magazine/shellbox,/obj/item/weapon/gun/projectile/shotgun/mts225,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/turf/floor/plating/concrete,/area/caribbean/houses)
+"bV" = (/obj/structure/simple_door/key_door/anyone/singledoor/housedoor,/obj/covers/wood_wall/adjustable,/turf/floor/plating/concrete,/area/caribbean/houses)
 "bX" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/american,/turf/floor/wood,/area/caribbean/houses)
 "cc" = (/obj/structure/fitness/punchingbag,/turf/floor/plating/concrete,/area/caribbean/houses)
+"cj" = (/obj/covers/wood_wall/adjustable,/turf/wall/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
 "ck" = (/turf/floor/plating/tiled/woodv,/area/caribbean)
+"cl" = (/obj/item/weapon/gun/projectile/submachinegun/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/turf/floor/wood,/area/caribbean/houses)
+"co" = (/obj/structure/barricade/construction/flashing,/turf/floor/dirt/dust,/area/caribbean/no_mans_land/invisible_wall/two)
 "cq" = (/obj/structure/barbwire,/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/wood,/area/caribbean)
 "cD" = (/obj/structure/barricade/tires,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/turf/floor/plating/concrete,/area/caribbean/houses)
-"cG" = (/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"cE" = (/obj/structure/table/modern,/obj/structure/radio/faction2,/obj/structure/camonet,/turf/floor/dirt,/area/caribbean)
+"cG" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 1},/obj/structure/barbwire,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "cI" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/obj/structure/lamp/lamp_small/alwayson{dir = 8},/turf/floor/wood,/area/caribbean/houses)
 "cM" = (/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/structure/closet/anchored,/obj/item/clothing/mask/gas/modern2,/obj/item/weapon/gun/projectile/submachinegun/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/clothing/mask/necklace/christian/gold,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
-"da" = (/obj/structure/window/barrier/sandbag{dir = 1},/obj/structure/window/barrier/sandbag{dir = 8; icon_state = "sandbag"},/turf/floor/wood,/area/caribbean/houses)
-"dd" = (/turf/wall/wood,/area/caribbean)
+"cO" = (/obj/structure/lamp/lamp_small/alwayson,/obj/structure/window/barrier/sandbag{dir = 8; icon_state = "sandbag"},/turf/floor/wood,/area/caribbean/houses)
 "de" = (/obj/structure/table/modern/table,/obj/item/flashlight/lamp/littlelamp/desklamp,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "di" = (/obj/covers/sidewalk,/obj/structure/shelf/palette,/turf/floor/grass,/area/caribbean)
+"dq" = (/obj/effect/autoassembler{dir = 1},/turf/floor/grass,/area/caribbean)
+"dC" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 1},/obj/structure/barbwire,/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
+"dL" = (/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars,/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars,/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars,/obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars,/obj/item/clothing/glasses/nvg,/turf/floor/grass,/area/caribbean)
 "dT" = (/obj/effect/landmark{icon_state = "x3"; name = "JoinLateJPDoc"},/turf/floor/grass,/area/caribbean)
-"dY" = (/obj/structure/curtain/open/red,/obj/effect/floor_decal/spline/fancy/wood,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
+"dY" = (/obj/structure/curtain/open/red,/obj/effect/floor_decal/spline/fancy/wood,/obj/structure/window/barrier/sandbag,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "eh" = (/obj/structure/window/classic,/obj/structure/barricade/vertical,/turf/floor/wood,/area/caribbean/houses)
 "ei" = (/obj/structure/railing{dir = 4; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"el" = (/turf/floor/plating/marble/tile,/area/caribbean/houses)
 "em" = (/obj/covers/sidewalk,/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/dirt/dust,/area/caribbean)
 "eo" = (/obj/structure/closet/crate/empty/large,/turf/floor/plating/concrete,/area/caribbean/houses)
 "ew" = (/obj/structure/wild/flowers,/obj/structure/barbwire,/turf/floor/grass,/area/caribbean)
 "ez" = (/obj/structure/window/barrier/railing/stone{dir = 4},/turf/floor/plating/concrete,/area/caribbean/houses)
 "eF" = (/obj/structure/bed/chair/wood/alt,/turf/floor/wood,/area/caribbean/houses)
 "eG" = (/obj/covers/sidewalk,/obj/structure/barbwire,/turf/floor/grass,/area/caribbean)
+"eL" = (/obj/structure/bed/chair/wood{dir = 1; icon_state = "wooden_chair"},/obj/structure/camonet,/turf/floor/grass,/area/caribbean)
 "eO" = (/obj/item/weapon/clay/advclaybricks/fired,/turf/floor/dirt/dust,/area/caribbean)
 "eW" = (/obj/structure/barbwire,/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/wood,/area/caribbean)
 "fq" = (/obj/structure/lamp/lamp_small/alwayson{dir = 1},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
-"fu" = (/obj/structure/props/junk{icon_state = "Junk_9"},/turf/floor/dirt,/area/caribbean)
 "fK" = (/obj/structure/props/stove{pixel_y = 14},/turf/floor/plating/marble/tile,/area/caribbean/houses)
 "fL" = (/obj/covers/sidewalk,/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
 "fN" = (/obj/structure/bed/chair/wood{dir = 4; icon_state = "wooden_chair"},/turf/floor/wood,/area/caribbean/houses)
@@ -51,7 +65,6 @@
 "gp" = (/obj/structure/props/engineprops/waterpump,/turf/floor/dirt,/area/caribbean)
 "gq" = (/obj/structure/window/classic/metal,/turf/floor/plating/dark,/area/caribbean/houses)
 "gs" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak74,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/turf/floor/wood,/area/caribbean/houses)
-"gD" = (/turf/wall/wood,/area/caribbean/british/land/inside/objective)
 "gI" = (/obj/structure/wild/tree_stump,/turf/floor/dirt,/area/caribbean)
 "gL" = (/turf/floor/plating/steel,/area/caribbean/houses)
 "gM" = (/obj/structure/railing{dir = 4; icon_state = "railing0"},/obj/structure/multiz/ladder/ww2/stairsdown{dir = 1; explosion_resistance = 1e+006},/turf/floor/wood,/area/caribbean/houses)
@@ -64,26 +77,25 @@
 "hx" = (/obj/structure/table/modern/table,/turf/floor/plating/marble/tile,/area/caribbean/houses)
 "hC" = (/obj/structure/curtain/leather/open,/turf/floor/wood,/area/caribbean/houses)
 "hK" = (/obj/covers/sidewalk,/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
-"hP" = (/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall/two)
 "ip" = (/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
+"is" = (/obj/structure/barricade/construction/flashing,/turf/floor/dirt/dust,/area/caribbean)
+"it" = (/obj/structure/railing{dir = 4; icon_state = "railing0"},/obj/structure/lamp/lamp_small/alwayson{dir = 1},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "iH" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/reagent_containers/spray/cleaner,/turf/floor/wood,/area/caribbean/houses)
-"iR" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/red,/turf/floor/wood,/area/caribbean/houses)
 "jb" = (/obj/item/stack/material/wood{anchored = 1},/obj/item/stack/material/wood{anchored = 1; pixel_y = 4},/obj/item/stack/material/wood{anchored = 1; pixel_y = 8},/obj/item/stack/material/wood{anchored = 1; pixel_y = 12},/obj/covers/sidewalk,/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall)
 "jd" = (/obj/structure/simple_door/key_door/anyone/doubledoor/wood,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
-"jf" = (/obj/structure/wild/bush,/turf/floor/grass,/area/caribbean)
 "jg" = (/obj/structure/wild/tree/live_tree,/turf/floor/grass,/area/caribbean)
 "jn" = (/obj/item/stack/material/wood{anchored = 1},/obj/item/stack/material/wood{anchored = 1; pixel_y = 4},/obj/item/stack/material/wood{anchored = 1; pixel_y = 8},/obj/item/stack/material/wood{anchored = 1; pixel_y = 12},/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall)
 "jt" = (/obj/covers/sidewalk,/obj/structure/props/junk{icon_state = "Junk_7"},/turf/floor/grass,/area/caribbean)
-"ju" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/barricade/horizontal,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
-"jH" = (/obj/structure/closet/anchored,/obj/item/weapon/storage/toolbox,/turf/floor/wood,/area/caribbean/houses)
-"jJ" = (/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/wood,/area/caribbean/houses)
+"jH" = (/obj/structure/closet/anchored,/obj/item/weapon/storage/toolbox,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/weapon/fire_extinguisher,/turf/floor/wood,/area/caribbean/houses)
+"jJ" = (/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/obj/structure/curtain/closed{pixel_y = -32},/turf/floor/wood,/area/caribbean/houses)
 "jQ" = (/obj/item/weapon/reagent_containers/glass/barrel/modern/gasoline,/turf/floor/plating/concrete,/area/caribbean/houses)
+"kd" = (/obj/structure/closet/crate/empty,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/turf/floor/wood,/area/caribbean/houses)
 "kf" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/brown,/turf/floor/wood,/area/caribbean/houses)
 "kj" = (/obj/covers/cobblestone/stairs{dir = 8; icon_state = "rampup"},/turf/floor/wood,/area/caribbean/houses)
 "kl" = (/obj/effect/floor_decal/grass_edge,/turf/floor/grass,/area/caribbean)
 "kt" = (/obj/item/ammo_casing/a556x45,/turf/floor/plating/concrete,/area/caribbean/houses)
-"kw" = (/obj/structure/grille/fence/picket{dir = 4},/turf/floor/dirt,/area/caribbean)
-"kM" = (/obj/item/weapon/generic_MRE_trash,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"kA" = (/obj/structure/barbwire,/obj/structure/curtain/closed{pixel_y = -32},/turf/floor/wood,/area/caribbean/houses)
+"kM" = (/obj/item/weapon/generic_MRE_trash,/obj/structure/lamp/lamp_small/alwayson,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "kQ" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/semiautomatic/remington11,/obj/item/weapon/gun/projectile/shotgun/pump/remington870,/turf/floor/plating/concrete,/area/caribbean/houses)
 "kR" = (/obj/structure/barbwire,/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/wood,/area/caribbean)
 "kT" = (/obj/structure/grille/metalsheetfence/yellow,/turf/floor/dirt,/area/caribbean/houses)
@@ -93,16 +105,18 @@
 "lk" = (/obj/covers/cobblestone/stairs{dir = 4; icon_state = "rampup"},/turf/floor/wood,/area/caribbean/houses)
 "lr" = (/obj/structure/simple_door/key_door,/turf/floor/plating/concrete,/area/caribbean/houses)
 "lA" = (/obj/structure/lamp/lamp_small/alwayson{dir = 8},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"lE" = (/obj/structure/wild/rock,/turf/floor/grass,/area/caribbean)
 "lF" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16,/obj/item/weapon/gun/projectile/submachinegun/m16,/obj/item/weapon/gun/projectile/submachinegun/m16,/obj/item/weapon/gun/projectile/submachinegun/m16,/turf/floor/wood,/area/caribbean/houses)
+"lQ" = (/obj/structure/table/modern,/obj/structure/roof_support,/obj/structure/camonet,/turf/floor/dirt,/area/caribbean)
 "lS" = (/obj/covers/sidewalk,/turf/floor/dirt/dust,/area/caribbean)
 "lY" = (/obj/structure/table/rack/shelf,/obj/item/weapon/storage/foodbox/chippack,/turf/floor/plating/concrete,/area/caribbean/houses)
 "mb" = (/obj/structure/bed/chair/wood/bleacher/r{dir = 1},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "ml" = (/obj/structure/sink,/turf/floor/plating/marble/grid,/area/caribbean/houses)
 "mu" = (/obj/structure/window/classic,/obj/structure/curtain/closed,/turf/floor/wood,/area/caribbean/houses)
 "mC" = (/obj/structure/bed/chair/wood/alt{dir = 8},/turf/floor/wood,/area/caribbean/houses)
-"mP" = (/turf/floor/dirt,/area/caribbean/no_mans_land/invisible_wall/one)
+"mK" = (/obj/structure/window/barrier/sandbag{dir = 8; icon_state = "sandbag"},/turf/floor/wood,/area/caribbean/houses)
+"mM" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/turf/floor/wood,/area/caribbean/houses)
 "mT" = (/obj/structure/props/car_wreck,/turf/floor/dirt/dust,/area/caribbean)
-"mV" = (/obj/structure/simple_door/key_door/anyone/singledoor/privacy,/turf/floor/plating/marble/grid,/area/caribbean/houses)
 "nn" = (/obj/item/stack/material/wood{anchored = 1},/obj/item/stack/material/wood{anchored = 1; pixel_y = 4},/obj/item/stack/material/wood{anchored = 1; pixel_y = 8},/obj/item/stack/material/wood{anchored = 1; pixel_y = 12},/obj/structure/window/barrier/railing/stone,/turf/floor/plating/concrete,/area/caribbean/houses)
 "nr" = (/obj/structure/curtain/closed/red,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "ns" = (/obj/structure/window/barrier/sandbag{dir = 8; icon_state = "sandbag"},/turf/floor/plating/concrete,/area/caribbean/houses)
@@ -111,12 +125,12 @@
 "ou" = (/obj/covers/sidewalk,/obj/structure/barbwire,/turf/floor/dirt/dust,/area/caribbean)
 "ox" = (/obj/structure/grille/fence/picket{dir = 1},/turf/floor/dirt/dust,/area/caribbean)
 "oH" = (/obj/structure/vehicleparts/frame/defaultarmored/rf/armored{w_front = list("carwindshield2door_rightU",1,1,55,90,0,0); dir = 1; w_right = list("none",1,1,55,90,0,1)},/obj/structure/vehicleparts/movement{dir = 1},/obj/structure/bed/chair/carseat/right/dark{icon_state = "carseat_right"; dir = 1},/turf/floor/grass,/area/caribbean)
-"oP" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 8},/turf/floor/wood,/area/caribbean/houses)
+"oJ" = (/obj/structure/camonet,/turf/floor/grass,/area/caribbean)
 "pl" = (/obj/structure/closet/crate/dumpster,/obj/item/weapon/storage/bag/trash,/turf/floor/wood,/area/caribbean/houses)
-"pp" = (/obj/structure/table/modern/table,/obj/structure/radio/transmitter_receiver/nopower,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"pp" = (/obj/structure/table/modern/table,/obj/structure/radio/faction1,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "pB" = (/turf/floor/broken_floor,/area/caribbean)
 "pI" = (/obj/structure/railing,/obj/structure/lamp/lamp_small/alwayson{dir = 4},/turf/floor/wood,/area/caribbean/houses)
-"pO" = (/turf/wall/cement,/area/caribbean/no_mans_land/invisible_wall/inside)
+"pO" = (/obj/covers/cement_wall,/obj/covers/cement_wall,/turf/wall/cement,/area/caribbean/houses)
 "pV" = (/turf/floor/grass,/area/caribbean)
 "qa" = (/obj/structure/lamp/lamp_big/alwayson,/turf/floor/plating/concrete,/area/caribbean/houses)
 "ql" = (/obj/structure/table/wood/flipped,/turf/floor/wood,/area/caribbean/houses)
@@ -124,31 +138,31 @@
 "qt" = (/turf/floor/dirt/flooded,/area/caribbean)
 "qG" = (/obj/structure/closet/crate/empty,/turf/floor/wood,/area/caribbean/houses)
 "qJ" = (/obj/item/stack/material/wood{anchored = 1},/obj/item/stack/material/wood{anchored = 1; pixel_y = -4},/obj/item/stack/material/wood{anchored = 1; pixel_y = -8},/obj/item/stack/material/wood{anchored = 1; pixel_y = -12},/obj/item/stack/material/wood{anchored = 1; pixel_y = -16},/obj/structure/window/barrier/railing/stone{dir = 1},/turf/floor/plating/concrete,/area/caribbean/houses)
-"qN" = (/obj/structure/bed/chair/wood,/obj/structure/lamp/lamp_small/alwayson,/turf/floor/wood,/area/caribbean/houses)
+"qK" = (/turf/floor/dirt,/area/caribbean)
 "re" = (/obj/structure/lamp/lamp_small/alwayson{dir = 4},/turf/floor/wood,/area/caribbean/houses)
 "rh" = (/obj/structure/bed/chair/wood/bleacher/l{dir = 1},/obj/structure/lamp/lamp_small/alwayson{dir = 8},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "rm" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/obj/item/weapon/gun/projectile/shotgun/pump,/turf/floor/wood,/area/caribbean/houses)
 "rr" = (/obj/structure/shower{dir = 4},/obj/structure/curtain/open/shower,/obj/structure/shower/bathtub/steel,/turf/floor/plating/marble/grid,/area/caribbean/houses)
+"ru" = (/obj/structure/window/barrier/sandbag,/obj/structure/curtain/closed{pixel_y = -32},/turf/floor/wood,/area/caribbean/houses)
 "rw" = (/obj/structure/multiz/ladder/ww2/stairsup,/obj/structure/railing{dir = 4; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/houses)
 "rL" = (/obj/effect/floor_decal/grass_edge{dir = 4},/turf/floor/grass,/area/caribbean)
 "rN" = (/obj/item/violin,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "rR" = (/obj/covers/divider_wall{icon_state = "divider1"},/obj/covers/divider_wall{icon_state = "divider2"},/turf/floor/plating/concrete,/area/caribbean/houses)
 "rZ" = (/obj/structure/multiz/ladder/ww2/up,/turf/floor/plating/concrete,/area/caribbean/houses)
-"sn" = (/obj/structure/closet/cabinet,/turf/floor/wood,/area/caribbean)
 "sr" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/turf/floor/wood,/area/caribbean/houses)
 "su" = (/obj/structure/window/barrier/sandbag{dir = 8; icon_state = "sandbag"},/obj/structure/window/barrier/sandbag,/turf/floor/plating/concrete,/area/caribbean/houses)
 "sy" = (/obj/structure/railing{dir = 1; icon_state = "railing0"},/obj/structure/lamp/lamp_small/alwayson{dir = 4},/turf/floor/wood,/area/caribbean/houses)
 "sz" = (/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/wood,/area/caribbean/houses)
+"sG" = (/obj/structure/railing{dir = 8; icon_state = "railing0"},/obj/structure/lamp/lamp_small/alwayson{dir = 1},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "sM" = (/obj/covers/sidewalk,/obj/structure/barbwire{pixel_y = 8},/turf/floor/grass,/area/caribbean)
-"sN" = (/obj/structure/table/wood/flipped{dir = 1},/obj/structure/lamp/lamp_small/alwayson,/turf/floor/wood,/area/caribbean/houses)
 "sY" = (/obj/structure/table/modern/table,/obj/effect/floor_decal/spline/plain,/turf/floor/wood,/area/caribbean/houses)
 "sZ" = (/obj/structure/bed/chair/wood/bleacher{dir = 1},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
+"th" = (/obj/structure/multiz/ladder/ww2,/turf/floor/broken_floor,/area/caribbean)
 "ti" = (/obj/structure/table/wood,/turf/floor/wood,/area/caribbean/houses)
-"tm" = (/obj/item/weapon/storage/toolbox/mechanical,/turf/floor/grass,/area/caribbean)
+"tm" = (/obj/item/weapon/storage/toolbox/mechanical,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/weapon/sledgehammer,/obj/item/weapon/shield/metal_riot,/turf/floor/grass,/area/caribbean)
 "tn" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "tq" = (/obj/structure/shelf/palette,/obj/item/weapon/reagent_containers/food/condiment/flour,/turf/floor/plating/concrete,/area/caribbean/houses)
-"ts" = (/obj/covers/cobblestone/stairs{dir = 4; icon_state = "rampup"},/obj/structure/window/barrier/sandbag,/turf/floor/wood,/area/caribbean/houses)
-"tL" = (/obj/effect/autoassembler{dir = 1},/turf/floor/grass,/area/caribbean)
+"ts" = (/obj/covers/cobblestone/stairs{dir = 4; icon_state = "rampup"},/obj/structure/window/barrier/sandbag,/obj/structure/curtain/closed{pixel_y = -32},/turf/floor/wood,/area/caribbean/houses)
 "tZ" = (/obj/item/trash/candle,/turf/floor/wood,/area/caribbean/houses)
 "uh" = (/obj/structure/barbwire,/turf/floor/grass,/area/caribbean)
 "uj" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 1},/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 1},/turf/floor/plating/concrete,/area/caribbean/houses)
@@ -157,7 +171,6 @@
 "ut" = (/obj/structure/multiz/ladder/ww2/stairsdown,/obj/structure/railing{dir = 4; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/houses)
 "uv" = (/obj/effect/landmark{icon_state = "x3"; name = "JoinLateJPCap"},/turf/floor/grass,/area/caribbean)
 "uw" = (/obj/item/weapon/paper/crumpled,/turf/floor/wood,/area/caribbean/houses)
-"uM" = (/obj/structure/bed/chair/wood/alt{dir = 1},/obj/structure/lamp/lamp_small/alwayson,/turf/floor/wood,/area/caribbean/houses)
 "uO" = (/obj/structure/wild/tree_stump,/turf/floor/grass,/area/caribbean)
 "uR" = (/obj/structure/window/barrier/railing/stone{dir = 4},/obj/structure/window/barrier/railing/stone{dir = 8},/turf/floor/plating/concrete,/area/caribbean/houses)
 "uT" = (/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/obj/structure/barbwire{pixel_y = 8},/turf/floor/grass,/area/caribbean)
@@ -166,7 +179,10 @@
 "vx" = (/obj/structure/barbwire,/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
 "vI" = (/obj/structure/window/barrier/railing/stone{dir = 8},/turf/floor/plating/concrete,/area/caribbean/houses)
 "vM" = (/turf/floor/plating/tiled/darker,/area/caribbean)
+"wc" = (/turf/floor/dirt,/area/caribbean/no_mans_land/invisible_wall/two)
+"we" = (/obj/structure/closet/anchored,/obj/item/weapon/mop,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/flashlight/militarylight,/obj/item/weapon/fire_extinguisher,/turf/floor/wood,/area/caribbean/houses)
 "wu" = (/obj/covers/sidewalk,/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/obj/structure/barbwire{pixel_y = 8},/turf/floor/grass,/area/caribbean)
+"wA" = (/turf/wall/wood,/area/caribbean/houses)
 "wD" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/american,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/american,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/american,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/space,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/space,/obj/item/weapon/reagent_containers/food/snacks/MRE/generic/space,/turf/floor/wood,/area/caribbean/houses)
 "wG" = (/obj/structure/props/junk{icon_state = "Junk_8"},/turf/floor/dirt,/area/caribbean)
 "wH" = (/obj/structure/table/wood/flipped,/turf/floor/plating/concrete,/area/caribbean/houses)
@@ -179,26 +195,36 @@
 "xj" = (/obj/structure/barbwire,/turf/floor/dirt,/area/caribbean)
 "xy" = (/obj/structure/barbwire,/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/grass,/area/caribbean)
 "xI" = (/obj/structure/props/car_wreck/truck{icon_state = "van_wreck2"},/turf/floor/dirt/dust,/area/caribbean)
+"xO" = (/obj/item/weapon/gun/projectile/revolver/magnum44,/obj/item/ammo_magazine/c44magnum,/turf/floor/wood,/area/caribbean/houses)
 "xP" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/turf/floor/plating/concrete,/area/caribbean/houses)
 "xS" = (/obj/structure/vehicleparts/frame/defaultarmored/rwall/armored{w_front = list("c_thin",1,1,0,0.1,0,0); dir = 1},/obj/structure/bed/chair/comfy/black{dir = 8},/turf/floor/grass,/area/caribbean)
 "xV" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/houses)
 "xW" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/obj/structure/window/barrier/sandbag,/turf/floor/plating/concrete,/area/caribbean/houses)
+"xX" = (/turf/floor/wood,/area/caribbean/houses)
 "yc" = (/obj/structure/bed/chair/wood/bleacher/l{dir = 1},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "yq" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/purple,/turf/floor/wood,/area/caribbean/houses)
 "yr" = (/obj/structure/bookcase,/turf/floor/wood,/area/caribbean/houses)
 "yz" = (/obj/structure/window/classic,/obj/structure/barricade/vertical,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"yE" = (/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"yH" = (/obj/structure/grille/fence/picket{dir = 4},/turf/floor/dirt,/area/caribbean)
 "yN" = (/obj/structure/bed/chair/comfy/diner_booth{dir = 4},/turf/floor/plating/dark,/area/caribbean/houses)
 "yO" = (/obj/structure/shelf/palette,/obj/structure/barricade/tires,/turf/floor/plating/concrete,/area/caribbean/houses)
+"yX" = (/obj/item/weapon/generic_MRE_trash,/obj/structure/window/barrier/sandbag/incomplete{dir = 4},/turf/floor/wood,/area/caribbean/houses)
 "zb" = (/obj/structure/table/rack/shelf/wooden,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/turf/floor/plating/concrete,/area/caribbean/houses)
 "zg" = (/obj/structure/barbwire,/turf/floor/dirt/dust,/area/caribbean)
+"zh" = (/obj/structure/simple_door/key_door/anyone/singledoor/privacy,/turf/floor/plating/marble/grid,/area/caribbean/houses)
 "zm" = (/obj/item/weapon/paper/crumpled,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "zp" = (/obj/structure/table/wood,/obj/structure/computer/nopower{pixel_y = 5},/turf/floor/wood,/area/caribbean/houses)
 "zv" = (/obj/structure/table/wood/flipped{dir = 2},/turf/floor/wood,/area/caribbean/houses)
-"zD" = (/obj/structure/closet/crate/ww2/un/m16ammo,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
+"zw" = (/obj/structure/closet/crate/empty,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/obj/item/flashlight/militarylight,/turf/floor/grass,/area/caribbean)
 "zG" = (/obj/covers/cobblestone/stairs,/turf/floor/wood,/area/caribbean/houses)
+"zN" = (/obj/structure/curtain/closed{pixel_y = -32},/turf/floor/wood,/area/caribbean/houses)
 "zO" = (/obj/structure/table/rack/shelf/wooden,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/turf/floor/plating/concrete,/area/caribbean/houses)
 "zS" = (/obj/structure/closet/crate/freezer,/obj/item/weapon/reagent_containers/food/snacks/meat,/obj/item/weapon/reagent_containers/food/snacks/meat,/obj/item/weapon/reagent_containers/food/snacks/meat,/obj/item/weapon/reagent_containers/food/snacks/meat,/obj/item/weapon/reagent_containers/food/snacks/meat,/turf/floor/plating/steel,/area/caribbean/houses)
 "Ac" = (/obj/structure/vehicleparts/frame/defaultarmored/lwall/armored{w_front = list("c_thin",1,1,0,0.1,0,0); dir = 1},/obj/structure/bed/chair/comfy/black{dir = 4},/turf/floor/grass,/area/caribbean)
+"An" = (/obj/structure/lamp/lamp_small/alwayson,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"At" = (/obj/structure/roof_support,/obj/structure/table/modern,/obj/structure/camonet,/turf/floor/grass,/area/caribbean)
+"Ax" = (/obj/structure/window/barrier/sandbag{dir = 1},/obj/structure/window/barrier/sandbag{dir = 8; icon_state = "sandbag"},/turf/floor/wood,/area/caribbean/houses)
 "AF" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/curtain/closed,/turf/floor/wood/fancywood,/area/caribbean/houses)
 "AI" = (/obj/structure/table/wood/flipped{dir = 1},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "AJ" = (/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 1},/turf/floor/plating/concrete,/area/caribbean/houses)
@@ -206,66 +232,69 @@
 "AR" = (/obj/covers/sidewalk,/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/grass,/area/caribbean)
 "AV" = (/obj/structure/closet/crate/empty,/obj/structure/lamp/lamp_small/alwayson,/turf/floor/wood,/area/caribbean/houses)
 "Bb" = (/obj/structure/table/rack/shelf/wooden,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/obj/item/clothing/mask/gas/modern2,/turf/floor/wood,/area/caribbean/houses)
+"Bf" = (/obj/structure/wild/tallgrass2,/turf/floor/grass,/area/caribbean)
 "Bl" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/turf/floor/dirt,/area/caribbean)
 "Bt" = (/obj/structure/bed/chair/wood/alt{dir = 1},/turf/floor/wood,/area/caribbean/houses)
 "BT" = (/obj/structure/railing,/turf/floor/wood,/area/caribbean/houses)
 "BU" = (/obj/effect/floor_decal/grass_edge{dir = 5},/turf/floor/dirt/dust,/area/caribbean)
+"BV" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/mac10,/obj/item/ammo_magazine/mac10,/obj/item/ammo_magazine/mac10,/obj/item/ammo_magazine/mac10,/turf/floor/wood,/area/caribbean/houses)
+"BX" = (/obj/structure/table/modern,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/turf/floor/grass,/area/caribbean)
 "BY" = (/obj/structure/window/classic/metal,/turf/floor/dirt,/area/caribbean/houses)
 "Ce" = (/obj/structure/barbwire{pixel_y = 8},/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
+"Cu" = (/turf/floor/dirt/dust,/area/caribbean)
 "CF" = (/turf/floor/plating/concrete,/area/caribbean/houses)
 "CK" = (/turf/wall/rockwall,/area/caribbean)
 "CM" = (/obj/structure/lamp/lamp_big/alwayson{dir = 4; icon_state = "tube"},/turf/floor/plating/concrete,/area/caribbean/houses)
 "Dc" = (/obj/covers/cobblestone/stairs,/obj/structure/railing{dir = 4; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/houses)
 "De" = (/obj/item/stack/material/wood{anchored = 1},/obj/item/stack/material/wood{anchored = 1; pixel_y = -4},/obj/item/stack/material/wood{anchored = 1; pixel_y = -8},/obj/item/stack/material/wood{anchored = 1; pixel_y = -12},/obj/item/stack/material/wood{anchored = 1; pixel_y = -16},/obj/covers/sidewalk,/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall)
-"Df" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/purple,/turf/floor/wood,/area/caribbean)
 "Dh" = (/obj/structure/simple_door/key_door/anyone/singledoor/housedoor,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "Dk" = (/obj/structure/closet/crate/sandbags,/turf/floor/wood,/area/caribbean/houses)
 "Dm" = (/obj/structure/barbwire{pixel_y = 8},/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/turf/floor/wood,/area/caribbean/houses)
-"Dr" = (/obj/structure/wild/smallbush,/turf/floor/grass,/area/caribbean)
-"Dt" = (/obj/effect/landmark{icon_state = "x1"; name = "JoinLateRUCap"},/obj/structure/bed/chair/office/dark,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"Dt" = (/obj/structure/bed/chair/office/dark,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "Dz" = (/obj/structure/window/classic,/obj/structure/barricade/vertical,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/houses)
 "DB" = (/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "DM" = (/obj/structure/barbwire,/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/grass,/area/caribbean)
 "DT" = (/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 4},/turf/floor/plating/concrete,/area/caribbean/houses)
 "DV" = (/obj/structure/closet/anchored,/obj/item/weapon/mop,/obj/item/weapon/reagent_containers/glass/bucket,/turf/floor/wood,/area/caribbean/houses)
 "DX" = (/obj/structure/window/barrier/sandbag,/turf/floor/wood,/area/caribbean/houses)
-"DY" = (/turf/floor/wood,/area/caribbean)
-"Em" = (/obj/structure/sink/kitchen{pixel_y = 14},/turf/floor/plating/marble/tile,/area/caribbean/houses)
 "Eq" = (/obj/structure/railing{dir = 4; icon_state = "railing0"},/obj/covers/cobblestone/stairs{dir = 1},/turf/floor/wood,/area/caribbean/houses)
 "Ex" = (/obj/structure/simple_door/key_door/anyone/doubledoor/steel,/turf/floor/plating/steel,/area/caribbean/houses)
 "EB" = (/obj/structure/props/junk,/turf/floor/dirt,/area/caribbean)
 "EC" = (/obj/structure/shelf/palette,/obj/item/weapon/reagent_containers/glass/barrel/modern/gasoline,/turf/floor/plating/concrete,/area/caribbean/houses)
-"EN" = (/obj/structure/barbwire{pixel_y = 8},/turf/floor/wood,/area/caribbean/houses)
 "EO" = (/obj/structure/bed/bedroll,/turf/floor/plating/concrete,/area/caribbean/houses)
 "EQ" = (/obj/structure/table/rack/shelf/wooden,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/obj/item/clothing/accessory/armor/nomads/civiliankevlar,/turf/floor/wood,/area/caribbean/houses)
 "ER" = (/obj/structure/window/classic,/obj/structure/barricade/vertical,/obj/structure/curtain/closed,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "EV" = (/obj/structure/closet/crate/empty,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/turf/floor/plating/concrete,/area/caribbean/houses)
 "EW" = (/obj/structure/practice_dummy/target/human,/turf/floor/plating/concrete,/area/caribbean/houses)
 "Fi" = (/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/dirt,/area/caribbean)
-"Fu" = (/obj/structure/simple_door/key_door/anyone/singledoor/privacy,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
+"Fj" = (/obj/structure/wild/smallbush,/turf/floor/grass,/area/caribbean)
 "FQ" = (/obj/structure/barbwire,/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/wood,/area/caribbean)
+"Gb" = (/obj/structure/barbwire,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "Gf" = (/obj/covers/sidewalk,/obj/structure/props/junk,/turf/floor/grass,/area/caribbean)
 "Gg" = (/obj/structure/closet/crate/empty,/obj/item/weapon/clay/advclaybricks/cement,/turf/floor/plating/concrete,/area/caribbean/houses)
 "Gu" = (/obj/structure/window/classic,/obj/structure/barricade/vertical,/obj/structure/curtain/closed,/turf/floor/wood/fancywood,/area/caribbean/houses)
 "Gw" = (/obj/structure/multiz/ladder/ww2/stairsup{dir = 4; icon_state = "rampup"},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
-"Gy" = (/obj/structure/bed/bedroll,/obj/effect/landmark{icon_state = "x1"; name = "JoinLateRU"},/turf/floor/plating/concrete,/area/caribbean/houses)
 "GC" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47/akms,/turf/floor/plating/concrete,/area/caribbean/houses)
 "GE" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
 "GF" = (/obj/structure/barbwire,/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
 "GJ" = (/obj/structure/bed/chair/wood,/turf/floor/wood,/area/caribbean/houses)
+"GP" = (/obj/structure/sink/kitchen{pixel_y = 14},/turf/floor/plating/marble/tile,/area/caribbean/houses)
+"GT" = (/obj/structure/table/modern,/obj/structure/roof_support,/obj/structure/camonet,/turf/floor/grass,/area/caribbean)
 "GV" = (/obj/structure/multiz/ladder/ww2/stairsdown{dir = 8},/turf/floor/wood,/area/caribbean/houses)
 "GZ" = (/obj/covers/cobblestone/stairs{dir = 1},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "Hn" = (/obj/structure/window/classic,/obj/structure/barricade/vertical,/obj/structure/curtain/closed,/turf/floor/wood,/area/caribbean/houses)
-"Hy" = (/obj/structure/table/wood/flipped{dir = 4},/obj/structure/lamp/lamp_small/alwayson{dir = 1},/turf/floor/wood,/area/caribbean/houses)
+"Hy" = (/obj/structure/lamp/lamp_small/alwayson{dir = 1},/obj/structure/window/barrier/sandbag/incomplete{dir = 8},/turf/floor/wood,/area/caribbean/houses)
+"HB" = (/obj/structure/closet/crate/sandbags,/turf/floor/grass,/area/caribbean)
 "Im" = (/obj/structure/toilet,/turf/floor/plating/marble/grid,/area/caribbean/houses)
 "IC" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "ID" = (/obj/structure/closet/crate/dumpster,/turf/floor/dirt,/area/caribbean)
 "IE" = (/obj/structure/table/rack/shelf,/obj/item/weapon/storage/fancy/egg_box,/turf/floor/plating/concrete,/area/caribbean/houses)
 "IF" = (/obj/structure/table/rack/shelf,/obj/item/weapon/storage/box/wheat,/turf/floor/plating/concrete,/area/caribbean/houses)
+"IL" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/m14,/obj/item/weapon/gun/projectile/submachinegun/m14,/turf/floor/wood,/area/caribbean/houses)
 "IP" = (/obj/structure/railing{dir = 4; icon_state = "railing0"},/obj/covers/cobblestone/stairs,/turf/floor/wood,/area/caribbean/houses)
 "IT" = (/obj/structure/barbwire{pixel_y = 8},/turf/floor/dirt,/area/caribbean)
 "IY" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/orange,/turf/floor/wood,/area/caribbean/houses)
-"Jd" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/mp40/mp5,/obj/item/weapon/gun/projectile/submachinegun/mp40/mp5,/obj/item/weapon/gun/projectile/submachinegun/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/turf/floor/wood,/area/caribbean/houses)
+"Jd" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/mp40/mp5,/obj/item/weapon/gun/projectile/submachinegun/mp40/mp5,/obj/item/weapon/gun/projectile/submachinegun/mp40/mp5,/turf/floor/wood,/area/caribbean/houses)
 "Jn" = (/turf/floor/dirt/dust,/area/caribbean/no_mans_land/invisible_wall/two)
 "Jo" = (/obj/structure/table/wood/flipped{dir = 8},/turf/floor/wood,/area/caribbean/houses)
 "Jr" = (/obj/structure/multiz/ladder/ww2/stairsup{dir = 8; icon_state = "rampup"},/turf/floor/wood,/area/caribbean/houses)
@@ -274,24 +303,25 @@
 "Jy" = (/obj/item/weapon/newspaper,/turf/floor/wood,/area/caribbean/houses)
 "JA" = (/obj/structure/grille/fence/picket{dir = 4},/turf/floor/grass,/area/caribbean)
 "JG" = (/obj/structure/bed/wood,/obj/structure/curtain/open/bed,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"JJ" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/turf/floor/wood,/area/caribbean/houses)
 "JN" = (/obj/structure/bed/chair/wood/bleacher/r{dir = 1},/obj/structure/lamp/lamp_small/alwayson{dir = 4},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "JV" = (/obj/covers/sidewalk,/obj/structure/props/junk{icon_state = "Junk_5"},/turf/floor/dirt/dust,/area/caribbean)
 "Ky" = (/obj/structure/table/modern/table,/obj/item/weapon/newspaper,/turf/floor/wood,/area/caribbean/british/land/inside/objective)
-"Kz" = (/turf/floor/plating/marble/tile,/area/caribbean/houses)
 "KG" = (/obj/structure/lamp/lamp_small/alwayson{dir = 4},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "KJ" = (/obj/item/weapon/reagent_containers/glass/barrel/modern,/turf/floor/dirt,/area/caribbean)
 "KK" = (/obj/structure/props/car_wreck/truck{icon_state = "truck"},/turf/floor/dirt/dust,/area/caribbean)
 "KX" = (/obj/covers/sidewalk,/obj/structure/props/junk{icon_state = "Junk_8"},/turf/floor/grass,/area/caribbean)
 "Ln" = (/obj/structure/table/wood/flipped{dir = 4},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
+"Lp" = (/obj/structure/wild/bush,/turf/floor/grass,/area/caribbean)
 "Lq" = (/obj/effect/landmark{icon_state = "x3"; name = "JoinLateJP"},/turf/floor/grass,/area/caribbean)
 "Lx" = (/obj/structure/bed/chair/wood/alt{dir = 4},/turf/floor/wood,/area/caribbean/houses)
 "LF" = (/obj/structure/table/rack/shelf,/obj/item/weapon/storage/foodbox,/turf/floor/plating/concrete,/area/caribbean/houses)
 "LL" = (/obj/structure/shelf/palette,/turf/floor/dirt/dust,/area/caribbean)
 "LN" = (/obj/structure/curtain/open/red,/obj/covers/wood/stairs,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "LS" = (/obj/covers/cobblestone/stairs{dir = 4; icon_state = "rampup"},/turf/floor/carpet/redcarpet,/area/caribbean/houses)
-"Ma" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/barricade/horizontal,/obj/structure/curtain/closed,/turf/floor/wood,/area/caribbean/houses)
+"Ma" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/barricade/horizontal,/turf/floor/wood,/area/caribbean/houses)
 "Mj" = (/obj/structure/multiz/ladder/ww2/stairsup,/turf/floor/wood,/area/caribbean/houses)
-"Ml" = (/turf/floor/dirt,/area/caribbean)
+"Ml" = (/obj/structure/table/modern,/obj/structure/camonet,/obj/item/weapon/paper_bin,/obj/item/weapon/pen/fancy,/turf/floor/grass,/area/caribbean)
 "Mw" = (/obj/structure/shelf/palette,/turf/floor/plating/concrete,/area/caribbean/houses)
 "MH" = (/obj/structure/simple_door/key_door/anyone/singledoor/housedoor,/turf/floor/plating/concrete,/area/caribbean/houses)
 "ML" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/obj/item/ammo_magazine/m16,/turf/floor/wood,/area/caribbean/houses)
@@ -300,29 +330,27 @@
 "MZ" = (/obj/effect/floor_decal/spline/plain{dir = 8},/turf/floor/plating/marble/tile,/area/caribbean/houses)
 "Na" = (/obj/structure/truck{dir = 8},/turf/floor/grass,/area/caribbean)
 "Nf" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/obj/item/ammo_magazine/ak47,/turf/floor/plating/concrete,/area/caribbean/houses)
-"Np" = (/turf/floor/dirt/dust,/area/caribbean)
+"Nl" = (/obj/structure/barricade/construction,/turf/floor/dirt/dust,/area/caribbean)
+"Np" = (/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/turf/floor/dirt/dust,/area/caribbean)
+"Nu" = (/obj/structure/closet/crate/ww2,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/weapon/gun/projectile/submachinegun/m16/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/ammo_magazine/ar15,/obj/item/weapon/gun/projectile/submachinegun/fal,/obj/item/weapon/gun/projectile/submachinegun/fal,/obj/item/ammo_magazine/fal,/obj/item/ammo_magazine/fal,/obj/item/ammo_magazine/fal,/obj/item/ammo_magazine/fal,/obj/item/ammo_magazine/fal,/obj/item/ammo_magazine/fal,/obj/item/weapon/gun/projectile/submachinegun/m14,/obj/item/weapon/gun/projectile/submachinegun/m14,/obj/item/weapon/gun/projectile/submachinegun/m14,/obj/item/weapon/gun/projectile/submachinegun/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/obj/item/ammo_magazine/m14,/turf/floor/grass,/area/caribbean)
 "NA" = (/obj/structure/barbwire{dir = 8; icon_state = "barbwire"},/turf/floor/dirt,/area/caribbean)
 "NC" = (/obj/structure/bed/chair/drivers{dir = 4},/turf/floor/plating/dark,/area/caribbean/houses)
 "NJ" = (/obj/structure/table/wood/flipped{dir = 8},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
 "NK" = (/obj/structure/closet/crate/empty/large,/obj/item/weapon/clay/advclaybricks/cement,/turf/floor/plating/concrete,/area/caribbean/houses)
-"Ou" = (/obj/structure/bed/chair/wood{dir = 8; icon_state = "wooden_chair"},/turf/floor/wood,/area/caribbean/houses)
 "Ov" = (/turf/wall/iron,/area/caribbean)
 "OU" = (/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall/one)
 "Pa" = (/obj/covers/sidewalk,/obj/item/weapon/reagent_containers/glass/barrel/modern,/turf/floor/grass,/area/caribbean)
 "Pf" = (/obj/structure/table/wood/flipped{dir = 1},/turf/floor/plating/concrete,/area/caribbean/houses)
 "Pg" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/shellbox,/obj/item/ammo_magazine/shellbox,/obj/item/ammo_magazine/shellbox,/obj/item/ammo_magazine/shellbox/slug,/obj/item/ammo_magazine/shellbox/slug,/turf/floor/plating/concrete,/area/caribbean/houses)
-"Pt" = (/turf/wall/cement,/area/caribbean/houses)
-"Pu" = (/turf/wall/wood,/area/caribbean/houses)
+"Pt" = (/obj/covers/cement_wall,/turf/wall/cement,/area/caribbean/houses)
 "PB" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/turf/floor/plating/concrete,/area/caribbean/houses)
-"PH" = (/turf/wall/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
 "PO" = (/obj/structure/vehicleparts/frame/defaultarmored/lf/armored{w_front = list("carwindshield2door_leftU",1,1,55,90,0,0); dir = 1; w_left = list("none",1,1,55,90,0,1)},/obj/structure/vehicleparts/movement/reversed{dir = 1},/obj/structure/bed/chair/drivers/car/dark{icon_state = "carseat_driver_left"; dir = 1},/obj/structure/emergency_lights{dir = 1},/turf/floor/grass,/area/caribbean)
 "Qr" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/blue,/turf/floor/wood,/area/caribbean/houses)
 "Qs" = (/obj/structure/wild/tree/live_tree,/turf/floor/dirt,/area/caribbean)
 "Qv" = (/obj/structure/wild/tallgrass,/turf/floor/grass,/area/caribbean)
 "Qx" = (/obj/structure/props/junk{icon_state = "Junk_5"},/turf/floor/dirt,/area/caribbean)
 "QB" = (/obj/structure/barbwire,/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/grass,/area/caribbean)
-"QF" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
-"QM" = (/obj/structure/wild/tallgrass2,/turf/floor/grass,/area/caribbean)
+"QF" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/obj/item/ammo_magazine/springfield,/turf/floor/wood,/area/caribbean/houses)
 "QO" = (/obj/structure/grille/fence/picket{dir = 1},/turf/floor/dirt,/area/caribbean)
 "QS" = (/obj/structure/multiz/ladder/ww2/stairsup{dir = 8; icon_state = "rampup"},/turf/floor/wood,/area/caribbean)
 "QT" = (/turf/floor/plating/marble/grid,/area/caribbean/houses)
@@ -331,9 +359,9 @@
 "Rv" = (/obj/item/weapon/gun/projectile/semiautomatic/barrett/sniper,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/obj/item/ammo_magazine/barrett,/turf/floor/wood,/area/caribbean/houses)
 "Rx" = (/obj/structure/closet/cabinet,/turf/floor/wood,/area/caribbean/houses)
 "RE" = (/obj/effect/decal/cleanable/flour,/turf/floor/plating/concrete,/area/caribbean/houses)
+"Sb" = (/obj/covers/cobblestone/stairs{dir = 4; icon_state = "rampup"},/turf/floor/carpet/redcarpet,/area/caribbean/no_mans_land/invisible_wall/inside)
 "Sj" = (/obj/structure/simple_door/key_door/anyone/wood,/turf/floor/plating/concrete,/area/caribbean/houses)
 "Sk" = (/obj/structure/barbwire{dir = 1; icon_state = "barbwire"},/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
-"Sl" = (/turf/floor/wood,/area/caribbean/houses)
 "Ss" = (/obj/structure/multiz/ladder/ww2/stairsdown{dir = 4},/turf/floor/wood,/area/caribbean/houses)
 "Sv" = (/obj/item/stack/material/wood{anchored = 1},/obj/item/stack/material/wood{anchored = 1; pixel_y = -4},/obj/item/stack/material/wood{anchored = 1; pixel_y = -8},/obj/item/stack/material/wood{anchored = 1; pixel_y = -12},/obj/item/stack/material/wood{anchored = 1; pixel_y = -16},/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall)
 "SA" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/shellbox,/obj/item/ammo_magazine/shellbox,/obj/item/ammo_magazine/shellbox,/obj/item/ammo_magazine/shellbox,/obj/item/ammo_magazine/shellbox,/turf/floor/wood,/area/caribbean/houses)
@@ -345,26 +373,27 @@
 "Tl" = (/obj/effect/landmark{icon_state = "x1"; name = "JoinLateRU"},/turf/floor/wood,/area/caribbean/houses)
 "Tz" = (/obj/structure/window/barrier/sandbag{dir = 1},/turf/floor/wood,/area/caribbean/houses)
 "TC" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/barricade/horizontal,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/houses)
+"TO" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 8},/turf/floor/wood,/area/caribbean/houses)
 "TR" = (/obj/structure/table/rack/shelf/wooden,/turf/floor/wood,/area/caribbean/houses)
-"TW" = (/turf/wall/cement,/area/caribbean)
-"TZ" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/obj/structure/curtain/closed,/turf/floor/wood,/area/caribbean/houses)
+"TW" = (/obj/covers/cement_wall,/turf/wall/cement,/area/caribbean)
+"TZ" = (/obj/structure/window/classic,/obj/structure/barricade/horizontal,/turf/floor/wood,/area/caribbean/houses)
 "Ug" = (/obj/structure/railing{dir = 4; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/houses)
 "Uk" = (/obj/structure/props/car_wreck/truck{icon_state = "van_wreck"},/turf/floor/dirt/dust,/area/caribbean)
 "Ut" = (/obj/covers/sidewalk,/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
-"Uy" = (/obj/structure/vehicleparts/movement/reversed{dir = 1},/obj/structure/bed/chair/comfy/black{dir = 8},/obj/structure/vehicleparts/frame/defaultarmored/bdoor{w_right = list("c_armoredwall",1,1,55,90,0,0); w_back = list("c_door",1,1,55,90,0,1); dir = 1},/turf/floor/grass,/area/caribbean)
+"Uy" = (/obj/structure/vehicleparts/movement/reversed{dir = 1},/obj/structure/bed/chair/comfy/black{dir = 8},/obj/structure/vehicleparts/frame/defaultarmored/bdoor{w_right = list("c_armoredwall",1,1,55,90,0,0); w_back = list("c_door",1,1,55,90,0,1); dir = 1},/obj/item/weapon/gun/launcher/rocket/single_shot/m72law,/turf/floor/grass,/area/caribbean)
 "UG" = (/obj/structure/grille/metalsheetfence/yellow,/turf/floor/plating/dark,/area/caribbean/houses)
-"UJ" = (/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
 "UN" = (/obj/structure/closet/crate/empty,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/obj/item/weapon/gun/projectile/submachinegun/m16/commando/m4,/turf/floor/plating/concrete,/area/caribbean/houses)
 "UO" = (/obj/structure/table/wood/flipped,/obj/structure/lamp/lamp_small/alwayson{dir = 4},/turf/floor/wood,/area/caribbean/houses)
 "UQ" = (/obj/structure/multiz/ladder/ww2/stairsup{dir = 4; icon_state = "rampup"},/turf/floor/wood,/area/caribbean/houses)
-"UR" = (/obj/item/weapon/grenade/chemical/xylyl_bromide,/obj/item/weapon/grenade/chemical/xylyl_bromide,/obj/item/weapon/grenade/chemical/xylyl_bromide,/obj/item/weapon/grenade/chemical/xylyl_bromide,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/structure/closet/crate/airdrops/military,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/obj/item/clothing/mask/gas/swat,/turf/floor/grass,/area/caribbean)
+"UR" = (/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/item/weapon/grenade/coldwar/stinger,/obj/structure/closet/crate/airdrops/military,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/obj/item/weapon/grenade/chemical/cs_gas/m7a2,/turf/floor/grass,/area/caribbean)
 "Vi" = (/obj/structure/props/car_wreck/truck{icon_state = "car_wreck2"},/turf/floor/dirt/dust,/area/caribbean)
 "Vo" = (/obj/structure/table/wood/flipped{dir = 1},/turf/floor/wood,/area/caribbean/houses)
+"Vp" = (/obj/structure/table/modern,/obj/structure/camonet,/obj/item/weapon/newspaper,/turf/floor/dirt,/area/caribbean)
 "Vr" = (/obj/structure/fitness/weightlifter,/turf/floor/plating/concrete,/area/caribbean/houses)
 "Vx" = (/turf/floor/plating/dark,/area/caribbean/houses)
 "VC" = (/obj/structure/props/car_wreck/truck,/turf/floor/dirt/dust,/area/caribbean)
+"VU" = (/obj/structure/table/rack/shelf/wooden,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/obj/item/ammo_magazine/mp40/mp5,/turf/floor/wood,/area/caribbean/houses)
 "VY" = (/obj/structure/table/wood/flipped{dir = 4},/turf/floor/wood,/area/caribbean/houses)
-"Wd" = (/turf/floor/plating/concrete,/area/caribbean/no_mans_land/invisible_wall/inside)
 "Wp" = (/obj/structure/railing{dir = 8; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/houses)
 "Wy" = (/obj/structure/closet/fridge,/obj/item/weapon/reagent_containers/food/snacks/sliceable/bread,/obj/item/weapon/reagent_containers/food/drinks/can/milk,/obj/item/weapon/reagent_containers/food/drinks/can/milk,/obj/item/weapon/reagent_containers/food/drinks/can/milk,/obj/item/weapon/reagent_containers/food/drinks/can/milk,/obj/item/weapon/storage/fancy/egg_box,/turf/floor/plating/steel,/area/caribbean/houses)
 "WA" = (/obj/structure/railing{dir = 1; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/houses)
@@ -376,12 +405,14 @@
 "Xu" = (/obj/structure/table/wood/flipped{dir = 2},/turf/floor/plating/concrete,/area/caribbean/houses)
 "Xw" = (/obj/structure/props/keyboard,/turf/floor/carpet/redcarpet,/area/caribbean/houses)
 "Xx" = (/obj/structure/closet/crate/empty,/obj/structure/railing{dir = 8; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/houses)
+"XL" = (/obj/structure/lamp/lamp_small/alwayson{dir = 8},/turf/floor/plating/marble/grid,/area/caribbean/houses)
 "XR" = (/obj/structure/closet/crate/empty,/obj/item/stack/material/barbwire/twnt,/turf/floor/plating/concrete,/area/caribbean/houses)
 "XS" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/boltaction/springfield,/obj/item/weapon/gun/projectile/boltaction/springfield,/obj/item/weapon/gun/projectile/boltaction/springfield,/obj/item/weapon/gun/projectile/boltaction/springfield,/turf/floor/wood,/area/caribbean/houses)
+"XV" = (/obj/effect/landmark{icon_state = "x1"; name = "JoinLateRUCap"},/turf/floor/wood,/area/caribbean/houses)
 "Ye" = (/obj/structure/closet/crate/sandbags,/turf/floor/plating/concrete,/area/caribbean/houses)
 "Yk" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/reagent_containers/food/condiment/flour,/obj/item/weapon/reagent_containers/food/condiment/flour,/obj/item/weapon/reagent_containers/food/condiment/flour,/obj/item/weapon/reagent_containers/food/condiment/flour,/turf/floor/wood,/area/caribbean/houses)
 "Yl" = (/obj/structure/railing{dir = 8; icon_state = "railing0"},/turf/floor/wood,/area/caribbean/british/land/inside/objective)
-"Yo" = (/obj/structure/vehicleparts/movement/reversed{dir = 1},/obj/structure/bed/chair/comfy/black{dir = 4},/obj/structure/vehicleparts/license_plate/us/centered{dir = 1},/obj/structure/vehicleparts/frame/defaultarmored/bdoor{w_left = list("c_armoredwall",1,1,55,90,0,0); w_back = list("c_door",1,1,55,90,0,1); dir = 1},/turf/floor/grass,/area/caribbean)
+"Yo" = (/obj/structure/vehicleparts/movement/reversed{dir = 1},/obj/structure/bed/chair/comfy/black{dir = 4},/obj/structure/vehicleparts/license_plate/us/centered{dir = 1},/obj/structure/vehicleparts/frame/defaultarmored/bdoor{w_left = list("c_armoredwall",1,1,55,90,0,0); w_back = list("c_door",1,1,55,90,0,1); dir = 1},/obj/item/weapon/plastique/c4,/turf/floor/grass,/area/caribbean)
 "Yr" = (/obj/structure/oven/grill/gas,/turf/floor/dirt,/area/caribbean)
 "YC" = (/obj/structure/lamp/lamp_small/alwayson{dir = 1},/turf/floor/wood,/area/caribbean/houses)
 "YF" = (/obj/structure/simple_door/key_door/anyone/singledoor/privacy,/turf/floor/wood,/area/caribbean/houses)
@@ -391,9 +422,10 @@
 "Zf" = (/obj/item/weapon/generic_MRE_trash,/turf/floor/wood,/area/caribbean/houses)
 "Zg" = (/obj/structure/grille/fence/picket,/turf/floor/grass,/area/caribbean)
 "Zr" = (/obj/structure/closet/crate/ww2/un/m16ammo,/turf/floor/wood,/area/caribbean/houses)
+"Zs" = (/obj/structure/lamp/lamp_small/alwayson{dir = 8},/turf/floor/wood,/area/caribbean/houses)
 "ZG" = (/obj/structure/wild/flowers,/turf/floor/grass,/area/caribbean)
+"ZK" = (/obj/structure/props/junk{icon_state = "Junk_9"},/turf/floor/dirt,/area/caribbean)
 "ZM" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak47,/obj/item/weapon/gun/projectile/submachinegun/ak74,/obj/item/weapon/gun/projectile/submachinegun/ak74,/obj/item/weapon/gun/projectile/submachinegun/ak74,/obj/item/weapon/gun/projectile/submachinegun/ak74,/obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u,/obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u,/obj/item/weapon/gun/projectile/submachinegun/ak47/akms,/obj/item/weapon/gun/projectile/submachinegun/ak47/akms,/obj/item/weapon/gun/projectile/automatic/rpk74,/turf/floor/wood,/area/caribbean/houses)
-"ZU" = (/obj/structure/window/classic,/obj/structure/barricade/vertical,/obj/structure/curtain/open,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/inside)
 "ZY" = (/obj/effect/landmark{icon_state = "x3"; name = "JoinLateJP"},/turf/floor/dirt,/area/caribbean)
 
 (1,1,1) = {"
@@ -435,7 +467,7 @@ CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtPtPtPtPtPtPtPtPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtPgCFkQPtwRwRwRPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtfWrZCFCFCFCFDTPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtzOCFzbPthfnWjQPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtzOCFzbpOhfnWjQPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtPtCFPtPtPtPtPtPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtEOCFEOPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKTWTWTWTWTWTWTWTWTWCKCKCKCKCKPtEOCFEOPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
@@ -454,14 +486,14 @@ CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtzbCFujMOMOCFxPPtCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtzOCFCFCFCFCFGCPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtbUCFCFCFCFCFNfPtPtPtPtPtPtPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFCFCFCFCFCFCFCFCFCFCFPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFpOpOpOpOpOPtPtPtkTCFBYkTBYkTBYkTCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFpOGyGyGypOCKCKCKgqVxVxyNVxyNNCgqCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtfWCFCFWdCFCFCMpOCKCKCKUGVxVxVxVxVxVxTeQSCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFpOGyGyGypOCKCKCKgqyNVxyNVxyNVxgqCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFpOpOpOpOpOCKCKCKkTkTBYkTBYkTvukTCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFPthfwRwRPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtfWCFCFCFCFCFCMPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
-CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFnWCFPtjQwRwRPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFPtPtPtPtPtPtPtPtkTCFBYkTBYkTBYkTCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFPtEOEOEOpOCKCKCKgqVxVxyNVxyNNCgqCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtfWCFCFCFCFCFCMpOCKCKCKUGVxVxVxVxVxVxTeQSCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFPtEOEOEOpOCKCKCKgqyNVxyNVxyNVxgqCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFPtPtPtPtpOCKCKCKkTkTBYkTBYkTvukTCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFCFCFPthfwRwRpOCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtfWCFCFCFCFCFCMpOCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
+CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtCFnWCFPtjQwRwRpOCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKPtPtPtPtPtPtPtPtPtCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
@@ -499,106 +531,106 @@ CKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 ulCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCKCK
 "}
 (1,1,2) = {"
-pVpVpVpVpVpVpVpVpVMlMlMlNpNpMlMlpVpVpVpVpVpVpVpVMlpVpVpVpVpVMlpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVMlpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVMlNpNpMlpVpVpVpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVMlNpNppVpV
-pVpVpVpVMlMlpVpVpVpVMlpVMlNpNppVpVpVpVpVpVpVpVpVpVpVMlMlMlpVpVpVpVpVpVpVMlpVpVpVMlMlMlMlMlMlpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlNpMlpVpVpVpVpVpVpVpVpVpVpVpVuOpVpVpVMlMlpVpVpVpVpVpVpVpVpVpVNpNppVpVpV
-pVpVpVpVpVpVpVpVpVpVpVNpMlpVMlNpNppVMlMlpVpVpVpVpVMlpVpVMlpVpVpVpVpVpVpVMlMlpVMlpVMlMlpVMlMlMlpVpVMlMlpVMlpVuOpVpVpVpVpVpVpVpVpVpVMlNpMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlpVpVNpNppVpVpVpV
-pVpVpVpVpVpVpVpVpVMlMlNpNpMlMlMlpVNpNppVMlMlMlMlpVMlMlpVMlMlMlpVMlpVpVMlMlpVpVMlMlpVpVpVpVpVMlMlpVMlMlpVMlpVpVpVMlpVpVpVpVpVpVpVpVMlNpMlpVpVpVpVSvSvSvSvSvSvSvSvSvSvpVQvpVpVpVpVpVpVpVpVNpNpMlpVpVjgpVpV
-pVpVpVpVpVpVpVMlMlpVpVpVpVNpNpMlMlpVpVNpNppVMlMlMlpVpVpVpVpVpVMlMlNpNppVNpNpNpMlMlMluOMlpVpVpVpVpVpVpVMlpVpVpVpVMlpVpVpVjgpVpVpVpVpVMlNpMlpVpVpVjnjnjnjnjnjnjnjnjnjnpVpVpVpVpVpVpVpVNpNpMlMlpVpVMlMlpVpV
-pVpVpVMlpVMlpVMlpVpVpVMlpVpVpVNpNpNpNpNpMlNppVMlMlMlMlpVpVMlMlpVMlMlMlpVMlMlMlMlMlMlMlpVMlMlpVpVpVpVpVMlpVMlMlpVMlpVpVpVpVpVpVpVpVpVpVNpNppVpVpVSvSvSvSvSvSvSvSvSvSvpVpVpVpVpVMlMlNpNpMlpVpVMlMlpVMlpVpV
-pVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpMlMlMlpVMlMlpVMlMlMlpVMlpVpVpVpVMlMlMlpVpVMlpVpVpVpVMlMlMlMlpVpVpVMlpVpVpVpVpVpVpVpVpVMlNpwGpVpVjnjnjnjnjnjnjnjnjnjnpVpVpVpVpVMlNpNpMlMlpVpVpVpVpVpVMlMl
-pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpMlMlMlMlpVpVpVpVpVpVpVMlpVpVpVpVMlMlMlpVpVpVuOpVpVpVpVpVMlpVpVMlMlMlpVpVpVpVpVpVpVpVpVMlNpMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlNpNpMlMlpVpVMlpVpVMlMlMlpVpV
-MlMlMlpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpMlMlMlpVMlMlMlMlMlpVpVpVpVpVpVMlMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVMlpVpVpVpVpVpVMlNpMlXepVpVpVaopVpVpVpVpVpVNpNpNpNpMlMlpVpVpVpVpVpVpVpVpVpVuOpV
-MlpVMlpVpVMlpVpVpVpVpVjgpVpVpVpVpVpVpVpVpVpVMlMlpVpVpVNpNpNpNpNpNpNppVpVpVpVMlMlpVpVpVpVpVpVMlMlMlpVMlpVpVpVpVpVpVpVpVpVpVMlpVpVpVQvpVpVpVNpNpMlpVpVpVpVpVpVpVNpNpNpMlMlMlMlMlpVpVpVMlMlpVpVpVpVpVpVpVMl
-pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVMlMlMlMlNpNpNpNpNpNpNppVMlMlpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpMlMlpVpVpVNpNpNpNpMlMlfuMlMlpVpVpVpVpVpVpVMlpVpVjgpVpVpVpV
-pVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVMlpVpVpVMlMlpVMlMlMlNpNpNpNpMlMlMlMlMlMlMlMlMlpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVSvSvSvSvSvNpNpMlMlMlNpMlMlMlMlpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpV
-pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVQMpVMlMlpVpVMlMlpVMlMlpVpVpVpVpVpVpVMlMlMlMlNpMlMlMlNpNpMlpVpVpVpVpVpVMlMlpVMlpVpVpVMlMlpVpVpVpVpVjnjnjnjnjnMlNpMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlurpVpVpVpVpVpVMlpV
-pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlNpNpNppVMlNpNppVNppVpVMlpVMlpVpVpVMlMlMlMlMlpVpVpVpVpVpVpVMlMlNpNppVpVpVpVpVpVpVpVpVpVNppVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpV
-pVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVDrpVpVpVpVpVpVpVpVpVpVMlMlNpNpNpNpNpMlMlMlNpNpNpMlMlMlMlMlMlNpNpNpNpNpNpNpNpNpNpNpNppVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVMlpVpVpVpV
-MlpVMlMlMlpVMlpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlMlMlNpNpNpMlpVpVNpNpNppVpVpVpVNpNpNpMlMlMlMlMlMlNpMlMlMlMlMlpVMlpVpVpVMlMlMlMlBlBlMlMlMlNpNpNppVQvpVpVpVMlpVpV
-pVpVMlpVMlpVpVpVpVpVpVpVpVpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVQMpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVMlMlpVpVpVpVpVpVMlNpNpMlKJKJMlpVpVpVpVNpNpNpNpNpNpNpNpMlpVMlpVMlxjxjGFuhpVpVMlMlNpNppVpVpVpVpVpVpV
-pVpVpVpVpVpVpVpVpVpVpVNaMlpVMlpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNppVPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuMHPuPuPupVMlNpNpMlpVpVMlpVpVpV
-MlpVpVpVpVpVpVMlMlpVpVpVMlpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVTWTWTWTWMlNpNpMlPuVrVrVrVrVrVrCFAJCFCFAJCFCFCFCFCFCFCFCFCFCFAJPfCFCFPupVpVpVNpNppVpVpVpVpVpV
-pVpVpVpVpVpVMlMlpVpVpVpVMlMlMlpVpVpVpVaopVpVpVpVpVrLBUklklklNpNpNpNpNpNpNpafafafafafafafafafafafafafafafafTWTWTWTWTWMlNpNpKJPuCFCFCFCFCFCFCFezqJqJqJqJuRqJqJqJqJqJqJqJqJvICFCFCFPupVMlMlNpNpNppVMlpVpVpV
-pVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpNpMlMlNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWTWTWMlNpNpMlPuccCFccccCFccCFeznnnnnnnnuRnnnnnnnnnnnnnnnnvICFCFCFPupVpVMlMlpVNpMlpVpVpVpV
-pVpVpVpVpVpVpVpVuOpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpMlMlMlMlNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWTWTWMlNpNpMlPuCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFPupVpVMlMlNpNppVMlpVpVpV
-pVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpMlMlNpNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWTWMlMlNpNpNpPuccCFccccCFccCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFPupVpVMlMlpVNpMlpVpVpVpV
-pVpVpVpVpVpVpVpVpVMlpVMlpVpVpVpVpVpVpVpVQMpVpVpVpVrLNpMlMlNpNpNpMlNpNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafMlNpNpNpNpPuCFCFCFCFCFCFCFCFCFCFCFCFCFYREVUNeoNKaEYeeoCFCFCFCFPupVpVpVMlpVNppVpVpVpVpV
-pVpVpVpVpVpVpVpVpVMlpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVrLMlMlMlNpNpNpMlNpNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafNpNpNpNpMlPuCFCFCFCFCFCFCFCFCFCFCFCFCFYeeoYRXRGgaEeoGgCFCFCFCFPupVpVpVMlMlNpMlpVMlMlpV
-pVpVpVpVjgpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpMlNpMlMlNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafNpNpNpNpMlPuCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFPupVpVpVMlMlNpNpMlpVMlpV
-pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpNpNpMlNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafMlNpNpNpMlPuCFCFCFCFCFCFCFCFMwMwCFCFCFECtqMwgVgVyOMwMwCFCFCFCFPupVpVpVpVMlMlNpMlpVMlpV
-pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpMlMlMlNpNpNpafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafMlNpNpNpMlPuCFCFCFCFCFCFCFCFMwMwCFCFCFtqMwMwMwgVMwMwECCFCFCFCFPupVpVpVpVMlMlNpNppVpVpV
-pVpVpVpVpVpVpVpVMlpVpVMlpVMlpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpMlNpNpNpNpNpafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafNpNpMlNpMlPuCFCFcDktCFEWrRCFMwMwCFCFCFRECFCFCFCFCFCFCFCFCFCFCFPupVpVpVpVMlMlMlNpNppVpV
-pVpVpVpVpVpVpVpVMlpVpVNpMlMlpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpNpMlMlNpMlNpafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafNpNpMlNpMlPuCFCFCFCFCFCFrRCFMwMwCFCFCFECtqyOtqtqgVMwMwCFCFCFCFPupVpVpVpVpVNpMlNpMlNppV
-pVpVpVpVpVpVpVpVpVpVpVNppVMlpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpMlMlMlNpNpNpafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafNpNpNpNpMlPuCFCFcDCFktEWrRCFMwMwCFCFCFECMwgVMwhqMwECMwCFCFCFCFPupVpVpVMlpVMlMlNpNppVpV
-NppVpVpVpVpVpVpVMlpVpVNppVMlpVpVpVpVpVpVjgpVpVpVpVrLNpMlMlNpNpNpNpMlNpNpNpafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafNpNpNpNpMlPuCFCFCFCFCFCFrRCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFPupVpVpVMlpVNpMlNpNpNpMl
-NppVpVpVpVpVpVpVpVMlpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpMlNpNpNpNpNpafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafNpNpNpNpMlPuCFCFcDCFktEWrRCFMwMwCFCFCFhihiIEIFLFIEhilYCFCFCFCFPupVpVpVMlpVNpMlNppVpVMl
-NpNppVpVpVpVpVurpVMlpVNppVpVMlpVpVpVpVpVpVpVpVpVpVrLNpMlMlNpNpNpNpNpMlNpNpafafafafafSWSWSWSWSWSWSWSWSWSWSWSWSWSWafMlNpNpNpNpPuCFCFCFktCFCFrRCFMwMwCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFPupVpVQvpVpVNpMlMlpVpVpV
-NpNppVpVpVpVpVpVpVMlMlNppVMlMlMlpVpVpVpVpVpVpVpVpVrLNpMlMlMlNpNpNpNpNpNpNpMlMlMlNpMlafafafafSWSWSWSWSWSWSWSWSWSWafMlNpNpNpLLPuCFXucDqaCFEWgeqaMwMwqaCFCFIEIFIEhihihilYLFqawHCFCFPupVpVpVpVpVNpMlMlMlpVMl
-NpNppVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVrLNpMlMlggOvOvOvggPuPuPuPuPuMlNpNpMlMlMlMlafafafafafafafafafafafMlNpNpNpMlPuPuMHPuPuPuPuPuPuPuPuPuDhPuPuPuPuPuPuPuPuPuPuMHPuPuPupVpVpVpVpVpVNpMlMlpVpV
-NpNppVpVpVpVpVpVpVMlpVNppVMlpVpVpVSvSvSvSvSvpVpVpVpVMlMlMlOvOvOvOvOvPuCFAJCFPuMlMlNpNpMlMlMlMlMlMlMlMlMlMlMlMlMlMlMlNpNpMlMlMlITITITPuDVjHPuGwLSLSLSDBDBDBPuKXjtafafafeGeGeGeGeGafpVpVpVMlpVMlNpNpMlpVpV
-NpNpNppVpVQMpVpVpVpVpVMlpVMlpVpVpVjnjnjnjnjnpVpVpVNpMlNpMlOvOvOvOvOvPuCFwZCFPuNpNpMlNpNpNpNpNpMlMlMlNpMlNpMlMlNpMlMlNpNpNpMlMlMlMlITPuSlSlPuGwLSLSLSDBDBDBPuDeafaflSlSlSoueGeGafafpVpVpVMlpVpVMlNpMlpVpV
-NpNpNppVpVQMpVpVpVpVpVpVNpMlMlpVpVSvSvSvSvSvpVpVpVNpNpNpMlOvOvOvOvOvPuCFCFCFPuNpNpNpNpNpNpNpNpNpNpNpMlNpNpNpNpNpNpNpNpNpNpMlMlMlMlNAPuSlSlPuPuPuPuPuDBDBDBPujbaflSlSlSlSlSafafafafpVpVpVMlpVpVpVNpMlMlpV
-NpNpNppVpVpVpVpVpVpVpVpVpVpVpVpVpVjnjnjnjnjnpVpVpVNpNpNpMlggOvOvOvggPuPuSjPuPuMlNpMlNpMlNpNpNpNpNpNpNpNpMlNpNpNpNpNpNpNpNpNpMlNpNpNAxgSlrePurNDBXwPuDBDBDBPuGfaflSlSNpNpNpNppVpVpVpVpVpVpVpVMlpVNpNppVpV
-NpNpNpNppVpVpVpVpVpVMlpVpVMlMlpVpVpVpVpVpVpVpVpVpVNpNpMlNpggggggggggggggggggggMlNpNpNpMlMlNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNAPuVoSlPuPunrPuPuDBDBDBPuafaflSlSNpNpNpNppVpVpVpVDrpVpVpVpVpVNpMlMlMl
-NpNpNpNppVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVaflSbylSbylSbylSbyggggggggggggggggggggNpNpNpNpNpNpNpNpNpNpMlNpNpNpNpNpNpNpNpNpNpNpNpMlNpNpIDPuSlSlxgbBDBDBfqDBDBDBPuPalSlSlSNpNpNpNppVpVpVpVpVpVpVpVMlpVNppVMlMl
-NpNpNpNppVpVpVpVaopVpVMlpVpVMlpVpVpVpVpVlSqtqtqtwPqtqtqtwPNpMlNpNpNpNpNpNpNpNpMlNpNpNpNpNpNpMlMlMlMlMlNpNpMlMlMlMlNpNpNpNpNpMlNpNpIDPuqlplPuDBDBDBDBDBDBDBPuaflSlSlSNpNpNpNpNppVpVpVpVpVMlMlMlpVNpMlMlMl
-NpNpNpNpNppVpVpVpVpVpVpVpVMlMlpVpVpVpVpVlSqtqtqtlSqtqtqtlSMlNpMlNpNpNpNpNpNpNpNpNpNpNpNpMlMlpVpVMlpVpVuhAPpVMlMlpVpVpVpVpVpVMlNpNpMlPuxgPuPudYdYdYdYdYLNdYPuafJVlSlSNpNpNpNpNppVpVpVpVpVpVpVMlpVNppVNpMl
-NpNpNpNpNppVpVpVpVpVpVpVMlpVMlpVpVpVpVpVlSqtqtqtlSqtqtqtlSMlNpNpNpNpNpNpMlNpNpNpNpNpNpMlMlpVGEGEGESkuhuhzguhGFuTpVpVpVpVpVMlMlNpMlMlafafafPuDBDBDBDBDBDBDBPuaflSlSlSNpNpNpNpNpNppVpVpVpVpVpVpVpVNpMlMlNp
-NpNpNpNpNppVpVpVpVpVpVpVMlpVpVpVpVpVafaflSlSlSlSlSlSlSlSlSNpNpNpNpNpNpNpNpNpNpNpMlMlNpMlMlPuAFAFPuAFAFPuxgPuAFAFPuPuPuPuPuPuPuPuPuPuafafafPuDBDBDBDBDBDBDBPudilSlSlSNpNpNpNpNpNppVpVQvpVpVMlMlpVNpMlpVMl
-NpNpNpNpNppVpVpVpVpVpVpVMlMlMlpVpVpVafpBpBpBpBpBpBpBlSNpNpNpNpNpNpNpNpNpNpNpNpNpNpMlNpMlCeGudaeFeFTzeFSlSlSlTzTzPuSlvrPuzSobPuTRTRPuafafafPurhsZmbDBycsZJNPudilSlSlSNpNpNpNpNpNpNppVpVpVpVpVMlpVNppVMlNp
-NpNpNpNpNpNppVpVpVpVpVpVMlpVMlpVpVpVafpBpBpBpBpBpBpBlSNpNpNpNpNpNpNpMlNpNpNpNpNpNpMlMlMlipGuLxtitititimCSlSlSlSlPuSlwDPugLgLPuSlSlPuafaffLERbBDBDBDBDBDBtnERUtlSlSlSNpNpNpNpNpNpNppVpVpVpVpVpVpVNppVMlNp
-NpNpNpNpNpNppVpVpVpVpVpVpVMlpVpVpVpVafpBpBpBpBpBpBpBlSNpNpNpNpNpNpNpNpMlNpNpNpMlNpNpNpFiipPuSltitititimCSlSlSlSlPuSlbXPugLWyPukVSlPuafaffLERbBDBDBDBDBDBtnERUtemlSlSNpNpNpNpNpNpNpNppVpVpVpVpVpVpVNppVMl
-pVNpNpNpNpNpNppVpVpVpVpVMlMlpVpVpVpVafpBpBpBpBpBpBpBlSNpNpNpNpNpNpNpNpNpMlNpMlNpMlNpNpFiipkUoPBtBtBtSlSlSlSlSlSlPuSlanPuExPuPuYkSlPuaffLfLPurhsZmbDBycsZJNPuUtemlSlSNpNpNpNpNpNpNpNppVpVpVpVpVpVpVNppVpV
-pVNpNpNpNpNpNppVpVpVpVpVpVMlMlpVpVpVafpBpBpBpBpBpBpBlSNpNpNpNpMlNpNpNpNpNpMlNpNpMlMlNpipipPuSlSlSlSlSlSlSlmCSlSlSlSlSlSlSlSlSlSlSlHnaffLfLERbBDBDBDBDBDBtnERUtemlSlSNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpVpV
-pVpVNpNpNpNpNpNppVpVDrpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpNpMlMlNpKJMlgpMlMlMlpVipPuSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlHnafhKfLERbBDBDBDBDBDBtnERUtUtlSlSNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpVpV
-pVpVNpNpNpNpNpNppVpVpVpVpVpVMlpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpMlXeMlNpPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuPuSlSlPuEqSlPuPuPuPusYPuPufLfLfLPurhsZmbDBycsZJNPuUtUtafafpVNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpV
-pVpVNpNpNpNpNpNppVpVpVpVpVpVMlpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpNpNpNpEBPuSlSlqGPuSlSlSlPuImmlPuQXQXQXQXPuSlSlPuwISlbdaPEmfKKzhxPusMwufLERbBDBDBDBDBDBtnERUtUtafafpVNpNpNpNpNpNpNpNpNppVpVpVjgpVpVpVpV
-pVpVpVNpNpNpNpNppVpVpVpVpVpVMlpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpMlMlNpQxPufNSlSlPukfSlRxPurrQTPuQTQTQTQTPuSlSlPuSKSlMZKzKzKzKzhxPusMARfLERbBDBDBDBDBDBtnERUtUtafafpVpVpVNpNpNpNpNpNpNppVpVpVpVpVpVpVpV
-pVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpNpYINpMlPuqlSlUOPuPuYFPuPuPumVPuPuPumVPuPuSlSlPuPuSlPuPuPuPuPuPuPuPumuPuPuPuPuPujdPuPuPuPuPuPuPuPupVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVpV
-pVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpeONpNpYrPutZSlSlPuSlSlSlHyqGSlSlYCSlZfVYYCSlSlSlYCSlSlJoYCSlSlSlYCSlSlSlYCSlSlSlSlPuzpWKzpWKzpWKehpVpVpVpVNpNpNpNpNpNpNppVpVpVpVpVpVpV
-pVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpNpNpNpqmPuSlSlJySlSlSlSlSlSlSlSlqlSlOuSlSlSlSlSlSlSlSlqGSlsrSlSlVYSlSlfNSlSlSlSlSlPukXSlBtSlBtSlehpVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpV
-pVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpMlNpNpfuPuSlSlSlSlGJSlSlSlSlSlSlSlSlSlSlLxSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlJoSlSlSlSlPuPuPuPuPuYFPuPupVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpV
-pVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpMlNpNpNpMlNpwGPuGVSlSlPuSlSlSlJxSlSlVYJxSlSlSlAVSlSluwazSlSlSlsNSlSlSluMENSlSlAVZfSlSlSlVYaKszSlDmSlsrPupVpVQvpVNpNpNpNpNpNpNpNppVpVpVpVpVpV
-pVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpMlNpNpNpNpMlPuSlSlMYPuPuYFPuPuPuYFPuPuPuYFPuPuPuYFPuPuPuYFPuPuPuYFPuPuPuYFPuPuPuPuPuSlPuPuPuPuPuYFPuPupVpVpVpVpVNpNpNpNpNpNpNppVpVpVpVpVpV
-pVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpNpNpNpMlPuSlSlSlPuaMSlSlPuaMSlSlPucISlSlPuaMSlSlPuaMSlSlPuaMSlSlPuaMSlSlPuUQlklkSlSlaKzvPuyrSleFehpVpVpVpVpVNpNpNpNpNpNpNppVpVpVpVpVpV
-pVpVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpNpMlNpMlPuSlqlSlPuRxqlkfPuRxSlkfPuRxJskfPuRxjJkfPuRxqlkfPuRxqlkfPuRxqlkfPuUQtstsqlDXDXSlPuyrJxtiehpVpVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVpV
-pVpVpVpVpVpVNpNpNpNpNpNpNppVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpoxMlNpMlPuPuTZPuPuPuTZPuPuPuTZPuPuPuTZPuPuPuTZPuPuPuTZPuPuPuTZPuPuPuTZPuPuPuMaMaSVMaMaPuPuPuPuPuPupVpVpVpVpVpVNpNpNpNpNppVpVpVpVpVpVpV
-pVpVpVpVpVpVNpNpNpNpNpNpNppVpVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpoxNpNpMlZgpVuhuhxjuhuhpVjfwQuhuhuhuhZGZGpVuhxjuhuhvxGFuhuhpVpVuhuhvxvxpVuhSSuheWcqFQDMSSewpVpVpVZgpVpVpVpVpVpVNpNpNpNpNppVpVpVpVpVpVpV
-pVpVpVpVpVpVpVNpNpNpNpNpNpNppVpVpVpVvMvMvMvMvMvMvMvMvMNpNpNpNpNpNpoxNpNpMlZgjfpVpVpVpVpVpVpVpVuhjgpVpVpVZGpVQvMlpVpVpVpVpVpVpVpVpVpVpVpVpVjguhQBkRcqFQGFxypVpVpVpVZgpVQvpVpVpVpVNpNpNpNpNppVpVpVpVpVpVpV
-pVpVpVpVpVpVpVpVNpNpNpNpNpNpNppVpVNpNpNpMlMlNpNpMlNpNpNpNpNpNpNpNpoxNpMlNppVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVuhuhzgxyxyuhpVpVZGpVZgpVpVpVpVpVpVNpNpNpNpNppVpVpVpVpVpVpV
-pVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNppVNpNpNpNpNpNpNpNpNpNpNpoxNpNpNppVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVjgpVpVpVQvpVpVpVpVpVpVpVNppVpVpVpVpVpVpVZgpVpVpVpVpVNpNpNpNpNpNppVpVQvpVpVpVpV
-pVpVpVQMpVpVpVpVpVNpNpNpNpNpNpNpNppVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpoxNpMlMlZgpVpVpVpVpVpVjfpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVjfpVZGpVpVpVpVpVpVMlpVNppVpVpVpVjgpVpVZgpVpVpVpVpVNpNpNpNpNpNppVpVQvpVpVpVpV
-pVpVpVpVMlpVpVpVpVNpNpNpNpNpNpNpNppVNpNppVNpNpNpNpNpNpNpNpNpNpNpNpQOMlNpMlZgjgpVjfJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJANpJAJAJAJAJAJAJAZgpVpVpVpVpVNpNpNpNpNppVpVQvQvpVpVpVpV
-pVpVpVpVMlpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpQOkwJAJAJAJAJAJANpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVNppVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNppVpVQvpVpVpVpVpV
-pVpVpVpVMlMlpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNppVpVNpNpNpNpNpNpNpNpNpMlMlpVpVpVNpNpNpVCNpNpNpNpViNpNpxINpNpNpNpNpmTNpNpNpNpNpNpNpNpNpNpUkNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVpVpVpV
-pVpVpVMlpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVNpNpNpNpNpNpNppVpVpVpVpVpVpVpV
-pVpVpVpVMlMlpVaopVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpKKNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVjgpVNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpV
-pVpVpVpVMlpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpV
-pVpVpVpVpVMlpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVpVjgpVpV
-pVpVpVMlMlpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpVpV
-pVpVpVpVMlQspVpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpVpV
-pVpVpVMlMlMlpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpVpVpV
-pVpVpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVjgpVpVpVpVpVpV
-pVpVpVMlpVMlpVpVpVpVpVpVpVQMpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVpVpVpVpV
-OUOUOUmPmPOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxOUOUOUOUOUOUOUOU
-OUOUmPOUOUmPOUOUOUOUOUOUOUOUmPOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxbxOUOUOUOUOUOUOU
-pVpVpVMlpVMlpVNppVpVpVpVpVpVMlMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpVpV
-pVMlpVMlpVpVpVNppVpVpVpVpVpVMlpVpVpVpVMlMlpVpVpVpVpVpVpVpVpVuOpVpVpVpVpVpVpVpVjgpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNpNpNpNpNpNppVpVpVpVpV
-pVpVpVMlMlpVNpNpMlpVpVpVpVpVpVpVMlMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVZGpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVQMpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVhPhPhPJnJnJnJnJnJnJnJnJnJnJnJnJnhPhPpVpV
-pVpVpVpVMlMlNpMlpVpVpVMlMlpVpVpVpVpVpVpVMlpVMlMlMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVjgpVpVpVpVpVhPpVpVpVpVpVNpNpNpNpNpNpNpNpNpNpNphPpVpV
-pVpVpVpVMlMlNpMlMlMlMlMlMlMlpVpVpVpVpVpVpVpVpVpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVQvpVpVpVpVpVpVjgpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVhPpVuvpVLqpVuvpVNpNpNpNpNpNpNpNpNphPpVpV
-MlpVpVpVNpNpNpMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVhPpVpVpVpVpVpVpVpVNpNpNpNpNpNpNpNpJnpVpV
-MlMlpVpVNpNppVpVMlpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlpVpVMlMlpVpVpVpVaopVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVMlpVpVpVMlpVMlpVpVpVpVpVpVpVpVhPpVLqpVuvpVLqpVpVpVNpNpNpNpNpNpNpJnpVpV
-pVMlpVpVpVMlMlpVpVpVpVpVpVpVpVpVpVpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVMlMlMlpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVMlMlpVpVMlpVMlpVpVpVpVpVpVpVpVpVMlpVpVpVpVMlpVpVpVpVpVpVpVpVhPpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNpJnNppV
-pVpVpVpVpVMlpVpVpVpVpVpVpVpVpVMljgMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVMlMlpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVMlpVpVpVMlpVpVpVpVpVpVhPpVdTpVLqpVdTpVpVpVpVpVNpNpNpNpNpJnNppV
-pVpVMlpVpVpVpVpVpVpVpVpVpVMlpVMlMlpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlMlMlpVMlpVMlgIpVpVpVMlMlpVMlpVpVMlMlMlMlpVpVpVpVpVpVpVpVpVpVMlMlpVpVpVMlpVpVpVhPpVpVpVpVpVpVpVpVbRWDpVpVNpNpNpNpJnNppV
-pVMlMlpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVaopVpVpVpVpVpVpVpVpVpVMlMlMlpVMlMlpVMlpVpVMlpVpVpVpVpVMlpVMlpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVMlMlpVpVpVpVpVMlpVbEpVLqpVuvpVLqpVpVPOoHpVpVpVNpNpNpJnNpNp
-pVpVMlMlpVpVMlpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVQMpVpVpVpVpVpVpVpVpVpVpVMlMlpVMlMlMlMlpVMlMlpVpVMlpVpVpVpVpVpVpVMlMlMlMlpVpVMlpVpVpVMlpVpVpVpVpVpVpVpVMlpVMlpVMlMlpVbEpVpVpVpVpVMlpVtmAcxStLpVpVpVNpNpJnNpNp
-pVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVgIpVpVpVQMQMpVpVpVpVpVpVMlpVpVpVpVpVMlMlpVMlMlMlNppVpVpVpVpVpVpVpVpVpVpVpVpVMlMlMlMlMlMlMlMlurpVMlMlpVpVpVpVpVpVpVpVMlpVpVpVMlbEpVuvpVZYMluvpVURYoUypVpVpVpVpVNpJnNpNp
-pVpVpVMlpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlMlMlpVMlMlQsMlpVMlMlMlNpNpNpMlMlpVpVpVpVQMpVpVpVpVpVpVpVMlMlMlMlMlMlMlMlpVpVMlpVpVpVpVpVpVpVpVpVMlpVpVpVbEpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVNpJnNpNp
-pVpVpVpVjgpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlMlMlpVMlMlMlMlpVpVpVpVpVpVpVNppVpVMlMlpVpVpVpVpVQMpVpVpVpVpVpVpVpVMlMlpVNpMlMlMlMlMlpVpVpVpVpVpVpVpVMlMlMlpVpVhPbEbEhPhPhPhPhPhPhPhPhPhPhPhPhPhPJnNpNp
-pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVNppVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVjgpVpVMlMlMlNpNpMlMlMlMlpVpVMlMlpVMlpVMlpVpVpVMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNp
-pVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVMlMlpVMlMlMlMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNpNpNpNppVpVpVpVpVMlMlMlpVMlpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVNpNpNp
+pVpVpVpVpVpVpVpVpVqKqKqKCuCuqKqKpVpVpVpVpVpVpVpVqKpVpVpVpVpVqKpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVqKpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVqKCuCuqKpVpVpVpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVqKCuCupVpV
+pVpVpVpVqKqKpVpVpVpVqKpVqKCuCupVpVpVpVpVpVpVpVpVpVpVqKqKqKpVpVpVpVpVpVpVqKpVpVpVqKqKqKqKqKqKpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKCuqKpVpVpVpVpVpVpVpVpVpVpVpVuOpVpVpVqKqKpVpVpVpVpVpVpVpVpVpVCuCupVpVpV
+pVpVpVpVpVpVpVpVpVpVpVCuqKpVqKCuCupVqKqKpVpVpVpVpVqKpVpVqKpVpVpVpVpVpVpVqKqKpVqKpVqKqKpVqKqKqKpVpVqKqKpVqKpVuOpVpVpVpVpVpVpVpVpVpVqKCuqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKpVpVCuCupVpVpVpV
+pVpVpVpVpVpVpVpVpVqKqKCuCuqKqKqKpVCuCupVqKqKqKqKpVqKqKpVqKqKqKpVqKpVpVqKqKpVpVqKqKpVpVpVpVpVqKqKpVqKqKpVqKpVpVpVqKpVpVpVpVpVpVpVpVqKCuqKpVpVpVpVSvSvSvSvSvSvSvSvSvSvpVQvpVpVpVpVpVpVpVpVCuCuqKpVpVjgpVpV
+pVpVpVpVpVpVpVqKqKpVpVpVpVCuCuqKqKpVpVCuCupVqKqKqKpVpVpVpVpVpVqKqKCuCupVCuCuCuqKqKqKuOqKpVpVpVpVpVpVpVqKpVpVpVpVqKpVpVpVjgpVpVpVpVpVqKCuqKpVpVpVjnjnjnjnjnjnjnjnjnjnpVpVpVpVpVpVpVpVCuCuqKqKpVpVqKqKpVpV
+pVpVpVqKpVqKpVqKpVpVpVqKpVpVpVCuCuCuCuCuqKCupVqKqKqKqKpVpVqKqKpVqKqKqKpVqKqKqKqKqKqKqKpVqKqKpVpVpVpVpVqKpVqKqKpVqKpVpVpVpVpVpVpVpVpVpVCuCupVpVpVSvSvSvSvSvSvSvSvSvSvpVpVpVpVpVqKqKCuCuqKpVpVqKqKpVqKpVpV
+pVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuqKqKqKpVqKqKpVqKqKqKpVqKpVpVpVpVqKqKqKpVpVqKpVpVpVpVqKqKqKqKpVpVpVqKpVpVpVpVpVpVpVpVpVqKCuwGpVpVjnjnjnjnjnjnjnjnjnjnpVpVpVpVpVqKCuCuqKqKpVpVpVpVpVpVqKqK
+pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuqKqKqKqKpVpVpVpVpVpVpVqKpVpVpVpVqKqKqKpVpVpVuOpVpVpVpVpVqKpVpVqKqKqKpVpVpVpVpVpVpVpVpVqKCuqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKCuCuqKqKpVpVqKpVpVqKqKqKpVpV
+qKqKqKpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuqKqKqKpVqKqKqKqKqKpVpVpVpVpVpVqKqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVqKpVpVpVpVpVpVqKCuqKXepVpVpVlEpVpVpVpVpVpVCuCuCuCuqKqKpVpVpVpVpVpVpVpVpVpVuOpV
+qKpVqKpVpVqKpVpVpVpVpVjgpVpVpVpVpVpVpVpVpVpVqKqKpVpVpVCuCuCuCuCuCuCupVpVpVpVqKqKpVpVpVpVpVpVqKqKqKpVqKpVpVpVpVpVpVpVpVpVpVqKpVpVpVQvpVpVpVCuCuqKpVpVpVpVpVpVpVCuCuCuqKqKqKqKqKpVpVpVqKqKpVpVpVpVpVpVpVqK
+pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVqKqKqKqKCuCuCuCuCuCuCupVqKqKpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuqKqKpVpVpVCuCuCuCuqKqKZKqKqKpVpVpVpVpVpVpVqKpVpVjgpVpVpVpV
+pVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVqKpVpVpVqKqKpVqKqKqKCuCuCuCuqKqKqKqKqKqKqKqKqKpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVSvSvSvSvSvCuCuqKqKqKCuqKqKqKqKpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpV
+pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVBfpVqKqKpVpVqKqKpVqKqKpVpVpVpVpVpVpVqKqKqKqKCuqKqKqKCuCuqKpVpVpVpVpVpVqKqKpVqKpVpVpVqKqKpVpVpVpVpVjnjnjnjnjnqKCuqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKurpVpVpVpVpVpVqKpV
+pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKCuCuCupVqKCuCupVCupVpVqKpVqKpVpVpVqKqKqKqKqKpVpVpVpVpVpVpVqKqKCuCupVpVpVpVpVpVpVpVpVpVCupVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpV
+pVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVFjpVpVpVpVpVpVpVpVpVpVqKqKCuCuCuCuCuqKqKqKCuCuCuqKqKqKqKqKqKCuCuCuCuCuCuCuCuCuCuCuCupVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVqKpVpVpVpV
+qKpVqKqKqKpVqKpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKqKqKCuCuCuqKpVpVCuCuCupVpVpVpVCuCuCuqKqKqKqKqKqKCuqKqKqKqKqKpVqKpVpVpVqKqKqKqKBlBlqKqKqKCuCuCupVQvpVpVpVqKpVpV
+pVpVqKpVqKpVpVpVpVpVpVpVpVpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVBfpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVqKqKpVpVpVpVpVpVqKCuCuqKKJKJqKpVpVpVpVCuCuCuCuCuCuCuCuqKpVqKpVqKxjxjGFuhpVpVqKqKCuCupVpVpVpVpVpVpV
+pVpVpVpVpVpVpVpVpVpVpVNaqKpVqKpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCupVajajajajajajajajajajajajajajajajajajajajajajajbVajajajpVqKCuCuqKpVpVqKpVpVpV
+qKpVpVpVpVpVpVqKqKpVpVpVqKpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVTWTWTWTWqKCuCuqKajVrVrVrVrVrVrCFAJCFCFAJCFCFCFCFCFCFCFCFCFCFAJPfCFCFajpVpVpVCuCupVpVpVpVpVpV
+pVpVpVpVpVpVqKqKpVpVpVpVqKqKqKpVpVpVpVlEpVpVpVpVpVrLBUklklklCuCuCuCuCuCuCuafafafafafafafafafafafafafafafafTWTWTWTWTWqKCuCuKJajCFCFCFCFCFCFCFezqJqJqJqJuRqJqJqJqJqJqJqJqJvICFCFCFajpVqKqKCuCuCupVqKpVpVpV
+pVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuCuqKqKCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWTWTWqKCuCuqKajccCFccccCFccCFeznnnnnnnnuRnnnnnnnnnnnnnnnnvICFCFCFajpVpVqKqKpVCuqKpVpVpVpV
+pVpVpVpVpVpVpVpVuOpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuqKqKqKqKCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWTWTWqKCuCuqKajCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFajpVpVqKqKCuCupVqKpVpVpV
+pVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuqKqKCuCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWTWqKqKCuCuCuajccCFccccCFccCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFajpVpVqKqKpVCuqKpVpVpVpV
+pVpVpVpVpVpVpVpVpVqKpVqKpVpVpVpVpVpVpVpVBfpVpVpVpVrLCuqKqKCuCuCuqKCuCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafqKCuCuCuCuajCFCFCFCFCFCFCFCFCFCFCFCFCFYREVUNeoNKaEYeeoCFCFCFCFajpVpVpVqKpVCupVpVpVpVpV
+pVpVpVpVpVpVpVpVpVqKpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVrLqKqKqKCuCuCuqKCuCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafCuCuCuCuqKajCFCFCFCFCFCFCFCFCFCFCFCFCFYeeoYRXRGgbbeoGgCFCFCFCFajpVpVpVqKqKCuqKpVqKqKpV
+pVpVpVpVjgpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuqKCuqKqKCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafCuCuCuCuqKajCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFajpVpVpVqKqKCuCuqKpVqKpV
+pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuCuCuqKCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafqKCuCuCuqKajCFCFCFCFCFCFCFCFMwMwCFCFCFECtqMwgVgVyOMwMwCFCFCFCFajpVpVpVpVqKqKCuqKpVqKpV
+pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuqKqKqKCuCuCuafggggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWafqKCuCuCuqKajCFCFCFCFCFCFCFCFMwMwCFCFCFtqMwMwMwgVMwMwECCFCFCFCFajpVpVpVpVqKqKCuCupVpVpV
+pVpVpVpVpVpVpVpVqKpVpVqKpVqKpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuqKCuCuCuCuCuafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafCuCuqKCuqKajCFCFcDktCFEWrRCFMwMwCFCFCFRECFCFCFCFCFCFCFCFCFCFCFajpVpVpVpVqKqKqKCuCupVpV
+pVpVpVpVpVpVpVpVqKpVpVCuqKqKpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuCuqKqKCuqKCuafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafCuCuqKCuqKajCFCFCFCFCFCFrRCFMwMwCFCFCFECtqyOtqtqgVMwMwCFCFCFCFajpVpVpVpVpVCuqKCuqKCupV
+pVpVpVpVpVpVpVpVpVpVpVCupVqKpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuqKqKqKCuCuCuafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafCuCuCuCuqKajCFCFcDCFktEWrRCFMwMwCFCFCFECMwgVMwhqMwECMwCFCFCFCFajpVpVpVqKpVqKqKCuCupVpV
+CupVpVpVpVpVpVpVqKpVpVCupVqKpVpVpVpVpVpVjgpVpVpVpVrLCuqKqKCuCuCuCuqKCuCuCuafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafCuCuCuCuqKajCFCFCFCFCFCFrRCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFajpVpVpVqKpVCuqKCuCuCuqK
+CupVpVpVpVpVpVpVpVqKpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuqKCuCuCuCuCuafggggggggSWSWSWSWSWSWSWSWSWSWSWSWSWSWafCuCuCuCuqKajCFCFcDCFktEWrRCFMwMwCFCFCFhihiIEIFLFIEhilYCFCFCFCFajpVpVpVqKpVCuqKCupVpVqK
+CuCupVpVpVpVpVurpVqKpVCupVpVqKpVpVpVpVpVpVpVpVpVpVrLCuqKqKCuCuCuCuCuqKCuCuafafafafafSWSWSWSWSWSWSWSWSWSWSWSWSWSWafqKCuCuCuCuajCFCFCFktCFCFrRCFMwMwCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFajpVpVQvpVpVCuqKqKpVpVpV
+CuCupVpVpVpVpVpVpVqKqKCupVqKqKqKpVpVpVpVpVpVpVpVpVrLCuqKqKqKCuCuCuCuCuCuCuqKqKqKCuqKafafafafSWSWSWSWSWSWSWSWSWSWafqKCuCuCuLLajCFXucDqaCFEWgeqaMwMwqaCFCFIEIFIEhihihilYLFqawHCFCFajpVpVpVpVpVCuqKqKqKpVqK
+CuCupVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVrLCuqKqKggOvOvOvggajajajajajqKCuCuqKqKqKqKafafafafafafafafafafafqKCuCuCuqKajajMHajajajajcjcjcjcjcjDhajajajajajajajajajajMHajajajpVpVpVpVpVpVCuqKqKpVpV
+CuCupVpVpVpVpVpVpVqKpVCupVqKpVpVpVSvSvSvSvSvpVpVpVpVqKqKqKOvOvOvOvOvajCFAJCFajqKqKCuCuqKqKqKqKqKqKqKqKqKqKqKqKqKqKqKCuCuqKqKqKITITITajDVjHcjGwLSLSSbDBDBDBajKXjtafafafeGeGeGeGeGafpVpVpVqKpVqKCuCuqKpVpV
+CuCuCupVpVBfpVpVpVpVpVqKpVqKpVpVpVjnjnjnjnjnpVpVpVCuqKCuqKOvOvOvOvOvajCFwZCFajCuCuqKCuCuCuCuCuqKqKqKCuqKCuqKqKCuqKqKCuCuCuqKqKqKqKITajxXxXcjGwLSLSSbDBDBDBajDeafaflSlSlSoueGeGafafpVpVpVqKpVpVqKCuqKpVpV
+CuCuCupVpVBfpVpVpVpVpVpVCuqKqKpVpVSvSvSvSvSvpVpVpVCuCuCuqKOvOvOvOvOvajCFCFCFajCuCuCuCuCuCuCuCuCuCuCuqKCuCuCuCuCuCuCuCuCuCuqKqKqKqKNAajxXxXcjcjcjcjcjDBDBDBajjbaflSlSlSlSlSafafafafpVpVpVqKpVpVpVCuqKqKpV
+CuCuCupVpVpVpVpVpVpVpVpVpVpVpVpVpVjnjnjnjnjnpVpVpVCuCuCuqKggOvOvOvggajajSjajajqKCuqKCuqKCuCuCuCuCuCuCuCuqKCuCuCuCuCuCuCuCuCuqKCuNpNAxgxXreajrNDBXwajDBDBDBajGfaflSlSCuCuCuCupVpVpVpVpVpVpVpVqKpVCuCupVpV
+CuCuCuCupVpVpVpVpVpVqKpVpVqKqKpVpVpVpVpVpVpVpVpVpVCuCuqKCuggggggggggggggggggggqKCuCuCuqKqKCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuNAajVoxXajajnrajajDBDBDBajafaflSlSCuCuCuCupVpVpVpVFjpVpVpVpVpVCuqKqKqK
+CuCuCuCupVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVaflSbylSbylSbylSbyggggggggggggggggggggCuCuCuCuCuCuCuCuCuCuqKCuCuCuCuCuCuCuCuCuCuCuCuqKCuCuIDajxXxXxgDBDBDBfqDBDBDBajPalSlSlSCuCuCuCupVpVpVpVpVpVpVpVqKpVCupVqKqK
+CuCuCuCupVpVpVpVlEpVpVqKpVpVqKpVpVpVpVpVlSqtqtqtwPqtqtqtwPCuqKCuCuCuCuCuCuCuCuqKCuCuCuCuCuCuqKqKqKqKqKCuCuqKqKqKqKCuCuCuCuCuqKCuCuIDajqlplajDBDBDBDBDBDBDBajdilSlSlSCuCuCuCuCupVpVpVpVpVqKqKqKpVCuqKqKqK
+CuCuCuCuCupVpVpVpVpVpVpVpVqKqKpVpVpVpVpVlSqtqtqtlSqtqtqtlSqKCuqKCuCuCuCuCuCuCuCuCuCuCuCuqKqKpVpVqKpVpVuhAPpVqKqKpVpVpVpVpVpVqKCuCuqKajxgajajdYdYdYdYdYLNdYajdiJVlSlSCuCuCuCuCupVpVpVpVpVpVpVqKpVCupVCuqK
+CuCuCuCuCupVpVpVpVpVpVpVqKpVqKpVpVpVpVpVlSqtqtqtlSqtqtqtlSqKCuCuCuCuCuCuqKCuCuCuCuCuCuqKqKpVGEGEGESkuhuhzguhGFuTpVpVpVpVpVqKqKCuqKqKafafafajcGcGdCcGcGDBcGajaflSlSlSCuCuCuCuCuCupVpVpVpVpVpVpVpVCuqKqKCu
+CuCuCuCuCupVpVpVpVpVpVpVqKpVpVpVpVpVafaflSlSlSlSlSlSlSlSlSCuCuCuCuCuCuCuCuCuCuCuqKqKCuqKqKajAFAFajAFAFajxgajAFAFajajajajajajajajajajafafafajDBGbGbDBDBDBDBajlSlSlSlSCuCuCuCuCuCupVpVQvpVpVqKqKpVCuqKpVqK
+CuCuCuCuCupVpVpVpVpVpVpVqKqKqKpVpVpVafpBpBpBpBpBpBpBlSCuCuCuCuCuCuCuCuCuCuCuCuCuCuqKCuqKCeGuAxeFeFTzeFxXxXxXTzTzajxXvrajzSobajTRTRajafafafajrhsZmbDBycsZJNajlSlSlSlSCuCuCuCuCuCuCupVpVpVpVpVqKpVCupVqKCu
+CuCuCuCuCuCupVpVpVpVpVpVqKpVqKpVpVpVafpBpBpBpBpBpBpBlSCuCuCuCuCuCuCuqKCuCuCuCuCuCuqKqKqKipGuLxtitititimCxXxXxXxXajxXwDajgLgLajxXxXajafaffLERbBDBDBDBDBDBtnERUtlSlSlSCuCuCuCuCuCuCupVpVpVpVpVpVpVCupVqKCu
+CuCuCuCuCuCupVpVpVpVpVpVpVqKpVpVpVpVafpBpBpBpBpBpBpBlSCuCuCuCuCuCuCuCuqKCuCuCuqKCuCuCuFiipajxXtitititimCxXxXxXxXajxXbXajgLWyajkVxXajafaffLERbBDBDBDBDBDBtnERUtemlSlSCuCuCuCuCuCuCuCupVpVpVpVpVpVpVCupVqK
+pVCuCuCuCuCuCupVpVpVpVpVqKqKpVpVpVpVafpBpBpBpBpBpBpBlSCuCuCuCuCuCuCuCuCuqKCuqKCuqKCuCuFiipkUTOBtBtBtxXxXxXxXxXxXajxXanajExajajYkxXajaffLfLajrhsZmbDBycsZJNajbclSlSlSCuCuCuCuCuCuCuCupVpVpVpVpVpVpVCupVpV
+pVCuCuCuCuCuCupVpVpVpVpVpVqKqKpVpVpVafpBpBpBpBpBpBpBlSCuCuCuCuqKCuCuCuCuCuqKCuCuqKqKCuipipajxXxXxXxXxXxXxXxXxXxXJoxXxXxXxXxXxXxXxXHnaffLfLERbBDBDBDBDBDBtnERUtlSlSlSCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpVpV
+pVpVCuCuCuCuCuCupVpVFjpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuCuqKqKCuKJqKgpqKqKqKpVipajxXxXxXxXxXxXxXxXxXxXJoxXxXxXxXxXxXxXxXHnafhKfLERbBDBDBDBDBDBtnERUtaflSlSCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpVpV
+pVpVCuCuCuCuCuCupVpVpVpVpVpVqKpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuqKXeqKCuajajajajajajajajajajajajajajajajajxXxXajEqxXajajajajsYajajfLfLfLajrhsZmbDBycsZJNajbcafafafpVCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpV
+pVpVCuCuCuCuCuCupVpVpVpVpVpVqKpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuCuCuCuEBajxXxXqGajxXxXxXajImmlajQXQXQXQXajxXxXajwIxXbdaPGPfKelhxajsMwufLERbBDBDBDBDBDBtnERUtUtafafpVCuCuCuCuCuCuCuCuCupVpVpVjgpVpVpVpV
+pVpVpVCuCuCuCuCupVpVpVpVpVpVqKpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuqKqKCuQxajfNxXxXajkfxXRxajrrWHajXLQTQTQTajxXxXajSKxXMZelelelelhxajsMARfLERbBDBDBDBDBDBtnERUtUtafafpVpVpVCuCuCuCuCuCuCupVpVpVpVpVpVpVpV
+pVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuCuYICuqKajqlxXUOajajYFajajajzhajajajzhajajxXxXajajDXajajajajajajajajmuajajajajajjdajajajajajajajajpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVpV
+pVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCueOCuCuYrajtZxXxXajxXxXxXYCxXxXxXYCxXyXJoYCxXxXkdYCJsxXxXYCxXxXVYbPxXxXxXYCxXxXxXxXajzpWKzpWKzpWKehpVpVpVpVCuCuCuCuCuCuCupVpVpVpVpVpVpV
+pVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuCuCuCuqmajxXxXJyxXxXxXxXxXxXxXxXxXxXmMJoxXxXxXxXxXxXxXxXxXxXxXVYmKxXxXxXxXxXxXxXxXajkXxXBtxXBtxXehpVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpV
+pVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuqKCuCuZKajxXxXxXxXGJxXxXxXxXmMJoxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXVYmKxXxXxXxXajajajajajYFajajpVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpV
+pVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuqKCuCuCuqKCuwGajGVxXxXajxXxXxXJxxXmMJoJxxXxXxXAVxXxXuwJxxXxXxXJxVYmKxXJxxXxXVYcOZfxXxXxXVYaKszxXDmxXsrajpVpVQvpVCuCuCuCuCuCuCuCupVpVpVpVpVpV
+pVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuqKCuCuCuCuqKajxXxXMYajajYFajajajYFajajajYFajajajYFajajajYFajajajYFajajajYFajajajajajzvajajajajajYFajajpVpVpVpVpVCuCuCuCuCuCuCupVpVpVpVpVpV
+pVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuCuCuCuqKajxXxXxXajZsxXxXajZsxXxXajcIxXxXajZsxXxXajZsxXxXajZsxXxXajZsxXxXajUQlklkxXxXaKzvajyrxXeFehpVpVpVpVpVCuCuCuCuCuCuCupVpVpVpVpVpV
+pVpVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuCuqKCuqKajxXbtxXajRxbtkfajRxzNkfajRxkAkfajRxjJkfajRxbtkfajRxbtkfajRxbtkfajUQtstsqlruruxXajyrJxtiehpVpVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpV
+pVpVpVpVpVpVCuCuCuCuCuCuCupVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuoxqKCuqKajwATZwAwAwATZwAwAwATZwAwAwATZwAwAwATZwAwAwATZwAwAwATZwAwAwATZwAwAwAMaMaSVMaMaajajajajajajpVpVpVpVpVpVCuCuCuCuCupVpVpVpVpVpVpV
+pVpVpVpVpVpVCuCuCuCuCuCuCupVpVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuoxCuCuqKZgpVuhuhxjuhuhpVLpwQuhuhuhuhZGZGpVuhxjuhuhvxGFuhuhpVpVuhuhvxvxpVuhSSuheWcqFQDMSSewpVpVpVZgpVpVpVpVpVpVCuCuCuCuCupVpVpVpVpVpVpV
+pVpVpVpVpVpVpVCuCuCuCuCuCuCupVpVpVpVvMvMvMvMvMvMvMvMvMCuCuCuCuCuCuoxCuCuqKZgLppVpVpVpVpVpVpVpVuhjgpVpVpVZGpVQvqKpVpVpVpVpVpVpVpVpVpVpVpVpVjguhQBkRcqFQGFxypVpVpVpVZgpVQvpVpVpVpVCuCuCuCuCupVpVpVpVpVpVpV
+pVpVpVpVpVpVpVpVCuCuCuCuCuCuCupVpVCuCuCuqKqKCuCuqKCuCuCuCuCuCuCuCuoxCuqKCupVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVuhuhzgxyxyuhpVpVZGpVZgpVpVpVpVpVpVCuCuCuCuCupVpVpVpVpVpVpV
+pVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCupVCuCuCuCuCuCuCuCuCuCuCuoxCuCuCupVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVjgpVpVpVQvpVpVpVpVpVpVpVCupVpVpVpVpVpVpVZgpVpVpVpVpVCuCuCuCuCuCupVpVQvpVpVpVpV
+pVpVpVBfpVpVpVpVpVCuCuCuCuCuCuCuCupVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuoxCuqKqKZgpVpVpVpVpVpVLppVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVLppVZGpVpVpVpVpVpVqKpVCupVpVpVpVjgpVpVZgpVpVpVpVpVCuCuCuCuCuCupVpVQvpVpVpVpV
+pVpVpVpVqKpVpVpVpVCuCuCuCuCuCuCuCupVCuCupVCuCuCuCuCuCuCuCuCuCuCuCuQOqKCuqKZgjgpVLpJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJAJACuJAJAJAJAJAJAJAZgpVpVpVpVpVCuCuCuCuCupVpVQvQvpVpVpVpV
+pVpVpVpVqKpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuQOyHJAJAJAJAJAJACuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVCupVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCupVpVQvpVpVpVpVpV
+pVpVpVpVqKqKpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCupVpVCuCuCuCuCuCuCuCuCuqKqKpVpVpVCuCuCuVCCuCuCuCuViCuCuxICuCuCuCuCumTCuCuCuCuCuCuCuCuCuCuUkCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVpVpVpV
+pVpVpVqKpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVCuCuCuCuCuCuCupVpVpVpVpVpVpVpV
+pVpVpVpVqKqKpVlEpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuKKCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVjgpVCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpV
+pVpVpVpVqKpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpV
+pVpVpVpVpVqKpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVpVjgpVpV
+pVpVpVqKqKpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpVpV
+pVpVpVpVqKQspVpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpVpV
+pVpVpVqKqKqKpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpVpVpV
+pVpVpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVjgpVpVpVpVpVpV
+pVpVpVqKpVqKpVpVpVpVpVpVpVBfpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVpVpVpVpV
+OUOUOUbmbmOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUbebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebeOUOUOUOUOUOUOUOU
+OUOUbmOUOUbmOUOUOUOUOUOUOUOUbmOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUOUbebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebebeOUOUOUOUOUOUOU
+pVpVpVqKpVqKpVCupVpVpVpVpVpVqKqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpVpV
+pVqKpVqKpVpVpVCupVpVpVpVpVpVqKpVpVpVpVqKqKpVpVpVpVpVpVpVpVpVuOpVpVpVpVpVpVpVpVjgpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCuCuCuCuCuCupVpVpVpVpV
+pVpVpVqKqKpVCuCuqKpVpVpVpVpVpVpVqKqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVZGpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVBfpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVbHbHbHJnJnJnJnJnJnJnJnJnJnJnJnJnbHbHpVpV
+pVpVpVpVqKqKCuqKpVpVpVqKqKpVpVpVpVpVpVpVqKpVqKqKqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVjgpVpVpVpVpVbHpVpVpVpVpVCuCuCuCuCuCuCuCuCuCuCubHpVpV
+pVpVpVpVqKqKCuqKqKqKqKqKqKqKpVpVpVpVpVpVpVpVpVpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVQvpVpVpVpVpVpVjgpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVbHpVuvpVLqpVuvpVCuCuCuCuCuCuCuCuCubHpVpV
+qKpVpVpVCuCuCuqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVbHpVpVpVpVpVpVpVpVCuCuCuCuCuCuCuCuJnpVpV
+qKqKpVpVCuCupVpVqKpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKpVpVqKqKpVpVpVpVlEpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVqKpVpVpVqKpVqKpVpVpVpVpVpVpVpVbHpVLqpVuvpVLqpVpVpVCuCuCuCuCuCuCuJnpVpV
+pVqKpVpVpVqKqKpVpVpVpVpVpVpVpVpVpVpVqKqKpVpVpVpVpVpVpVpVpVpVpVpVqKqKqKpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVqKqKpVpVqKpVqKpVpVpVpVpVpVpVpVpVqKpVpVpVpVqKpVpVpVpVpVpVjgpVbHpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCuJnCupV
+pVpVpVpVpVqKpVpVpVpVpVpVpVpVpVqKjgqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVqKqKpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVqKpVpVpVqKpVpVpVpVpVpVbHpVdTpVLqpVdTpVdLHBNupVCuCuCuCuCuJnCupV
+pVpVqKpVpVpVpVpVpVpVpVpVpVqKpVqKqKpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKqKqKpVqKpVqKgIpVpVpVqKqKpVqKpVpVqKqKqKqKpVpVpVpVpVpVpVpVpVpVqKqKpVpVpVqKpVpVpVbHpVpVpVpVpVpVpVaUbRWDpVpVNlisNlNlcoNlpV
+pVqKqKpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVlEpVpVpVpVpVpVpVpVpVpVqKqKqKpVqKqKpVqKpVpVqKpVpVpVpVpVqKpVqKpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVqKqKpVpVpVlQVpGTpVwcpVLqpVuvpVLqpVBXPOoHpVpVpVCuCuCuJnCuCu
+pVpVqKqKpVpVqKpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVBfpVpVpVpVpVpVpVpVpVpVpVqKqKpVqKqKqKqKpVqKqKpVpVqKpVpVpVpVpVpVpVqKqKqKqKpVpVqKpVpVpVqKpVpVpVpVpVpVpVpVqKpVqKcEeLMlzwwcpVpVpVpVpVqKpVtmAcxSdqpVpVpVCuCuJnCuCu
+pVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVgIpVpVpVBfBfpVpVpVpVpVpVqKpVpVpVpVpVqKqKpVqKqKqKCupVpVpVpVpVpVpVpVpVpVpVpVpVqKqKqKqKqKqKqKqKurpVqKqKpVpVpVpVpVpVpVpVqKAtoJAtqKwcpVuvpVZYqKuvpVURYoUypVpVpVpVpVCuJnCuCu
+pVpVpVqKpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKqKqKpVqKqKQsqKpVqKqKqKCuCuCuqKqKpVpVpVpVBfpVpVpVpVpVpVpVqKqKqKqKqKqKqKqKpVpVqKpVpVjgpVpVpVpVpVpVqKpVpVpVwcpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVCuJnCuCu
+pVpVpVpVjgpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKqKqKpVqKqKqKqKpVpVpVpVpVpVpVCupVpVqKqKpVpVpVpVpVBfpVpVpVpVpVpVpVpVqKqKpVCuqKqKqKqKqKpVpVpVpVpVpVpVpVqKqKqKpVpVbHwcwcbHbHbHbHbHbHbHbHbHbHbHbHbHbHJnCuCu
+pVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVCupVqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVjgpVpVqKqKqKCuCuqKqKqKqKpVpVqKqKpVqKpVqKpVpVpVqKqKpVpVpVpVpVpVjgpVpVpVpVpVpVpVpVpVCuCuCu
+pVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVqKqKpVqKqKqKqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCuCuCuCupVpVpVpVpVqKqKqKpVqKpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVpVCuCuCu
 "}
 (1,1,3) = {"
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
@@ -618,53 +650,53 @@ pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuxVxVPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuGJRvPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlVYPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlrePuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuaMSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlqlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlrePuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuSlSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuJoSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQPuaMSlPuYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvpBckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQPuxVxVPuPuSlSlPuPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvOvOvckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPuGVkjkjkjJoSlBbPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvOvOvckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPuGVkjkjkjJoSlEQPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvOvOvckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPHPHPHPHPHzDUJQFPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvpBckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPHlFMLZMgsDkTlXSPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPHTlSlTlSlSlSlJdPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPHSlSlSlSlTlSlrePHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPHqlqlrmSAbhqlqlPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQPHhchcPHPHPHhchcPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjhchccjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjGJRvcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXVYcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXrecjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjqlxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjZsxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXqlcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXrecjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjxXxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjDkxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjZrxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjJoxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQYQYQcjZsxXcjYQYQYQYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvpBckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQcjhchccjcjkdXVcjcjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvOvOvckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjGVkjkjkjxXxXBbcjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvOvOvckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjGVkjkjkjxXTlEQcjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvOvOvckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjajajajajTlxXQFcjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBOvOvOvpBckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjlFMLZMgsxXTlXScjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjTlxXTlxXTlxXJdcjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjxXTlxXTlxXTlrecjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjILJJrmSAbhBVVUcjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQcjcjcjcjcjcjcjcjcjpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckPuPuPuPuPuPuPuxVxVPupBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckDzJoSlUgMjMjXxVoVoPupBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckDzJoSlUgzGzGWpSlSlPupBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckPuSlSlUgzGzGWpSlSlPupBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckPuaMSlSlSlSlSlSlrePupBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckPuSlSlSlSlSlSlZfVYDzpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckPuSlSlSlSlqGZrSlVYDzpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPHPHPHPHPHPHPHPHPHPuPuPuPuPuPuPuPuPuPuPuIPSlPuPuPuPuPuPuPupBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBZUaeDYDYddaeDYDYPHImmlPuQXQXQXQXPuDViHPuDcSlPuckckckckckckpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBZUDfDYsnddDfDYsnPHrrWHPuQTQTQTWHPuSlSlPuutSlPuckckckckckckpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPHPHFuPHPHPHFuPHPHPumVPuPuPumVPuPuhChCPuPuSlPuPuPuPuPuPuPuPuxVPuPuxVxVPuPuPHhchcPHPHPHPHPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPurwSlSlYCSlSlSlHyqGSlSlYCSlSlSlJoSlSlSlSlSlSlSlYCSlSlqGSlSlSlZfSlSlSlSlSlPHaMTlSlTlSlTlZUpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuDcSlSlSlSlVYSlSlSlSlSlSluwSlSlSlSlSlSlSlSlSlVYSlSlSlSlSlSlSlSlSlSlSlSlSlPHSlQrRxIYRxQrZUpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuDcSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlJoSluwSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlPHFuPHPHPHPHPHPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuSlSlSlJxSlSlSlqNSlSlVYJxSlSlSlqGSlJxSlSlqGSlSlJxSlJoSlSlqlJxSlSlSlSlSlSlSlSlSlSlkjkjJrPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPHPHFuPHPHPHFuPHPHPHFuPHPHPHFuPHPHxVPuxVPuxVPuxVPuxVPuxVPuxVPuxVPuPuPuPuSlPHFuPHPHPHPHPHPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBZUaMSlTlPuaMSlTlPuaMSlTlPuaMSlTlPHckckckckckckckckckckckckckckckPuUQlklkSlPHSliRRxQrRxQrZUpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBZURxqlyqPuRxqlyqPuRxSlyqPuRxSlyqPHckckckckckckckckckckckckckckckPuUQlklkJxPHaMTlSlTlSlTlZUpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPHPHhcPHPHPHhcPHPHPHhcPHPHPHhcPHPHckckckckckckckckckckckckckckckPuPuTCTCPuPHjujuPHjujuPHPHpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckajajajajajajajxVxVajpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckDzJoxXUgMjMjXxVoVoajpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckDzJoxXUgzGzGWpxXxXajpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckajxXxXUgzGzGWpxXxXajpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckajZsxXxXxXxXxXxXreajpBpBpBYQYQYQYQYQYQYQYQYQthpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckajxXxXxXxXxXxXZfahDzpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckckckajxXxXxXJxkdZrxXVYDzpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajajajajajajajajajajajajajajajajajajajajIPxXxXajajajajajajpBpBpBYQYQYQYQYQYQYQYQYQthpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzxXxXxXajxXxXxXajImmlajQXQXQXQXajweiHajDcxXreajckckckckckpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzyqxXRxajyqxXRxajrrWHajXLQTQTQTajxXxXajutxXxXajckckckckckpBpBpBYQYQYQYQYQYQYQYQYQpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajajYFajajajYFajajajzhajajajzhajajhChCajajxXxXajajajajajajajxVajajxVxVajajajajxVxVajajajajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajrwxXxXYCxXxXVYHyxXxXxXYCxXxXxXxXxXxXxXxXxXxXxXYCxXxXqGxXxXZfVYmKxXxXxXxXxXajZsxXxXxXxXDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajDcxXxXVYaQxXxXxXxXxXxXxXuwxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXVYmKxXxXxXxXxXajxXRxIYRxQrDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajDcxXxXVYaQxXxXxXxXxXxXxXVYmKxXxXxXxXuwxXxXJoxXxXxXVYxXxXxXxXxXxXxXVYaQxXxXajYFajajajajajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajxXxXxXJxxXxXxXJxxXxXxXJxVYmKxOqGxXJxxXxXqGJozvJxzvVYxXxXqlJxxXxXxXVYmKxXxXxXxXxXkjkjJrajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajajYFajajajYFajajajYFwAajajYFajajxVajxVajxVajxVajxVajxVajxVajxVajajajajxXxXajYFajajajajajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzZsxXxXajZsxXxXajZsxXxXajZsxXxXajckckckckckckckckckckckckckckckajGVkjkjxXxXajxXRxQrRxQrDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzRxqlyqajRxqlyqajRxxXyqajRxxXyqajckckckckckckckckckckckckckckckajGVkjkjJxxXajZsxXxXxXxXDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajajxVajajajxVajajajxVajajajxVajajckckckckckckckckckckckckckckckajajTCTCajajajTCTCajTCTCajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
@@ -748,25 +780,25 @@ pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBgDgDgDgDgDgDgDICICgDpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpByzNJJGeiaVaVYlAIAIgDpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpByzNJcGeiGZGZYlcGcGgDpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBgDcGcGeiGZGZYlzmcGgDpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBgDlAcGcGcGcGcGcGKGgDpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBgDppDtcGcGcGcGcGLnyzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBgDdeKycGcMcGkMcGLnyzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuPuPuxVxVPuPuPuckckckckckckckckckckckgDICICgDgDgDgDgDgDgDpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoYCVoVoYCVYDzckckckckckckckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoSlSlSlSlVYDzckckckckckckckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuBTSlSlSlZfSlPuckckckckckckckckckckckckckckckckckckckckckckckckckckckckckPuxVxVPuPuPuPuPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPugMSlSlSlSlSlPuckckckckckckckckckckckckckckckckckckckckckckckckckckckckckDzJoSlSlSlSlVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuEqSlSlSlSlSlPuckckckckckckckckckckckckckckckckckckckckckckckckckckckckckDzJoSlSlSlSlVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuEqSlSlSlSlSlPuckckckckckckckckckckckckckckckckckckckckckckckckckckckckckPuaMSlSlBTBTpIPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuSlSlSlSlSlSlPuckckckckckckckckckckckckckckckckckckckckckckckckckckckckckPuSlSlSllklkSsPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuSlSlSlSlSluwPuckckckckckckckckckckckckckckckckckckckckckckckckckckckckckPuaMSlSlWAWAsyPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoSlSlSlSlVYDzckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckDzJoSlSlSlSlVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoJxqlqlJxVYDzckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckDzJoqlSlSlZfVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
-pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBPuPuPuxVxVPuPuPuckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckPuxVxVPuPuxVxVPupBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBaJaJaJaJaJaJaJICICaJpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpByzNJJGitaVaVsGAIAIaJpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpByzNJyEeiGZGZYlyEyEaJpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBaJyEyEeiGZGZYlzmyEaJpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBaJlAyEyEyEyEyEyEKGaJpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBaJppDtyEyEyEyEyELnyzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBaJdeKyAncMyEkMyELnyzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajajajxVxVajajajckckckckckckckckckckckaJICICaJaJaJaJaJaJaJpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoYCVoVoYCVYDzckckckckckckckckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoxXxXxXxXVYDzckckckckckckckckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajBTxXxXxXZfxXajckckckckckckckckckckckckckckckckckckckckckckckckckckckckckajxVxVajajajajajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajgMxXxXxXxXxXajckckckckckckckckckckckckckckckckckckckckckckckckckckckckckDzJoxXxXxXxXVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajEqxXxXxXxXxXajckckckckckckckckckckckckckckckckckckckckckckckckckckckckckDzJoxXxXxXxXVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajEqxXxXxXxXxXajckckckckckckckckckckckckckckckckckckckckckckckckckckckckckajZsxXxXBTBTpIajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajxXxXxXxXxXxXajckckckckckckckckckckckckckckckckckckckckckckckckckckckckckajxXxXxXlklkSsajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajxXxXxXxXxXuwajckckckckckckckckckckckckckckckckckckckckckckckckckckckckckajZsxXxXWAWAsyajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoxXclxXxXVYDzckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckDzJoxXxXxXxXVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBDzJoJxqlqlJxVYDzckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckDzJoqlxXxXZfVYDzpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
+pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBajajajxVxVajajajckckckckckckckckckpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBckckckckckajxVxVajajxVxVajpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB
 pBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpBpB


### PR DESCRIPTION
---Cultists---
-davidians spawn above stage in the gun room

-davidians can no longer spawn whilst the point is being captured

-davidians only have civie armor now

-disciple spawns with only two shell boxes now, (one normal and one slug)

---ATF---
-atf all now spawn with black pasgt armor

-atf now have: 1 disposable launcher, 3 c4, abunch of tear gas nades replacing the others , more masks on a table, more toolboxes, a sledgehammer, a riot shield, a box of sandbags, a box of guns and ammo, and two Barret 50cals

---Other---
-added ladders on the side of the chapel giving the atf a third access point

-changed the table placement to make it more linear

-changed some room layouts so that the front stair pathway is two wide on the second floor