### PR TITLE
Mining checks + bug-fix.

### DIFF
--- a/code/game/turfs/floor_attackby.dm
+++ b/code/game/turfs/floor_attackby.dm
@@ -64,7 +64,7 @@
 				else
 					ChangeTurf(/turf/floor/dirt)*/
 
-var/in_progress = null
+var/in_progress = null // Define the variable out of any scopes and the attackby() procedures.
 /turf/floor/attackby(obj/item/C as obj, mob/user as mob)
 
 	if (!C || !user)

--- a/code/game/turfs/floor_attackby.dm
+++ b/code/game/turfs/floor_attackby.dm
@@ -64,6 +64,7 @@
 				else
 					ChangeTurf(/turf/floor/dirt)*/
 
+var/in_progress = null
 /turf/floor/attackby(obj/item/C as obj, mob/user as mob)
 
 	if (!C || !user)
@@ -276,16 +277,25 @@
 		var/turf/T = get_turf(src)
 		var/mob/living/human/H = user
 		if (istype(T, /turf/floor/dirt/underground) && istype(H))
-			visible_message("<span class = 'notice'>[user] starts to break the rock with the [C.name].</span>", "<span class = 'notice'>You start to break the rock with the [C.name].</span>")
+			if (in_progress)
+				to_chat(user, SPAN_WARNING("You are already breaking the rock with \the [C.name]."))
+				return
+
+			// Set in_progress to TRUE to indicate the process has started
+			in_progress = TRUE
+			visible_message("<span class = 'notice'>[user] starts to break the rock with \the [C.name].</span>", "<span class = 'notice'>You start to break the rock with \the [C.name].</span>")
 			playsound(src,'sound/effects/pickaxe.ogg',100,1)
 			if (do_after(user, (320/(H.getStatCoeff("strength"))/SH.usespeed)))
 				collapse_check()
 				if (istype(src, /turf/floor/dirt/underground/empty))
 					var/turf/floor/dirt/underground/empty/TT = src
 					TT.mining_clear_debris()
+					in_progress = FALSE // Reset the variable to FALSE after the breaking process is complete
 					return
 				else if (!istype(src, /turf/floor/dirt/underground/empty))
 					mining_proc(H)
+			else
+				in_progress = FALSE // In case we abort mid-way.
 	else if (istype(C, /obj/item/weapon/reagent_containers/glass/extraction_kit))
 		var/mob/living/human/H = user
 		var/obj/item/weapon/reagent_containers/glass/extraction_kit/ET = C
@@ -567,12 +577,19 @@
 	if (istype(C, /obj/item/weapon/material/pickaxe))
 		var/mob/living/human/H = user
 		if (istype(H))
-			visible_message("<span class = 'notice'>[user] starts to break the rocky floor with the [C.name].</span>", "<span class = 'notice'>You start to break the rocky floor with the [C.name].</span>")
+			if(in_progress)
+				to_chat(user, SPAN_WARNING("You are already trying to break the rocky floor with \the [C.name]."))
+				return
+			// Set in_progress to TRUE to indicate the process has started.
+			in_progress = TRUE
+			visible_message("<span class = 'notice'>[user] starts to break the rocky floor with \the [C.name].</span>", "<span class = 'notice'>You start to break the rocky floor with \the [C.name].</span>")
 			playsound(src,'sound/effects/pickaxe.ogg',100,1)
 			var/timera = 320/(H.getStatCoeff("strength"))
 			if (do_after(user, timera))
 				mining_proc(H)
+				in_progress = FALSE // Reset the variable to FALSE after finishing the breaking process.
 		else
+			in_progress = FALSE // In case we abort mid-way.
 			return ..(C, user)
 	else if (istype(C, /obj/item/weapon/reagent_containers/glass/extraction_kit))
 		var/mob/living/human/H = user
@@ -835,6 +852,11 @@
 		var/turf/floor/dirt/underground/U = src
 		var/mob/living/human/H = user
 		if (H.ant && H.a_intent == I_GRAB)
