### PR TITLE
Fixes bug report "message error" and misc.

### DIFF
--- a/code/game/mob/living/carbon/human/human.dm
+++ b/code/game/mob/living/carbon/human/human.dm
@@ -1198,7 +1198,7 @@ var/list/coefflist = list()
 				animate(user.client, pixel_x = world.icon_size*_x, pixel_y = world.icon_size*_y, time = 3, easing = SINE_EASING)
 				user.client.pixel_x = world.icon_size*_x
 				user.client.pixel_y = world.icon_size*_y
-			user.visible_message("[user] looks into the distance.")
+			user.visible_message("[user] looks into the distance.", "You look into the distance.")
 			handle_ui_visibility()
 			user.dizzycheck = TRUE
 	else//Resets

--- a/code/game/mob/mob_movement.dm
+++ b/code/game/mob/mob_movement.dm
@@ -759,7 +759,7 @@
 					else
 						for (var/mob/living/L in mob.loc)
 							if (L.lying && L != H)
-								H.visible_message("<span class = 'warning'>[H] steps over [L].</span>")
+								H.visible_message("<span class = 'warning'>[H] steps over \the [L].</span>", "<span class = 'warning'>You step over \the [L].</span>", "You hear a step.")
 
 			#undef STOMP_TIME
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -504,7 +504,14 @@ var/list/global/slot_flags_enumeration = list(
 
 	if (istype(H))
 		if (prob(80) && H != user)
-			visible_message(SPAN_NOTICE("[M] tried to stab [user] in the eyes with \the [src] but missed!"))
+			var/list/see = get_mobs_or_objects_in_view(7,src) | viewers(7,src) // The following to line 529 is a gutted mob.visible_message(), consider updating the proc to have a list of ignored mobs as an argument.
+
+			for (var/I in see)
+				if (ismob(I))
+					if(I != M && I != user) // If we see M or user in the for loop, skip them.
+						var/mob/X = I
+						if (X.see_invisible >= invisibility) // Cannot view the invisible
+							X.show_message("[M] tried to stab [user] in the eyes with \the [src] but missed!", TRUE)
 			to_chat(M, SPAN_WARNING("[user] tried to stab you in the eyes with \the [src] but missed!"))
 			to_chat(user, SPAN_WARNING("You tried to stab [M] in the eyes with \the [src] but missed!"))
 			return
@@ -512,25 +519,31 @@ var/list/global/slot_flags_enumeration = list(
 		var/obj/item/organ/eyes/eyes = H.internal_organs_by_name["eyes"]
 
 		if (H != user)	
-			visible_message(SPAN_DANGER("[M] has been stabbed in the eye with \the [src] by [user]."))
-			to_chat(M, SPAN_DANGER("[user] stabs you in the eye with \the [src]!"))
-			to_chat(user, SPAN_DANGER("You stab [M] in the eye with \the [src]!"))
-		else
-			visible_message(SPAN_DANGER("[user] has stabbed themselves with \the [src]!"))
-			user.visible_message(SPAN_DANGER("You stab yourself in the eyes with \the [src]"))
+			var/list/see = get_mobs_or_objects_in_view(7,src) | viewers(7,src) // The following to line 529 is a gutted mob.visible_message(), consider updating the proc to have a list of ignored mobs as an argument.
 
+			for (var/I in see)
+				if (ismob(I))
+					if(I != M && I != user) // If we see M or user in the for loop, skip them.
+						var/mob/Xx = I
+						if (Xx.see_invisible >= invisibility) // Cannot view the invisible
+							Xx.show_message("[M] has been stabbed in the eyes by [user] with \the [src]!", TRUE)
+			to_chat(M, SPAN_DANGER("[user] stabs you in the eyes with \the [src]!"))
+			to_chat(user, SPAN_DANGER("You stab [M] in the eyes with \the [src]!"))
+		else
+			user.visible_message("<span class = 'danger'>[user] has stabbed \himself in the eye with \the [src]!</span>", "<span class = 'danger'>You stab yourself in the eyes with \the [src]!</span>")
 		eyes.damage += rand(3,4)
 		if (eyes.damage >= eyes.min_bruised_damage)
 			if (prob(50))
 				if (M.stat != 2)
-					to_chat(M, SPAN_WARNING("You drop what you're holding and clutch at your eyes!"))
+					M.visible_message("[M] drops what they're holding and clutches at their eyes!", "You drop what you're holding and clutch at your eyes!")
 					M.drop_item()
 				M.eye_blurry += 10
 				M.Paralyse(1)
 				M.Weaken(3)
 			if (eyes.damage >= eyes.min_broken_damage)
 				if (M.stat != 2)
-					M << "<span class='warning'>You go blind!</span>"
+					to_chat(M, SPAN_WARNING("You go blind!"))
+					M.dizziness += 5
 		var/obj/item/organ/external/affecting = H.get_organ("head")
 		if (affecting.take_damage(7))
 			M:UpdateDamageIcon()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -519,7 +519,7 @@ var/list/global/slot_flags_enumeration = list(
 		var/obj/item/organ/eyes/eyes = H.internal_organs_by_name["eyes"]
 
 		if (H != user)	
-			var/list/see = get_mobs_or_objects_in_view(7,src) | viewers(7,src) // The following to line 529 is a gutted mob.visible_message(), consider updating the proc to have a list of ignored mobs as an argument.
+			var/list/see = get_mobs_or_objects_in_view(7,src) | viewers(7,src) // The following to line 531 is a gutted mob.visible_message(), consider updating the proc to have a list of ignored mobs as an argument.
 
 			for (var/I in see)
 				if (ismob(I))

--- a/code/modules/1713/barriers/sandbag.dm
+++ b/code/modules/1713/barriers/sandbag.dm
@@ -53,6 +53,11 @@
 					for (var/v in TRUE to (1 + pick(I.progress-1, I.progress)))
 						new /obj/item/weapon/barrier(turf)
 				qdel(src)
+		else if (user.a_intent == I_GRAB)
+			var/mob/living/H = user
+			if (istype(H) && can_climb(H))
+				user.dir = get_dir(user, src)
+				src.do_climb(user)
 
 /obj/structure/window/barrier/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION
* Proper client perspectives for doing certain things.
* Bug in discord bug-reports labelled "message error" fixed.

Someone should really modernize our mob.visible_message(), to include ignored mobs.

* And you can now grab intent on barriers [sandbags, dirt barricades, etc.] to climb over them as well.