### PR TITLE
Dev QoL: Adds a verb in the Debug panel to view runtimes

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -146,6 +146,7 @@ var/list/admin_verbs_server = list(
 var/list/admin_verbs_debug = list(
 	/client/proc/cmd_admin_list_open_jobs,
 	/client/proc/Debug2,
+	/datum/admins/proc/view_runtimes,
 	/client/proc/toggle_gc_helper,
 	/client/proc/run_gc_helper,
 	/client/proc/check_null_atoms,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -44,3 +44,13 @@
 	M.ckey = ckey
 	if (isghost(adminmob))
 		qdel(adminmob)
+
+/datum/admins/proc/view_runtimes()
+	set category = "Debug"
+	set name = "View Runtimes"
+	set desc = "Open the Runtime Viewer"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	error_cache.showTo(usr)


### PR DESCRIPTION
Instead of waiting for a runtime to occur, you can now access the panel using "View Runtimes" in the Debug panel.