### PR TITLE
Spawn on SL fix attempt

### DIFF
--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -1029,7 +1029,8 @@ var/global/redirect_all_players = null
 						H << "<big><b>Your squad leader is [map.faction2_squad_leaders[H.squad]].</b></big>"
 				else if (map.faction2_squad_leaders[H.squad])
 					H << "<big><b>Your squad leader is [map.faction2_squad_leaders[H.squad]].</b></big>"
-
+	if(!map.fob_spawns)
+		job_master.relocate(character)
 	if (character.buckled && istype(character.buckled, /obj/structure/bed/chair/wheelchair))
 		character.buckled.loc = character.loc
 		character.buckled.set_dir(character.dir)


### PR DESCRIPTION
Attempts to fix players not being able to spawn on their SL on non-FOB spawn maps (that is all of them except Falcon, heh).