### PR TITLE
90s Russian loadouts tweaks

### DIFF
--- a/code/modules/1713/apparel_coldwar.dm
+++ b/code/modules/1713/apparel_coldwar.dm
@@ -1241,15 +1241,15 @@
 /obj/item/weapon/storage/belt/smallpouches/green/sov_74
 /obj/item/weapon/storage/belt/smallpouches/green/sov_74/New()
 	..()
-	new /obj/item/weapon/grenade/chemical/xylyl_bromide(src)
+	new /obj/item/weapon/grenade/coldwar/rgd5(src)
 	new /obj/item/ammo_magazine/ak74(src)
 	new /obj/item/ammo_magazine/ak74(src)
 	new /obj/item/stack/medical/bruise_pack/gauze(src)
 
-/obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt
-/obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt/New()
+/obj/item/weapon/storage/belt/smallpouches/green/sov_74/alt
+/obj/item/weapon/storage/belt/smallpouches/green/sov_74/alt/New()
 	..()
-	new /obj/item/weapon/grenade/coldwar/rgd5(src)
+	new /obj/item/weapon/grenade/chemical/xylyl_bromide(src)
 	new /obj/item/ammo_magazine/ak74(src)
 	new /obj/item/ammo_magazine/ak74(src)
 	new /obj/item/stack/medical/bruise_pack/gauze(src)

--- a/code/modules/1713/jobs/grozny.dm
+++ b/code/modules/1713/jobs/grozny.dm
@@ -253,7 +253,7 @@
 	return TRUE
 
 /datum/job/arab/civilian/chechen/medic
-	title = "Chechnyan Militia Medic"
+	title = "Chechen Militia Medic"
 	rank_abbreviation = "Dr."
 
 	spawn_location = "JoinLateCC"
@@ -606,7 +606,7 @@
 	switch(randarmwrus)
 		if (1)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 		if (2)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
@@ -704,7 +704,7 @@
 		if (1)
 			if (prob(80))
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-				H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+				H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 			else
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/pkm(H), slot_l_hand)
 				H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/largepouches/pkm(H), slot_belt)

--- a/code/modules/1713/jobs/grozny.dm
+++ b/code/modules/1713/jobs/grozny.dm
@@ -351,7 +351,6 @@
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/special/ak74mtactical(H), slot_shoulder)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/makarov(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/rusoff(H), slot_belt)
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/soviet/pmk1(H), slot_r_store)
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
@@ -429,7 +428,6 @@
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74m(H), slot_shoulder)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/makarov(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/rusoff(H), slot_belt)
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/soviet/pmk1(H), slot_r_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
@@ -506,10 +504,8 @@
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(H), slot_back)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/combat/modern(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/makarov(H), slot_l_hand)
-
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/white(H), slot_gloves)
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/soviet/pmk1(H), slot_r_store)
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/custom/armband/white = new /obj/item/clothing/accessory/custom/armband(null)
 	uniform.attackby(white, H)
@@ -610,8 +606,7 @@
 		if (2)
 			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
-
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/soviet/pmk1(H), slot_r_store)
+	
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/faction2(H), slot_back)
 
 	H.s_tone = rand(-32,-24)
@@ -716,9 +711,6 @@
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svd(H), slot_shoulder)
 				H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_svd(H), slot_belt)
 
-
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/soviet/pmk1(H), slot_r_store)
-
 	H.s_tone = rand(-32,-24)
 	H.f_style = pick("Selleck Mustache","Shaved","Short Facial Hair")
 	H.h_style = pick("Crewcut","Undercut","Short Hair","Cut Hair","Skinhead","Average Joe","Fade","Combover")
@@ -786,8 +778,7 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/sovietbala(H), slot_wear_mask)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/makarov(H), slot_l_hand)
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/soviet/pmk1(H), slot_r_store)
-
+	
 	var/randarmwruspez = rand(1,3)
 	switch (randarmwruspez)
 		if (1)

--- a/code/modules/1713/jobs/red_menace.dm
+++ b/code/modules/1713/jobs/red_menace.dm
@@ -96,7 +96,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/sov_ushanka_new(H), slot_head)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/makarov(H), slot_l_hand)
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
@@ -224,10 +224,10 @@
 //back
 	if (prob(20))
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	else
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/faction2(H), slot_back)
 //jacket
 	if (prob(15))
