### PR TITLE
Drug Bust: expands the Mobster's spawn protection area further

### DIFF
--- a/maps/1969/drug_bust.dmm
+++ b/maps/1969/drug_bust.dmm
@@ -39,7 +39,7 @@
 "eE" = (/obj/covers/wood_wall/log{dir = 4},/turf/floor/wood,/area/caribbean/british/land/inside)
 "eP" = (/obj/structure/barbwire{pixel_y = 8},/obj/structure/grille/chainlinkfence,/obj/structure/grille/chainlinkfence{dir = 8},/obj/structure/grille/chainlinkfence/corner{dir = 1},/turf/floor/grass,/area/caribbean)
 "eY" = (/obj/structure/vehicleparts/frame/car/falcon/rbc{dir = 8; icon_state = "frame_steel"; override_color = "#d6d6d6"},/obj/structure/bed/chair/carseat/right/dark{icon_state = "carseat_right"; dir = 8},/turf/floor/plating/road,/area/caribbean)
-"fa" = (/obj/structure/window/classic/brickfull,/obj/structure/barricade/steel,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/two)
+"fa" = (/obj/structure/window/classic/brickfull,/obj/structure/barricade/steel,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "fv" = (/obj/structure/closet/crate/empty/large{name = "shipping crate"; desc = "A hefty wooden crate for shipping item's oversea's."; w_class = 20; anchored = 1},/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/structure/lamp/lamp_big/alwayson,/obj/effect/floor_decal/industrial/outline/yellow,/turf/floor/plating/steel,/area/caribbean/british/land/inside/objective{name = "Storage Depot"})
 "fy" = (/obj/structure/closet/crate/empty/large{name = "shipping crate"; desc = "A hefty wooden crate for shipping item's oversea's."; w_class = 20; anchored = 1},/obj/item/stack/material/bone,/turf/floor/grass,/area/caribbean)
 "fM" = (/obj/covers/brick_wall,/turf/floor/grass,/area/caribbean/british/land/inside)
@@ -54,6 +54,7 @@
 "hd" = (/obj/structure/lamp/lamp_big/alwayson,/obj/item/weapon/stool{anchored = 1},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "hk" = (/obj/structure/table/modern/retable,/obj/item/weapon/reagent_containers/cocaineblocks/four,/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "ho" = (/obj/structure/sign/logo/red{pixel_y = 32; desc = "A sign with the logo of Rednikov Industries, logistical warehouse"},/turf/floor/grass,/area/caribbean)
+"hz" = (/obj/structure/table/modern/retable,/obj/item/weapon/wrench,/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "hC" = (/turf/floor/plating/cobblestone/vertical/dark,/area/caribbean)
 "hK" = (/obj/structure/closet/crate/empty/large{name = "shipping crate"; desc = "A hefty wooden crate for shipping item's oversea's."; w_class = 20; anchored = 1},/obj/structure/closet/crate/empty/large{name = "shipping crate"; desc = "A hefty wooden crate for shipping item's oversea's."; w_class = 20; anchored = 1},/obj/item/stack/material/bone,/obj/item/remains/human,/turf/floor/grass,/area/caribbean)
 "hL" = (/obj/structure/vehicleparts/frame/car/falcon/rfc{icon_state = "frame_steel"; dir = 8; override_color = "#d6d6d6"; w_right = list("none",1,1,0,0.1,1,1)},/obj/structure/bed/chair/carseat/right/dark{icon_state = "carseat_right"; dir = 8},/turf/floor/plating/road,/area/caribbean)
@@ -106,7 +107,7 @@
 "oa" = (/turf/floor/grass,/area/caribbean)
 "oi" = (/obj/structure/table/modern/retable,/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "ok" = (/obj/structure/table/modern/retable,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/empty,/obj/item/weapon/material/machete,/turf/floor/wood,/area/caribbean/british/land/inside)
-"ol" = (/obj/structure/sign/logo/red{pixel_y = -32},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
+"ol" = (/obj/structure/sign/logo/red{pixel_y = -32},/turf/floor/plating/steel,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "os" = (/obj/structure/bookcase,/obj/item/weapon/book,/obj/item/weapon/book,/obj/item/weapon/book,/obj/item/weapon/book,/obj/item/weapon/book,/turf/floor/wood,/area/caribbean/british/land/inside)
 "oV" = (/obj/structure/gate/barrier,/turf/floor/plating/road,/area/caribbean)
 "pb" = (/obj/structure/table/modern/retable,/obj/item/weapon/reagent_containers/pill/cocaine_line,/turf/floor/plating/steel,/area/caribbean/british/land/inside)
@@ -137,13 +138,13 @@
 "th" = (/obj/structure/table/modern/table,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 4},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "tu" = (/obj/item/tape/police{icon_state = "police_v_0"; dir = 2; pixel_x = -5},/turf/floor/plating/road,/area/caribbean/no_mans_land/invisible_wall/one)
 "tG" = (/obj/item/weapon/storage/toolbox/blue{pixel_y = 4; pixel_x = -6},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
-"tS" = (/obj/covers/brick_wall,/turf/floor/dirt,/area/caribbean/no_mans_land/invisible_wall/two)
+"tS" = (/obj/covers/brick_wall,/turf/floor/dirt,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "ue" = (/obj/structure/table/modern/table,/obj/item/weapon/paper_bin,/obj/item/weapon/pen{pixel_y = 8},/turf/floor/wood,/area/caribbean/british/land/inside)
 "ug" = (/obj/structure/wild/tree/live_tree/pine{maxhealth = 1000000; health = 1000000},/turf/floor/grass,/area/caribbean/no_mans_land/invisible_wall)
 "uh" = (/obj/structure/bed/chair/comfy/fancy_sofa/r,/obj/structure/sign/clock{pixel_y = 32},/turf/floor/wood,/area/caribbean/british/land/inside)
 "up" = (/obj/structure/bed/chair{dir = 4},/turf/floor/wood,/area/caribbean/british/land/inside)
 "us" = (/obj/effect/floor_decal/industrial/loading{dir = 4},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
-"uv" = (/obj/covers/brick_wall,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/two)
+"uv" = (/obj/covers/brick_wall,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "uE" = (/turf/floor/plating/road/yellowline{icon_state = "road_yellowline"; dir = 1},/area/caribbean)
 "uQ" = (/obj/structure/lamp/lamppost_small/alwayson,/turf/floor/grass,/area/caribbean)
 "uW" = (/obj/structure/window/barrier/sandbag{dir = 8},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
@@ -151,6 +152,7 @@
 "vh" = (/obj/covers/wood_wall/log/corner,/turf/floor/wood,/area/caribbean/british/land/inside)
 "vk" = (/obj/structure/closet/crate/empty/large{name = "shipping crate"; desc = "A hefty wooden crate for shipping item's oversea's."; w_class = 20; anchored = 1},/obj/effect/floor_decal/industrial/outline/yellow,/obj/item/weapon/package,/turf/floor/plating/steel,/area/caribbean/british/land/inside/objective{name = "Storage Depot"})
 "vm" = (/obj/structure/vehicleparts/frame/car/falcon/lf{icon_state = "frame_steel_corner_lf"; dir = 1},/obj/structure/vehicleparts/movement{dir = 1},/obj/structure/engine/internal/gasoline/premade/falcon{dir = 1},/obj/structure/vehicleparts/license_plate/us/centered/front{dir = 1},/obj/structure/vehicleparts/axis/car/falcon/police{dir = 1},/turf/floor/plating/road,/area/caribbean)
+"vo" = (/turf/floor/plating/steel,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "vq" = (/obj/structure/table/modern/table,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shot,/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "vv" = (/obj/structure/lamp/lamp_big/alwayson{dir = 8},/turf/floor/plating/steel,/area/caribbean/british/land/inside/objective{name = "Storage Depot"})
 "vx" = (/obj/item/weapon/cigbutt,/turf/floor/grass,/area/caribbean)
@@ -212,6 +214,7 @@
 "Cc" = (/obj/structure/table/rack/shelf/wooden,/obj/effect/floor_decal/industrial/warning/cee{dir = 8},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "Cg" = (/obj/structure/curtain/closed/red{pixel_y = -32},/obj/structure/table/modern/retable,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,/obj/item/weapon/material/machete,/turf/floor/wood,/area/caribbean/british/land/inside)
 "Cl" = (/obj/covers/roads/dirt{icon_state = "d_roadfull"},/obj/effect/floor_decal/grass_edge{dir = 8},/turf/floor/grass,/area/caribbean)
+"Co" = (/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 1},/turf/floor/plating/steel,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "Cw" = (/obj/structure/table/modern/table,/obj/structure/cutting_board,/obj/item/weapon/reagent_containers/food/snacks/mince{pixel_y = 13},/turf/floor/wood,/area/caribbean/british/land/inside)
 "Cy" = (/obj/structure/shelf/palette{anchored = 1},/obj/item/weapon/reagent_containers/cocaineblocks/five,/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "CI" = (/obj/structure/closet/crate/bin{anchored = 1},/obj/item/weapon/paper/crumpled,/obj/item/weapon/package{desc = "Some kind of package. There is 'BOMB' writen on it with a pen."},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
@@ -345,7 +348,7 @@
 "Vp" = (/obj/effect/decal/cleanable/blood/oil,/turf/floor/plating/steel,/area/caribbean/british/land/inside/objective{name = "Storage Depot"})
 "Vx" = (/obj/structure/grille/chainlinkfence/corner{dir = 4},/obj/structure/barbwire{pixel_y = 8; pixel_x = 13},/turf/floor/plating/road,/area/caribbean)
 "VA" = (/obj/structure/table/rack/shelf/wooden,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/turf/floor/plating/steel,/area/caribbean/british/land/inside/objective{name = "Storage Depot"})
-"VJ" = (/obj/covers/brick_wall,/turf/floor/plating/steel,/area/caribbean/no_mans_land/invisible_wall/two)
+"VJ" = (/obj/covers/brick_wall,/turf/floor/plating/steel,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "VR" = (/obj/structure/vending/rednikovweapons,/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 8},/turf/floor/wood,/area/caribbean/british/land/inside)
 "Wq" = (/obj/structure/table/modern/retable,/obj/item/weapon/material/marx{density = 1; pixel_y = 9; anchored = 1},/turf/floor/wood,/area/caribbean/british/land/inside)
 "Wr" = (/obj/item/tape/police{icon_state = "police_v_0"; dir = 2; pixel_x = 5},/turf/floor/plating/road/yellowline,/area/caribbean)
@@ -361,13 +364,13 @@
 "XF" = (/obj/structure/closet/crate/empty/large{name = "shipping crate"; desc = "A hefty wooden crate for shipping item's oversea's."; w_class = 20; anchored = 1},/obj/item/weapon/reagent_containers/cocaineblocks/five,/obj/effect/floor_decal/industrial/outline/yellow,/turf/floor/plating/steel,/area/caribbean/british/land/inside/objective{name = "Storage Depot"})
 "XV" = (/obj/structure/closet/crate/empty/large{name = "shipping crate"; desc = "A hefty wooden crate for shipping item's oversea's."; w_class = 20; anchored = 1},/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/item/stack/material/coca,/obj/structure/lamp/lamp_big/alwayson{dir = 8},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "XZ" = (/obj/structure/lamp/lamp_small/alwayson{dir = 8},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
-"Yd" = (/obj/structure/window/classic/brickfull,/obj/structure/barricade/steel,/turf/floor/plating/steel,/area/caribbean/no_mans_land/invisible_wall/two)
+"Yd" = (/obj/structure/window/classic/brickfull,/obj/structure/barricade/steel,/turf/floor/plating/steel,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "Yo" = (/obj/structure/table/rack/shelf/wooden,/obj/item/weapon/package,/obj/effect/floor_decal/industrial/warning/cee{dir = 1},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "Yr" = (/obj/structure/curtain/closed/red{pixel_y = -32},/obj/structure/closet/crate/sandbags,/turf/floor/wood,/area/caribbean/british/land/inside)
 "Yv" = (/obj/structure/table/modern/retable,/obj/item/weapon/weldingtool{pixel_y = 4},/obj/item/weapon/weldingtool,/obj/item/weapon/weldingtool{pixel_y = -4},/obj/item/weapon/weldingtool{pixel_y = 8},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
 "Yw" = (/obj/structure/lamp/lamp_big/alwayson{icon_state = "tube"; dir = 8},/turf/floor/wood,/area/caribbean/british/land/inside)
 "YG" = (/obj/structure/grille/chainlinkfence{dir = 8},/obj/structure/barbwire{dir = 4; icon_state = "barbwire"},/turf/floor/grass,/area/caribbean)
-"YI" = (/obj/structure/simple_door/key_door/anyone,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/two)
+"YI" = (/obj/structure/simple_door/key_door/anyone,/turf/floor/wood,/area/caribbean/no_mans_land/invisible_wall/two{location = 0})
 "YO" = (/obj/effect/floor_decal/grass_edge{dir = 4},/obj/structure/grille/chainlinkfence,/obj/structure/barbwire{pixel_y = 8},/turf/floor/plating/road,/area/caribbean)
 "Zn" = (/obj/structure/bed/chair/comfy/beige{dir = 4},/turf/floor/wood,/area/caribbean/british/land/inside)
 "ZS" = (/obj/structure/window/barrier/sandbag{icon_state = "sandbag"; dir = 4},/turf/floor/plating/steel,/area/caribbean/british/land/inside)
@@ -462,17 +465,17 @@ ycycycycycycycycycycfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRNFXAXAXAXAXAXAXAXA
 ycycycycycycycycycycfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRNFXAXAXAXAXAXAXAXAXApCNFycycycycycycycycycycycyc
 ycycycycycycycycycycfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRNFXACbXACbXAgBXAXAXAEnNFycycycycycycycycycycycyc
 ycycycycycycycycycycfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRfRNFwdCbXACbXANFNFXZXAyGNFycycycycycycycycycycycyc
-ycycycycycycycycycycfRfRfRfRfRfRfRfRfRfRfRfRfRfRNFNFOZOZOZOZNFNFXACbXACbkeNFNFXAXASWNFycycycycycycycycycycycyc
-ycycycycycycycycycycNFNFNFNFNFNFNFNFNFNFNFNFNFNFNFBxXAXAXAXABxZSXACbXACbXAXAcKXAXAIgNFycycycycycycycycycycycyc
-ycycycycycycycycycycNFecdARvmHBxdAKwmHBxDyTFBRjdkiXAXAXAXAXAXAZSXACbXACbXAXAXAXAXAlLNFycycycycycycycycycycycyc
-ycycycycycycycycycycOZmHWAoiXAmHKwoiXAmHdADyXAjdxvXAXAXAXAXAXANFXACbXACbXAXAXAXAXAjdOZycycycycycycycycycycycyc
-ycycycycycycycycycycOZXARvTFmHXAoiTFmHXALEKwmHkijdXAXAXAXAXAgBNFXAXAXAXAXAgBXAXAXAjdOZycycycycycycycycycycycyc
-ycycycycycycycycycycOZXAXAXAXAmHWAhkXAmHTFJeXAkimZXAXAXAXAXANFNFXZXAXAXAXANFNFXZXAXAOZycycycycycycycycycycycyc
-ycycycycycycycycycycOZXAkeNFXZXAXAXAXAXAXAXAkeNFXZXAXAXAXAkeNFNFXAXAXAXAkeNFNFXAXAjdOZycycycycycycycycycycycyc
-ycycycycycycycycycycNFXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAcKXAXAXAXAXAXAHyXAXAXANFycycycycycycycycycycycyc
-ycycycycycycycycycycNFmHRvXAXABTJeWAmHmHJenVmHNFXZXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAXAxPNFycycycycycycycycycycycyc
-ycycycycycycycycycycNFecRvXAXAmHDydAXAmHpbDyXANFXAXAXAXAXAXAXAXAXACbXACbXAXAXAXAXAXANFycycycycycycycycycycycyc
-ycycycycycycycycycycNFmHWAqAXAXApbDyhdXAKwdAhdNFXAolXAXAXAXAgBXAXACbXACbXAgBXAXAXAXANFycycycycycycycycycycycyc
+ycycycycycycycycycycfRfRfRfRfRfRfRfRfRfRfRfRfRfRNFVJYdOZOZOZNFNFXACbXACbkeNFNFXAXASWNFycycycycycycycycycycycyc
+ycycycycycycycycycycNFNFNFNFNFNFNFNFNFNFNFNFNFNFNFCovoXAXAXABxZSXACbXACbXAXAcKXAXAIgNFycycycycycycycycycycycyc
+ycycycycycycycycycycNFecdARvmHBxdAKwmHBxDyTFBRjdkivovoXAXAXAXAZSXACbXACbXAXAXAXAXAlLNFycycycycycycycycycycycyc
+ycycycycycycycycycycOZmHWAoiXAmHKwoiXAmHdADyXAjdxvvovoXAXAXAXANFXACbXACbXAXAXAXAXAjdOZycycycycycycycycycycycyc
+ycycycycycycycycycycOZXARvTFmHXAoiTFmHXALEKwmHkijdvovoXAXAXAgBNFXAXAXAXAXAgBXAXAXAjdOZycycycycycycycycycycycyc
+ycycycycycycycycycycOZXAXAXAXAmHWAhkXAmHTFJeXAkimZvovoXAXAXANFNFXZXAXAXAXANFNFXZXAXAOZycycycycycycycycycycycyc
+ycycycycycycycycycycOZXAkeNFXZXAXAXAXAXAXAXAkeNFXZvovoXAXAkeNFNFXAXAXAXAkeNFNFXAXAjdOZycycycycycycycycycycycyc
+ycycycycycycycycycycNFXAXAXAXAXAXAXAXAXAXAXAXAXAXAvovoXAXAXAXAcKXAXAXAXAXAXAHyXAXAXANFycycycycycycycycycycycyc
+ycycycycycycycycycycNFmHRvXAXABTJeWAmHmHJenVmHNFXZvovoXAXAXAXAXAXAXAXAXAXAXAXAXAXAxPNFycycycycycycycycycycycyc
+ycycycycycycycycycycNFecRvXAXAmHDydAXAmHpbDyXANFXAvovoXAXAXAXAXAXACbXACbXAXAXAXAXAXANFycycycycycycycycycycycyc
+ycycycycycycycycycycNFmHWAqAXAXApbDyhdXAKwdAhdNFXAolvoXAXAXAgBXAXACbXACbXAgBXAXAXAXANFycycycycycycycycycycycyc
 ycycycycycycycycycycNFNFVJVJYIVJVJVJVJVJVJVJVJVJVJuvVJXAXAXANFNFXZCbXACbXANFNFVaKoKoNFycycycycycycycycycycycyc
 ycycycycycycycycycycfRfRYdjjuYuYnfuYuYuYnfuYuYuYuYgHVJwdXAkeNFNFXACbXACbkeNFNFXAOxXANFycycycycycycycycycycycyc
 ycycycycycycycycycycfRfRYdjjbFuYuYuYkQuYuYuYbFuYuYuYVJXAXAXAXAHyXACbXACbXAXAlwOxmSthNFycycycycycycycycycycycyc
@@ -482,7 +485,7 @@ ycycycycycycycycycycfRfRVJdNuYuYuYuYuYgHNFdTuYuYuYuYVJNFWyNFNFNFNFkDXAkDXAgBXAXA
 ycycycycycycycycycycfRycVJuYuYuYuYuYuYuYNFVRuYuYrJrJVJwdXAOUTcIsNFNFWyNFNFNFNFXZXAXAOZycycycycycycycycycycycyc
 ycycycycycycycycycycfRfRVJuYuYuYZZikueDkNFgkuYdtIyokVJXAXAXAXAXANFShXAXAXAlHNFXAXAXANFycycycycycycycycycycycyc
 ycycycycycycycycycycfRfRVJdNuYuYAmcUuYgHNFOwuYdtAZVeVJXAXAXAXAXANFvZXAXAXAoiNFXAXAxPNFycycycycycycycycycycycyc
-ycycycycycycycycycycfRfRVJEdSwuYbFbywNNlNFnXYrDtCghTVJKmoiYvNqUsNFDaEfXAXABiNFCbCbCbNFycycycycycycycycycycycyc
+ycycycycycycycycycycfRfRVJEdSwuYbFbywNNlNFnXYrDtCghTVJKmhzYvNqUsNFDaEfXAXABiNFCbCbCbNFycycycycycycycycycycycyc
 ycycycycycycycycycycfRfRVJVJVJVJVJVJtStStStSfafafatSVJNFNFNFNFNFNFNFOZOZOZNFNFNFNFNFNFycycycycycycycycycycycyc
 ycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycyc
 ycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycycyc


### PR DESCRIPTION
In order to prevent spancamping hell.