### PR TITLE
Ambience recoding (to be reverted if causing issues)

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -136,7 +136,7 @@
 		return
 
 	var/lastsound = CL.ambience_playing
-	var/sound = (map && map.ambience.len) ? pick(map.ambience) : null
+	var/sound = src.ambience && src.ambience.len ? pick(src.ambience) : (map && map.ambience.len) ? pick(map.ambience) : null
 	var/override_volume = 0
 
 	if (sound && (!CL.ambience_playing || override || sound != lastsound))


### PR DESCRIPTION
- Makes the code check for the area ambience var before going for the ambience defined in metadata file (this will need readjusting on areas/maps that have the wrong ambience var selected)