### PR TITLE
Re-implements screwdrivers

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -890,7 +890,7 @@ var/global/list/common_tools = list(
 	return FALSE
 
 /proc/isscrewdriver(O)
-	if (istype(O, /obj/item/weapon/hammer))
+	if (istype(O, /obj/item/weapon/hammer) || istype(O, /obj/item/weapon/screwdriver)) // TO DO: separate hammers and screwdrivers in the whole codebase
 		return TRUE
 	return FALSE
 /*

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -135,6 +135,25 @@
 /*
  * Screwdriver
  */
+/obj/item/weapon/screwdriver
+	name = "screwdriver"
+	desc = "Your archetypal flathead screwdriver, with a nice, heavy polymer handle."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "screwdriver"
+	item_state = "screwdriver"
+	flags = CONDUCT
+	slot_flags = SLOT_BELT | SLOT_POCKET | SLOT_EARS
+	force = WEAPON_FORCE_WEAK
+	w_class = ITEM_SIZE_TINY
+	throwforce = WEAPON_FORCE_WEAK
+	throw_speed = 3
+	throw_range = 5
+	attack_verb = list("stabbed")
+	flammable = FALSE
+
+/*
+ * Hammers
+ */
 /obj/item/weapon/hammer
 	name = "hammer"
 	desc = "Hit stuff apart with this."


### PR DESCRIPTION
Re-implements screwdrivers (don't know why they were taken out of the codebase in the first place)

To-do:
- Separate screwdrivers and hammers function-wise
- Make screwdrivers craftable