### PR TITLE
Pillar buff

### DIFF
--- a/code/game/objects/roof_stuff.dm
+++ b/code/game/objects/roof_stuff.dm
@@ -250,11 +250,11 @@
 		if (istype(src, /obj/roof/canopy))
 			for (var/obj/structure/tent/TT in loc)
 				supportfound = TRUE
-		for (var/obj/structure/roof_support/RS in range(2, src))
+		for (var/obj/structure/roof_support/RS in range(4, src))
 			supportfound = TRUE
 		for (var/obj/structure/mine_support/stone/SS in range(2, src))
 			supportfound = TRUE
-		for (var/turf/wall/W in range(1, src))
+		for (var/turf/wall/W in range(4, src))
 			supportfound = TRUE
 		for (var/obj/structure/simple_door/SD in loc)
 			supportfound = TRUE
@@ -372,7 +372,7 @@
 		to_chat(user, "That area is already roofed!")
 		return
 	var/confirm = FALSE
-	for(var/obj/structure/roof_support/RS in range(2, get_step(user, user.dir)))
+	for(var/obj/structure/roof_support/RS in range(4, get_step(user, user.dir)))
 		confirm = TRUE
 	for(var/obj/structure/mine_support/stone/SS in range(2, get_step(user, user.dir)))
 		confirm = TRUE


### PR DESCRIPTION
Increases pillar range by two.
Makes walls function same as pillars in terms of roof supporting so small rooms wont need pillars and eliminates the need of the good old in-wall pillaring.
This should overall decrease the bad looking pillar spam requirement and eliminate the need of in-wall pillaring, and makes smaller rooms not require a pillar.

Mine supports remain the same.