### PR TITLE
Utes/Kord bullet damage rebalance

### DIFF
--- a/code/modules/projectiles/__projectiles.dm
+++ b/code/modules/projectiles/__projectiles.dm
@@ -580,10 +580,10 @@ obj/item/projectile/bullet/rifle/a556x45
 		explosion(T, 1, 0, 2, 1)
 
 /obj/item/projectile/bullet/rifle/a127
-	damage = DAMAGE_OH_GOD + 65
+	damage = DAMAGE_HIGH
 	penetrating = 20
 	armor_penetration = 55
-	heavy_armor_penetration = 25
+	heavy_armor_penetration = 35
 
 /obj/item/projectile/bullet/rifle/a145
 	damage = DAMAGE_OH_GOD + 90


### PR DESCRIPTION
- Debuffs overall damage (was 265, hence the instakills), increases heavy armor penetration a bit