### PR TITLE
Rotstadt under "Fiction" category

### DIFF
--- a/code/datums/vote.dm
+++ b/code/datums/vote.dm
@@ -54,7 +54,7 @@ var/global/list/round_voters = list() //Keeps track of the individuals voting fo
 						C << browse(vote.interface(C),"window=vote")
 
 	proc/autogamemode()
-		if (map.ID == MAP_NATIONSRP || map.ID == MAP_NATIONSRP_TRIPLE || map.ID == MAP_NATIONSRPMED || map.ID == MAP_NATIONSRP_WW2 || map.ID == MAP_NATIONSRP_COLDWAR || map.ID == MAP_NATIONSRP_COLDWAR_CAMPAIGN || map.ID == MAP_NOMADS_PERSISTENCE_BETA || map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT || map.ID == MAP_GLADIATORS || map.ID == MAP_ALLEYWAY || map.ID == MAP_FOOTBALL || map.ID == MAP_FOOTBALL_CAMPAIGN || map.ID == MAP_NOMADS_EXTENDED || map.ID == MAP_CIVILIZATIONS || map.ID == MAP_TRIBES || map.ID == MAP_JUNGLE_OF_THE_CHADS || map.ID == MAP_NOMADS_WASTELAND || map.ID == MAP_NOMADS_WASTELAND_2 || map.ID == MAP_TESTING || map.battleroyale || map.ID == MAP_THE_ART_OF_THE_DEAL || map.ID == MAP_FOUR_KINGDOMS)
+		if (map.ID == MAP_NATIONSRP || map.ID == MAP_NATIONSRP_TRIPLE || map.ID == MAP_NATIONSRPMED || map.ID == MAP_NATIONSRP_WW2 || map.ID == MAP_NATIONSRP_COLDWAR || map.ID == MAP_NATIONSRP_COLDWAR_CAMPAIGN || map.ID == MAP_NOMADS_PERSISTENCE_BETA || map.ID == MAP_CAMPAIGN || map.ID == MAP_GLADIATORS || map.ID == MAP_ALLEYWAY || map.ID == MAP_FOOTBALL || map.ID == MAP_FOOTBALL_CAMPAIGN || map.ID == MAP_NOMADS_EXTENDED || map.ID == MAP_CIVILIZATIONS || map.ID == MAP_TRIBES || map.ID == MAP_JUNGLE_OF_THE_CHADS || map.ID == MAP_NOMADS_WASTELAND || map.ID == MAP_NOMADS_WASTELAND_2 || map.ID == MAP_TESTING || map.battleroyale || map.ID == MAP_THE_ART_OF_THE_DEAL || map.ID == MAP_FOUR_KINGDOMS)
 			return
 		if (map.persistence)
 			return

--- a/code/game/mob/living/carbon/human/death.dm
+++ b/code/game/mob/living/carbon/human/death.dm
@@ -422,7 +422,7 @@
 		if (map.gamemode == "Hardcore")
 			client.next_normal_respawn = world.realtime+999999
 		else
-			if (map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT)
+			if (map.ID == MAP_CAMPAIGN)
 				client.next_normal_respawn = world.realtime + 1800 + (client.respawn_count * 600)
 				client.respawn_count++
 			else

--- a/code/game/mob/living/carbon/human/human_life.dm
+++ b/code/game/mob/living/carbon/human/human_life.dm
@@ -1652,7 +1652,7 @@
 							holder2.overlays += icon(holder2.icon,"i_cpl")
 					else
 						holder2.overlays += icon(holder2.icon,"squad_[squad]")
-			if (map.ID != MAP_CAMPAIGN)
+			if (map.ID != MAP_CAMPAIGN && map.ID != MAP_ROTSTADT)
 				if (original_job.is_commander || (original_job.is_commander && original_job.is_officer) || original_job.is_vip)
 					if (faction_text == CIVILIAN && map.ID == MAP_OCCUPATION)
 						holder2.icon_state = ""

--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -484,16 +484,22 @@ var/global/redirect_all_players = null
 					var/msg = "[key_name(src)] bypassed a [wait] minute wait to respawn."
 					log_admin(msg)
 					message_admins(msg, client.ckey)
-					LateChoices()
+					if (map.ID == MAP_ROTSTADT)
+						LateChoicesRotstadt()
+					else
+						LateChoices()
 					return TRUE
 			WWalert(src, "Because you died in combat, you must wait [wait] more minutes to respawn.", "Error")
 			return FALSE
-		LateChoices()
+		if (map.ID == MAP_ROTSTADT)
+			LateChoicesRotstadt()
+		else
+			LateChoices()
 		return TRUE
 
 	if (href_list["SelectedJob"])