+			if(in_progress)
+				to_chat(user, SPAN_WARNING("You are already trying to break the rocky floor."))
+				return
+			// Set in_progress to TRUE to indicate the process has started.
+			in_progress = TRUE
 			visible_message("<span class = 'notice'>[user] starts to break the rock with their hands...</span>", "<span class = 'notice'>You start to break the rock with the your hands...</span>")
 			playsound(src,'sound/effects/pickaxe.ogg',100,1)
 			if (do_after(user, (320/(H.getStatCoeff("strength"))/1.5)))
@@ -842,10 +864,13 @@
 				if (istype(src, /turf/floor/dirt/underground/empty))
 					var/turf/floor/dirt/underground/empty/T = src
 					T.mining_clear_debris()
+					in_progress = FALSE // Reset the in_progress variable after the process has finished.
 					return TRUE
 				else if (!istype(src, /turf/floor/dirt/underground/empty))
 					mining_proc(H)
 				return TRUE
+			else
+				in_progress = FALSE // In case we abort mid-way.
 		else
 			..()
 	else

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -135,6 +135,11 @@ var/list/interior_areas = list(/area/caribbean/houses,
 		var/turf/floor/dirt/underground/U = src
 		var/mob/living/human/H = user
 		if (H.ant)
+			if(in_progress)
+				to_chat(user, SPAN_WARNING("You are already trying to break the rocky floor."))
+				return
+			// Set in_progress to TRUE to indicate the process has started.
+			in_progress = TRUE
 			visible_message("<span class = 'notice'>[user] starts to break the rock with their hands...</span>", "<span class = 'notice'>You start to break the rock with the your hands...</span>")
 			playsound(src,'sound/effects/pickaxe.ogg',100,1)
 			if (do_after(user, (160/(H.getStatCoeff("strength"))/1.5)))
@@ -142,10 +147,13 @@ var/list/interior_areas = list(/area/caribbean/houses,
 				if (istype(src, /turf/floor/dirt/underground/empty))
 					var/turf/floor/dirt/underground/empty/T = src
 					T.mining_clear_debris()
+					in_progress = FALSE // Reset the variable after the process has finished.
 					return
 				else if (!istype(src, /turf/floor/dirt/underground/empty))
 					mining_proc(H)
 				return TRUE
+			else
+				in_progress = FALSE // In case we abort mid-way.
 	if (world.time >= user.next_push)
 		if (ismob(user.pulling))
 			var/mob/M = user.pulling

--- a/code/modules/1713/weapons/guns/bow.dm
+++ b/code/modules/1713/weapons/guns/bow.dm
@@ -261,7 +261,7 @@ obj/item/weapon/gun/projectile/bow/Fire()
 		user.remove_from_mob(C)
 		C.loc = src
 		loaded.Insert(1, C) //add to the head of the list
-		user.visible_message("[user] inserts \a [C] into the [src].", "<span class='notice'>You insert \a [C] into the [src].</span>")
+		user.visible_message("[user] inserts \a [C] into \the [src].", "<span class='notice'>You insert \a [C] into \the [src].</span>")
 		icon_state = "[icotype]1"
 		load_arrow_overlay(C)
 		if (bulletinsert_sound) playsound(loc, bulletinsert_sound, 75, TRUE)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -298,7 +298,7 @@
 		user.remove_from_mob(C)
 		C.loc = src
 		loaded.Insert(1, C) //add to the head of the list
-		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
+		user.visible_message("[user] inserts \a [C] into \the [src].", "<span class='notice'>You insert \a [C] into \the [src].</span>")
 		if (bulletinsert_sound) playsound(loc, bulletinsert_sound, 75, TRUE)
 
 	update_icon()


### PR DESCRIPTION
6:11am coding hits different.
_you know what you did nomads guy... don't doubt coderman_

* Fixes the bug to do with loading "'[x] loads the steel bolt into the the crossbow".

* No one can spam the mining sound + visible_message anymore unless they purposefully move.

We need loops for all of these mining sounds, they should be in their own something, I don't want them all to be in a proc to reduce proc overhead but still.