### PR TITLE
fix perma speed debuff as aftermath of being sick

### DIFF
--- a/code/game/mob/living/carbon/human/human_life.dm
+++ b/code/game/mob/living/carbon/human/human_life.dm
@@ -986,11 +986,15 @@
 		if (resting)
 			dizziness = max(0, dizziness - 15)
 			jitteriness = max(0, jitteriness - 15)
-			adjustHalLoss(-3)
+			//adjustHalLoss(-3)
+			if (halloss >= 3)
+				halloss -= 3
 		else
 			dizziness = max(0, dizziness - 3)
 			jitteriness = max(0, jitteriness - 3)
-			adjustHalLoss(-1)
+			//adjustHalLoss(-1)
+			if (halloss >= 1)
+				halloss -= 1
 
 		//Other
 		handle_statuses()


### PR DESCRIPTION
a quick and dirty fix, makes halloss remove properly as it did before the adjusthalloss function got changed into whatever it is now