### PR TITLE
Fixes things to do with plurality and examine-based turfs.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -165,7 +165,9 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 		var/obj/item/stack/S = W
 		merge(S)
 		S.update_icon()
+		S.update_strings()
 		src.update_icon()
+		src.update_strings()
 		spawn(0) //give the stacks a chance to delete themselves if necessary
 		if (S && usr.using_object == S)
 			S.interact(usr)
@@ -195,14 +197,20 @@ obj/item/stack/Crossed(var/obj/item/stack/S)
 			return
 		else
 			change_stack(user, stackmaterial)
+			update_strings(stackmaterial)
 			to_chat(user, "<span class='notice'>You take [stackmaterial] out of the stack.</span>")
+
+/obj/item/stack/proc/update_strings()
+    return
 
 /obj/item/stack/proc/change_stack(mob/user, amount)
 	var/obj/item/stack/F = split(amount)
 	if (F)
 		user.put_in_hands(F)
 		F.update_icon()
+		F.update_strings()
 		src.update_icon()
+		src.update_strings()
 		add_fingerprint(user)
 		F.add_fingerprint(user)
 		spawn(0)

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -153,7 +153,7 @@
 	icon_state = "ironsand[rand(1,15)]"
 
 /turf/floor/grass/jungle
-	name = "jungle grass"
+	name = "jungle grass patch"
 	overlay_priority = 0
 	is_diggable = TRUE
 	may_become_muddy = TRUE

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -38,7 +38,7 @@ var/list/flooring_types
 	var/can_paint
 
 /decl/flooring/grass
-	name = "grass"
+	name = "grass patch"
 	desc = "Simple grass."
 	icon = 'icons/turf/floors.dmi'
 	icon_base = "grass"
@@ -47,7 +47,7 @@ var/list/flooring_types
 //	flags = TURF_HAS_EDGES
 
 /decl/flooring/dirt
-	name = "dirt"
+	name = "dirt patch"
 	desc = "Simple dirt."
 	icon = 'icons/turf/floors.dmi'
 	icon_base = "dirt"
@@ -65,7 +65,7 @@ var/list/flooring_types
 //	flags = TURF_HAS_EDGES
 
 /decl/flooring/dust
-	name = "dry dirt"
+	name = "dry dirt patch"
 	desc = "Simple dry dirt."
 	icon = 'icons/turf/floors.dmi'
 	icon_base = "dust"
@@ -74,7 +74,7 @@ var/list/flooring_types
 //	flags = TURF_HAS_EDGES
 
 /decl/flooring/flooded
-	name = "flooded plains dirt"
+	name = "flooded plains dirt patch"
 	desc = "The dirt left after a flood recesses."
 	icon = 'icons/turf/floors.dmi'
 	icon_base = "flood_dirt"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -324,7 +324,7 @@
 	initial_flooring = null
 
 /turf/floor/dirt/burned
-	name = "burned ground"
+	name = "burnt ground"
 	icon_state = "burned_dirt"
 	uses_winter_overlay = TRUE
 	may_become_muddy = TRUE

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -37,7 +37,7 @@
 /obj/item/stack/material/get_material()
 	return material
 
-/obj/item/stack/material/proc/update_strings()
+/obj/item/stack/material/update_strings()
 	// Update from material datum.
 	if (material)
 		singular_name = material.sheet_singular_name


### PR DESCRIPTION
This properly updates plurality by pushing back the procedure using basic object oriented programming, then calling the stack/proc to properly check and invoke for the changes.

Make grass into a grass patch.

Dirt into dirt patch.

burned ground --> burnt ground.


This is done because of the examine proc for ALL atoms which does

" That's a burned ground. " --> " That's a burnt ground."
" That's a grass " --> " That's a grass patch. "

Temporary fixes for long-term solutions (no coders)