### PR TITLE
Vaulting Runtime Fix -and- Table Vaulting Fix.

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -147,7 +147,6 @@
 			return objects_blocked_2
 	return objects_blocked
 
-
 /obj/structure/proc/neighbor_turf_passable()
 	var/turf/T = get_step(get_turf(src), src.dir)
 	if (!T || !istype(T))
@@ -155,16 +154,16 @@
 	if (T.density == TRUE)
 		return FALSE
 	for (var/obj/O in T.contents)  // Iterate over all objects in the turf
-		var/obj/structure/S = O
-		if (S.climbable) continue // We don't include this in the is-type checks because open crates aren't climbable if open, so that could lead to some technicalities
-		if (istype(O, /obj/structure/closet/crate))
-			continue // Allow us to climb onto crates
-		if (istype(O, /obj/structure/table))
-			continue // Allow us to climb onto other tables (UNLESS they face our way (handled in obj/str/table/do_climb()))
-		if (O.density == TRUE) 
-			return FALSE
+		if (istype(O, /obj/structure)) // Type-cast to the superclass which has `climbable` defined
+			var/obj/structure/S = O
+			if(S.climbable) continue // We don't include this in the is-type checks because open crates aren't climbable if open, so that could lead to some technicalities
+			if (istype(O, /obj/structure/closet/crate))
+				continue // Allow us to climb onto crates
+			if (istype(O, /obj/structure/table))
+				continue // Allow us to climb onto other tables (UNLESS they face our way (handled in obj/str/table/do_climb()))
+			if (O.density == TRUE) 
+				return FALSE
 	return TRUE
-
 
 /obj/structure/proc/do_climb(var/mob/living/user)
 	if (!can_climb(user))


### PR DESCRIPTION
 I fixed the vaulting runtime by type-casting to a superclass and then assigning the variable `S` to it, therefore we can check all structures that have `climbable` in the target-turf and continue the for loop as a result.
 
![ffcfd7be1610372aba0f41efd1254827](https://github.com/Civ13/Civ13/assets/131271192/3a54b7e6-27f2-4fcb-af7c-99b51d71a5b3)

 I also fixed a previous bug that didn't allow you to vault over a flipped table onto another table that was facing a completely different direction.

![5bf93512c25566b8fa4f81a135b5d363](https://github.com/Civ13/Civ13/assets/131271192/144703c5-e9f1-4b40-966c-3b70a0811afe)


 Runtime for recording sake.
```Runtime in code/game/objects/structures.dm,159: undefined variable /obj/covers/road/var/climbable
   proc name: neighbor turf passable (/obj/structure/proc/neighbor_turf_passable)
   usr: Annabelle Blanc (the dirt patch) (5,180,2) (/turf/floor/dirt) (captainastra)
   usr.loc: The dirt patch (Forest) (5,180,2) (/area/caribbean/nomads/forest)
   src: the jersey barrier (/obj/structure/window/barrier/jersey)
   src.loc: the dirt patch (6,180,2) (/turf/floor/dirt)
   call stack:
   the jersey barrier (/obj/structure/window/barrier/jersey): neighbor turf passable()
   the jersey barrier (/obj/structure/window/barrier/jersey): do climb(Annabelle Blanc (/mob/living/human))
   the jersey barrier (/obj/structure/window/barrier/jersey): MouseDrop T(Annabelle Blanc (/mob/living/human), Annabelle Blanc (/mob/living/human))
   Annabelle Blanc (/mob/living/human): MouseDrop(the jersey barrier (/obj/structure/window/barrier/jersey), the dirt patch (5,180,2) (/turf/floor/dirt), the dirt patch (6,180,2) (/turf/floor/dirt), "mapwindow.map", "mapwindow.map", "icon-x=8;icon-y=19;left=1;butt...")``````
   