@@ -292,14 +292,14 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_svd(H), slot_belt)
 	else if (prob(60))
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 		var/obj/item/ammo_magazine/ak74/mag = new /obj/item/ammo_magazine/ak74(null)
 		uniform.attackby(mag, H)
 		var/obj/item/ammo_magazine/ak74/mag2 = new /obj/item/ammo_magazine/ak74(null)
 		uniform.attackby(mag2, H)
 	else
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 		var/obj/item/ammo_magazine/ak74/mag = new /obj/item/ammo_magazine/ak74(null)
 		uniform.attackby(mag, H)
 		var/obj/item/ammo_magazine/ak74/mag2 = new /obj/item/ammo_magazine/ak74(null)
@@ -360,7 +360,7 @@
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/key/russian(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u(H), slot_shoulder)
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	if (prob(50))
 		var/obj/item/clothing/under/uniform = H.w_uniform
 		var/obj/item/clothing/accessory/armor/coldwar/plates/b3/armour2 = new /obj/item/clothing/accessory/armor/coldwar/plates/b3(null)

--- a/code/modules/1713/jobs/russian.dm
+++ b/code/modules/1713/jobs/russian.dm
@@ -2880,7 +2880,7 @@
 //gun
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74m/ak12(H), slot_shoulder)
 //belt
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 //helmet
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/modern/ssh_68/winter(H), slot_head)
 //glove

--- a/code/modules/1713/jobs/sovafghan.dm
+++ b/code/modules/1713/jobs/sovafghan.dm
@@ -163,7 +163,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/sov_ushanka_new(H), slot_head)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/makarov(H), slot_l_hand)
 	if (time_of_day == "Night" || time_of_day == "Evening" || time_of_day == "Early Morning")
 		H.equip_to_slot_or_del(new /obj/item/flashlight/militarylight/alt(H), slot_wear_id)
@@ -298,10 +298,10 @@
 //back
 	if (prob(20))
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	else
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	if (map.ID == MAP_SOVAFGHAN)
 		H.equip_to_slot_or_del(new /obj/item/weapon/key/soviet(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/faction2(H), slot_back)
@@ -383,14 +383,14 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_svd(H), slot_belt)
 	else if (prob(60))
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 		var/obj/item/ammo_magazine/ak74/mag = new /obj/item/ammo_magazine/ak74(null)
 		uniform.attackby(mag, H)
 		var/obj/item/ammo_magazine/ak74/mag2 = new /obj/item/ammo_magazine/ak74(null)
 		uniform.attackby(mag2, H)
 	else
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 		var/obj/item/ammo_magazine/ak74/mag = new /obj/item/ammo_magazine/ak74(null)
 		uniform.attackby(mag, H)
 		var/obj/item/ammo_magazine/ak74/mag2 = new /obj/item/ammo_magazine/ak74(null)
@@ -538,7 +538,7 @@
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/key/russian(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u(H), slot_shoulder)
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	if (prob(50))
 		var/obj/item/clothing/accessory/armor/coldwar/plates/b3/armour2 = new /obj/item/clothing/accessory/armor/coldwar/plates/b3(null)
@@ -608,7 +608,7 @@
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/key/russian(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u(H), slot_shoulder)
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	if (prob(50))
 		var/obj/item/clothing/under/uniform = H.w_uniform
 		var/obj/item/clothing/accessory/armor/coldwar/plates/b3/armour2 = new /obj/item/clothing/accessory/armor/coldwar/plates/b3(null)
@@ -887,7 +887,7 @@
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74(H), slot_shoulder)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/tt30(H), slot_l_hand)
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/faction2(H), slot_back)
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
@@ -962,7 +962,7 @@
 //back
 	if (prob(40))
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74(H), slot_shoulder)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74_alt(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
 	else if (prob(50))
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak47(H), slot_shoulder)
 	else

--- a/code/modules/1713/jobs/yeltsin.dm
+++ b/code/modules/1713/jobs/yeltsin.dm
@@ -1,6 +1,8 @@
-/datum/job/russian/sa_lieutenant
+/datum/job/russian/ra
+	title = "Russian Army (DO NOT USE)"
+/datum/job/russian/ra/lieutenant
 	title = "Russian Army Lieutenant"
-	rank_abbreviation = "Lt."
+	rank_abbreviation = "Leyt."
 
 	spawn_location = "JoinLateRUCap"
 
@@ -11,9 +13,9 @@
 	whitelisted = TRUE
 
 	min_positions = 1
