### PR TITLE
New chat overlay font style

### DIFF
--- a/code/game/mob/living/chat_overlay.dm
+++ b/code/game/mob/living/chat_overlay.dm
@@ -54,7 +54,7 @@
 		message.maptext_width = TILE_SIZE*7
 		message.maptext_x = (maptext_width * -0.5)-TILE_SIZE*2.5
 		message.maptext_y = TILE_SIZE*1
-		message.maptext = "<center>[desired_text]</center>"
+		message.maptext = "<center><span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black;\">[desired_text]</span></center>"
 		if(target)
 			target.images += message
 			target.overlay_cleaner(message)


### PR DESCRIPTION
Adjusts the chat overlay font to look like on other servers.

<img width="345" alt="image" src="https://github.com/Civ13/Civ13/assets/76013553/6d2984f5-af75-46ec-ad6b-5d4bca554d7c">
