### PR TITLE
Aiming text re-worded.

### DIFF
--- a/code/modules/1713/apparel_modern.dm
+++ b/code/modules/1713/apparel_modern.dm
@@ -6,7 +6,7 @@
    * - 2 Us Army
    * - 2a Us Army Armor
    * - 2a1 PASGT Armor
-   * - 2a2 US Lightwieght Helmets
+   * - 2a2 US Lightweight Helmets
    * - 2b US Army Clothing
    * - 2c Russian Army Clothing
    /////////////////////////////////////
@@ -507,7 +507,7 @@
 	item_state = "n34bmm"
 	worn_state = "n34bmm"
 
-		/* US Lightwieght Helmets*/
+		/* US Lightweight Helmets*/
 
 /obj/item/clothing/head/helmet/modern/lwh
 	name = "LWH helmet"

--- a/code/modules/projectiles/_ammo_casing.dm
+++ b/code/modules/projectiles/_ammo_casing.dm
@@ -1070,6 +1070,7 @@
 	projectile_type = /obj/item/projectile/bullet/rifle/a556x45
 	caliber = "a556x45"
 	value = 2
+
 /obj/item/ammo_casing/a762x51
 	name = "7.62x51mm NATO cartridge"
 	desc = "A brass casing."

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -153,8 +153,10 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 			to_chat(target, SPAN_DANGER("You now have \a [thing] pointed at you. <big>No sudden moves!</big>"))
 		else if (istype(thing, /obj/item/weapon/gun/projectile/pistol)) // Pistols are usually upper-cased, so therefore classed as proper-nouns, and so we have to specify.
 			to_chat(target, SPAN_DANGER("You now have a pistol pointed at you. <big>No sudden moves!</big>"))
+		//else if (istype(thing, /obj/item/weapon/gun/projectile/submachinegun)) // This is not really correct; calling it a submachine gun (SMG) since, by definition, an SMG fires a pistol-caliber cartridge. And we have ak7
+			//to_chat(target, SPAN_DANGER("You now have a submachinegun pointed at you. <big>No sudden moves!</big>"))
 		else
-			to_chat(target, SPAN_DANGER("You now have a gun pointed at you. <big>No sudden moves!</big>"))
+			to_chat(target, SPAN_DANGER("You now have a weapon pointed at you. <big>No sudden moves!</big>"))
 		aiming_with = thing
 		aiming_at = target
 		if (istype(aiming_with, /obj/item/weapon/gun))


### PR DESCRIPTION
I re-worded the else statement to say that you now have a 'weapon' pointed at you instead of a 'gun' since there are slings and other things that aren't per-say 'guns'.

* Comment grammar fixed. Lightwieght --> Lightweight

* Added a space between an ammo_casing define.

* Commented out code getting ready to re-path the guns to be proper defines.

* Corrected the else statement in targeting_overlay.dm to meet "weapon" instead of "gun" 