-	max_positions = 3
+	max_positions = 2
 
-/datum/job/russian/sa_lieutenant/equip(var/mob/living/human/H)
+/datum/job/russian/ra/lieutenant/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/soldiershoes(H), slot_shoes)
@@ -59,9 +61,9 @@
 	H.setStat("machinegun", STAT_MEDIUM_LOW)
 	return TRUE
 
-/datum/job/russian/sa_sergeant
+/datum/job/russian/ra/sergeant
 	title = "Russian Army Sergeant"
-	rank_abbreviation = "Sgt."
+	rank_abbreviation = "Srj."
 
 	spawn_location = "JoinLateRUCap"
 
@@ -72,10 +74,10 @@
 
 	can_get_coordinates = TRUE
 
-	min_positions = 2
+	min_positions = 1
 	max_positions = 8
 
-/datum/job/russian/sa_sergeant/equip(var/mob/living/human/H)
+/datum/job/russian/ra/sergeant/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 
 //shoes
@@ -125,9 +127,9 @@
 	return TRUE
 
 
-/datum/job/russian/sa_medic
-	title = "Russian Army Field Medic"
-	rank_abbreviation = "Cpl."
+/datum/job/russian/ra/medic
+	title = "Russian Army Corpsman"
+	rank_abbreviation = "Efr."
 
 	spawn_location = "JoinLateRU"
 
@@ -138,7 +140,7 @@
 	min_positions = 2
 	max_positions = 8
 
-/datum/job/russian/sa_medic/equip(var/mob/living/human/H)
+/datum/job/russian/ra/medic/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/soldiershoes(H), slot_shoes)
@@ -185,9 +187,9 @@
 	H.setStat("machinegun", STAT_MEDIUM_LOW)
 	return TRUE
 
-/datum/job/russian/sa_swat
-	title = "Russian OMON Unit"
-	en_meaning = "SWAT"
+/datum/job/russian/ra/omon
+	title = "OMON Officer"
+	en_meaning = "Riot Police"
 	rank_abbreviation = "OMON ofc."
 
 	spawn_location = "JoinLateRUswat"
@@ -199,7 +201,7 @@
 	min_positions = 10
 	max_positions = 50
 
-/datum/job/russian/sa_swat/equip(var/mob/living/human/H)
+/datum/job/russian/ra/omon/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/iogboots/black(H), slot_shoes)
@@ -236,9 +238,9 @@
 	H.setStat("machinegun", STAT_HIGH)
 	return TRUE
 
-/datum/job/russian/sa_soldier
-	title = "Russian Army Rifleman"
-	rank_abbreviation = "Pvt."
+/datum/job/russian/ra/soldier
+	title = "Russian Army Private"
+	rank_abbreviation = "Ryad."
 
 	spawn_location = "JoinLateRU"
 
@@ -250,7 +252,7 @@
 	min_positions = 10
 	max_positions = 200
 
-/datum/job/russian/sa_soldier/equip(var/mob/living/human/H)
+/datum/job/russian/ra/soldier/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
 	var/randshoes = rand(1,3)
@@ -285,7 +287,7 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/modern/ssh_68(H), slot_head)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74(H), slot_shoulder)
-	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_74/alt(H), slot_belt)
 
 	H.civilization = "Russian Army"
 	give_random_name(H)
@@ -301,9 +303,9 @@
 	H.setStat("machinegun", STAT_MEDIUM_LOW)
 	return TRUE
 
-/datum/job/russian/spetznaz
-	title = "Spetznaz"
-	rank_abbreviation = "Spz.Op"
+/datum/job/russian/ra/spetsnaz
+	title = "Spetsnaz"
+	rank_abbreviation = "Jr. Srj."
 
 	spawn_location = "JoinLateRUsptz"
 	whitelisted = TRUE
@@ -315,7 +317,7 @@
 	min_positions = 1
 	max_positions = 10
 
-/datum/job/russian/spetznaz/equip(var/mob/living/human/H)
+/datum/job/russian/ra/spetsnaz/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)


### PR DESCRIPTION
- Switches some file paths for the filled AK-74 belts
- Updates paths and ranks for the Russian Army on Yeltsin
- Replaces Xylil bromide grenades for a RDG-5 on Grozny
- Removes the gasmask on Russian Army loadouts on Grozny (they will now spawn with an addiitonal magazine for the weapon they have)