-		if (map.ID == MAP_CAMPAIGN)
-			if (!findtext(href_list["SelectedJob"], "Private") && !findtext(href_list["SelectedJob"], "Machinegunner") && !findtext(href_list["SelectedJob"], "Des. Marksman"))
+		if (map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT)
+			if (map.ID == MAP_CAMPAIGN && !findtext(href_list["SelectedJob"], "Private") && !findtext(href_list["SelectedJob"], "Machinegunner") && !findtext(href_list["SelectedJob"], "Des. Marksman"))
 				if ((input(src, "This is a specialist role. You should have decided with your faction on which roles you should pick. If you haven't done so, its probably better if you join as a Private instead. Are you sure you want to join in as a [href_list["SelectedJob"]]?") in list("Yes", "No")) == "No")
 					return
 			if(findtext(href_list["SelectedJob"],"BAF"))
@@ -1386,11 +1392,16 @@ var/global/redirect_all_players = null
 						temp_name = "Chinese Red Army"
 					if (temp_name == "Chinese")
 						temp_name = "Chinese National Army"
-				else if (map && map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT)
+				else if (map && map.ID == MAP_CAMPAIGN)
 					if (temp_name == "Civilian")
 						temp_name = "Blugoslavia"
 					if (temp_name == "Pirates")
 						temp_name = "Redmenia"
+				else if (map && map.ID == MAP_ROTSTADT)
+					if (temp_name == "Civilian")
+						temp_name = "Blugoslavian Armed Forces"
+					if (temp_name == "Pirates")
+						temp_name = "Rotstadt People's Republic"
 				else if (map && map.ID == "MAP_HOLDMADRID")
 					if (temp_name == "Civilian")
 						temp_name = "Republican"

--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -132,13 +132,13 @@ var/global/redirect_all_players = null
 		else if (map.nomads)
 			output += "<p><a href='byond://?src=\ref[src];nomads=1'>Join!</a></p>"
 		else
-			if(map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT)
+			if(map.ID == MAP_CAMPAIGN)
 				output += "<p><a href='byond://?src=\ref[src];join_campaign=1'>Join Game!</a></p>"
 			else
 				output += "<p><a href='byond://?src=\ref[src];late_join=1'>Join Game!</a></p>"
 
 	var/height = 250
-	if (map && map.ID != MAP_CAMPAIGN || map.ID != MAP_ROTSTADT || client.holder)
+	if (map && map.ID != MAP_CAMPAIGN || client.holder)
 		output += "<p><a href='byond://?src=\ref[src];observe=1'>Observe</A></p>"
 
 	output += "</div>"
@@ -191,7 +191,7 @@ var/global/redirect_all_players = null
 		new_player_panel_proc()
 
 	if (href_list["observe"])
-		if ((map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT) && !client.holder)
+		if (map.ID == MAP_CAMPAIGN && !client.holder)
 			WWalert(src,"You cannot observe during this round.","Error")
 			return TRUE
 
@@ -439,8 +439,6 @@ var/global/redirect_all_players = null
 		if (factjob)
 			if (map.ID == MAP_CAMPAIGN)
 				LateChoicesCampaign(factjob)
-			else // To be changed according to new non-canon maps or Nomads Persistence
-				LateChoicesRotstadt(factjob) // To be changed according to new non-canon maps or Nomads Persistence
 		else
 			if (config.discordurl)
 				WWalert(src, "This round is part of an event. You need to be part of one of the two factions to participate. Visit the discord for more information: [config.discordurl]")
@@ -494,8 +492,8 @@ var/global/redirect_all_players = null
 		return TRUE
 
 	if (href_list["SelectedJob"])
-		if (map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT)
-			if (!findtext(href_list["SelectedJob"], "Private") && !findtext(href_list["SelectedJob"], "Machinegunner") && !findtext(href_list["SelectedJob"], "Des. Marksman") && !findtext(href_list["SelectedJob"], "RPR Fighter"))
+		if (map.ID == MAP_CAMPAIGN)
+			if (!findtext(href_list["SelectedJob"], "Private") && !findtext(href_list["SelectedJob"], "Machinegunner") && !findtext(href_list["SelectedJob"], "Des. Marksman"))
 				if ((input(src, "This is a specialist role. You should have decided with your faction on which roles you should pick. If you haven't done so, its probably better if you join as a Private instead. Are you sure you want to join in as a [href_list["SelectedJob"]]?") in list("Yes", "No")) == "No")
 					return
 			if(findtext(href_list["SelectedJob"],"BAF"))
