### PR TITLE
Farming runtime error fix attempt

### DIFF
--- a/code/game/objects/farming.dm
+++ b/code/game/objects/farming.dm
@@ -1006,6 +1006,8 @@
 
 	// Check for rain or monsoon and increase water level
 	var/area/A = get_area(loc)
+	if (!A)
+		return
 	if (findtext(A.icon_state, "rain") || findtext(A.icon_state, "monsoon"))
 		water += 15
 		return


### PR DESCRIPTION
Associated runtime error:

```
[15:54:56] Runtime in farming.dm,1009: Cannot read null.icon_state
   usr: _Firstname Lastname_ (the ploughed field) (374,160,2) (/turf/floor/dirt/ploughed) (_ckey_)
   usr.loc: The ploughed field (Forest) (374,160,2) (/area/caribbean/nomads/forest)