### PR TITLE
AOTD witnesses for murder

### DIFF
--- a/code/game/mob/living/carbon/human/death.dm
+++ b/code/game/mob/living/carbon/human/death.dm
@@ -242,9 +242,15 @@
 				map.scores[civilization] -= 200
 				if (ishuman(last_harmed))
 					var/mob/living/human/Huser = last_harmed
+					var/mob/living/human/Witness
 					var/probtogetcaught = rand(50,70)
-					if (Huser.wear_mask)
-						probtogetcaught = rand(0,50)
+					if (Witness in range(7, Huser) && Witness.stat != 1 && Witness.stat != 2 && Witness.civilization != "Sheriff Office" && Witness.civilization != "Paramedics" && Witness.civilization != "Government")
+						if (WWinput(Witness, "Report this murder?","Witness Report", "Yes", list("Yes", "No")) == "Yes")
+							if (Huser.wear_mask)
+								probtogetcaught = rand(0,40)
+							else
+								probtogetcaught = 100
+
 					if (Huser.civilization != "Sheriff Office" && Huser.civilization != "Paramedics" && Huser.civilization != "Government")
 						if (prob(probtogetcaught))
 							spawn (rand(300,500))


### PR DESCRIPTION
makes it so people who aren't paramedics, govt, or police within range to a murder get an option to report it or not. Whether a warrant gets issued for masked suspects is reduced.