@@ -1390,9 +1388,9 @@ var/global/redirect_all_players = null
 						temp_name = "Chinese National Army"
 				else if (map && map.ID == MAP_CAMPAIGN || map.ID == MAP_ROTSTADT)
 					if (temp_name == "Civilian")
-						temp_name = "Red"
+						temp_name = "Blugoslavia"
 					if (temp_name == "Pirates")
-						temp_name = "Blue"
+						temp_name = "Redmenia"
 				else if (map && map.ID == "MAP_HOLDMADRID")
 					if (temp_name == "Civilian")
 						temp_name = "Republican"

--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -959,7 +959,7 @@ var/global/redirect_all_players = null
 	character = job_master.EquipRank(character, rank, TRUE)					//equips the human
 
 	//squads
-	if (ishuman(character) && map.ID != MAP_CAMPAIGN)
+	if (ishuman(character) && map.ID != MAP_CAMPAIGN && map.ID != MAP_ROTSTADT)
 		var/mob/living/human/H = character
 		if (H.original_job_title == "FBI officer" || H.original_job_title == "KGB officer")
 			H.verbs += /mob/living/human/proc/find_hvt

--- a/code/game/objects/map_metadata/rotstadt.dm
+++ b/code/game/objects/map_metadata/rotstadt.dm
@@ -8,7 +8,7 @@
 	victory_time = 36000
 	grace_wall_timer = 9000
 	mission_start_message = "<font size=4><b>15 minutes</b> until the battle begins.</font>"
-	
+
 	roundend_condition_sides = list(
 		list(CIVILIAN) = /area/caribbean/british,
 		list(PIRATES) = /area/caribbean/japanese/land/inside,
@@ -17,7 +17,7 @@
 	faction_organization = list(
 		PIRATES,
 		CIVILIAN)
-		
+
 	age = "2023"
 	ordinal_age = 8
 	faction_distribution_coeffs = list(PIRATES = 0.5, CIVILIAN = 0.5)
@@ -227,7 +227,7 @@ var/no_loop_rot = FALSE
 	last_win_condition = win_condition.hash
 	return TRUE
 
-/*/mob/new_player/proc/LateChoicesRotstadt(factjob)
+/mob/new_player/proc/LateChoicesRotstadt()
 	var/list/available_jobs_per_side = list(
 		CIVILIAN = FALSE,
 		PIRATES = FALSE,
@@ -248,14 +248,11 @@ var/no_loop_rot = FALSE
 
 	dat += "<br>"
 
-	if (factjob == "BAF")
-		dat +="<b><h1><big>Blugoslavian Armed Forces</big></h1></b>"
-	else if (factjob == "RDF")
-		dat +="<b><h1><big>Rotstadt's People's Republic</big></h1></b>"
 	for (var/datum/job/job in job_master.faction_organized_occupations)
 		if (!job.is_event)
 			continue
-		if (factjob == "BAF")
+		dat +="<b><h1><big>Blugoslavian Armed Forces</big></h1></b>"
+		if (istype(job, /datum/job/civilian))
 			if(!findtext(job.title, "BAF"))
 				continue
 			if(findtext(job.title, "BAF Doctor") && MR.squad_jobs_blue["none"]["Doctor"]<= 0)
@@ -278,14 +275,15 @@ var/no_loop_rot = FALSE
 				continue
 			if(findtext(job.title, "BAF Squad [job.squad] Machinegunner") && MR.squad_jobs_blue["Squad [job.squad]"]["Machinegunner"]<= 0)
 				continue
-		else if (factjob == "RDF")
+		dat +="<b><h1><big>Rotstadt's People's Republic</big></h1></b>"
+		if (istype(job, /datum/job/pirates))
 			if (!job.is_rotstadt)
 				continue
 			if(findtext(job.title, "RPR Commander") && MR.squad_jobs_red["none"]["Commander"]<= 0)
 				continue
 			if(findtext(job.title, "RPR Doctor") && MR.squad_jobs_red["none"]["Doctor"]<= 0)
 				continue
-			
+
 		if (job)
 			var/active = processes.job_data.get_active_positions(job)
 			var/extra_span = "<b>"
@@ -326,5 +324,5 @@ var/no_loop_rot = FALSE
 	"}
 
 	spawn (1)
-		src << browse(data, "window=latechoices;size=600x640;can_close=1")*/
+		src << browse(data, "window=latechoices;size=600x640;can_close=1")
 

--- a/code/game/objects/map_metadata/rotstadt.dm
+++ b/code/game/objects/map_metadata/rotstadt.dm
@@ -26,8 +26,9 @@
 	faction2 = CIVILIAN
 	valid_weather_types = list(WEATHER_WET, WEATHER_EXTREME)
 	songs = list(
-		"All is Lost:1" = "sound/music/shellshock.ogg",)
+		"Noisia - Shellshock:1" = "sound/music/shellshock.ogg",)
 	artillery_count = 0
+	no_hardcore = TRUE
 	var/list/squad_jobs_blue = list(
 		"Squad 1" = list("Corpsman" = 2, "Machinegunner" = 1),
 		"Squad 2" = list("Corpsman" = 2, "Machinegunner" = 1),
@@ -46,7 +47,7 @@
 	..()
 	if (istype(J, /datum/job/civilian))
 		if (J.is_event)
-			if (!istype(J, /datum/job/civilian/bluefaction/navy))
+			if(findtext(J.title, "BAF"))
 				. = TRUE
 			else
 				. = FALSE
@@ -226,7 +227,7 @@ var/no_loop_rot = FALSE
 	last_win_condition = win_condition.hash
 	return TRUE
 
-/mob/new_player/proc/LateChoicesRotstadt(factjob)
+/*/mob/new_player/proc/LateChoicesRotstadt(factjob)
 	var/list/available_jobs_per_side = list(
 		CIVILIAN = FALSE,
 		PIRATES = FALSE,
@@ -325,5 +326,5 @@ var/no_loop_rot = FALSE
 	"}
 
 	spawn (1)
-		src << browse(data, "window=latechoices;size=600x640;can_close=1")
+		src << browse(data, "window=latechoices;size=600x640;can_close=1")*/
 

--- a/code/game/objects/map_metadata/rotstadt.dm
+++ b/code/game/objects/map_metadata/rotstadt.dm
@@ -247,11 +247,10 @@ var/no_loop_rot = FALSE
 		dat += "[alive_civilians.len] Blugoslavians "
 
 	dat += "<br>"
-
+	
 	for (var/datum/job/job in job_master.faction_organized_occupations)
 		if (!job.is_event)
 			continue
-		dat +="<b><h1><big>Blugoslavian Armed Forces</big></h1></b>"
 		if (istype(job, /datum/job/civilian))
 			if(!findtext(job.title, "BAF"))
 				continue
@@ -275,7 +274,6 @@ var/no_loop_rot = FALSE
 				continue
 			if(findtext(job.title, "BAF Squad [job.squad] Machinegunner") && MR.squad_jobs_blue["Squad [job.squad]"]["Machinegunner"]<= 0)
 				continue
-		dat +="<b><h1><big>Rotstadt's People's Republic</big></h1></b>"
 		if (istype(job, /datum/job/pirates))
 			if (!job.is_rotstadt)
 				continue

--- a/code/modules/1713/jobs/campaign_jobs.dm
+++ b/code/modules/1713/jobs/campaign_jobs.dm
@@ -8,6 +8,7 @@
 	additional_languages = list("Blugoslavian" = 15)
 	min_positions = 999
 	max_positions = 999
+	selection_color = "#CC0000"
 
 /datum/job/pirates/redfaction/civilian
 	title = "Redmenian Civilian"
@@ -366,6 +367,7 @@
 	min_positions = 999
 	max_positions = 999
 	additional_languages = list("Redmenian" = 15)
+	selection_color = "#102f44"
 
 /datum/job/civilian/bluefaction/civilian
 	title = "Blugoslavian Civilian"

--- a/code/processes/mapswap.dm
+++ b/code/processes/mapswap.dm
@@ -246,7 +246,9 @@
 			if ("Fiction")
 				maps = list(
 					MAP_TANTIVEIV = 0,
-					MAP_WHITERUN = 10,)
+					MAP_WHITERUN = 10,
+					//MAP_ROTSTADT = 12,
+				)
 			if ("HRP TDM (Gulag, Occupation, AOTD, etc)")
 				maps = list(
 					MAP_HUNT = 6,

--- a/code/processes/mapswap.dm
+++ b/code/processes/mapswap.dm
@@ -247,7 +247,7 @@
 				maps = list(
 					MAP_TANTIVEIV = 0,
 					MAP_WHITERUN = 10,
-					//MAP_ROTSTADT = 12,
+					MAP_ROTSTADT = 12,
 				)
 			if ("HRP TDM (Gulag, Occupation, AOTD, etc)")
 				maps = list(


### PR DESCRIPTION
In order to appease the wait for new Campaign rounds, players will be able to choose Rotstadt from the "Fiction" category, without the need to be in either factions. 

As campaign uses a custom job handling system, job handling still needs some adjustments