### PR TITLE
Production Dehydrator Update

### DIFF
--- a/code/modules/1713/production.dm
+++ b/code/modules/1713/production.dm
@@ -687,7 +687,7 @@
 		if (0.6 to 0.85) return "three quarters dried"
 		if (1 to INFINITY)
 			if (!findtext(normal_item_name(I),"dried")) // Look at normal_item_name()
-				if (!findtext(normal_item_name(I),"dry")) //two if for optimization purpose (this breaks because the problem seems to be that it doesnt find dried so it moves on to dry it doesn't find that and it returns dried. Fix this.)
+				if (!findtext(normal_item_name(I),"dry")) //two if for optimization purpose (This breaks because the name "dried" is in the final product, and so it bugs out and adds an extra space before the dry_as_text descriptor.)
 					return "dried"
 			else
 				return ""

--- a/code/modules/1713/production.dm
+++ b/code/modules/1713/production.dm
@@ -686,8 +686,8 @@
 		if (0.4 to 0.6) return "half dried"
 		if (0.6 to 0.85) return "three quarters dried"
 		if (1 to INFINITY)
-			if (!findtext(normal_item_name(I),"dried"))
-				if (!findtext(normal_item_name(I),"dry")) //two if for optimization purpose
+			if (!findtext(normal_item_name(I),"dried")) // Look at normal_item_name()
+				if (!findtext(normal_item_name(I),"dry")) //two if for optimization purpose (this breaks because the problem seems to be that it doesnt find dried so it moves on to dry it doesn't find that and it returns dried. Fix this.)
 					return "dried"
 			else
 				return ""
@@ -701,7 +701,7 @@
 	if (storage.contents.len>0)
 		for(var/obj/item/I in storage.contents)
 			dryed_now += "[additional_info ? "[dry_as_text(I)]" : ""] [normal_item_name(I)]"
-		to_chat(user, SPAN_NOTICE("There is \a [english_list(dryed_now, and_text = " and a ")]."))
+		to_chat(user, SPAN_NOTICE("There hangs \a [esnglish_list(dryed_now, and_text = " and a ")].")) // \a because we need "there hangs an almost dried..."
 
 /obj/structure/dehydrator/proc/normal_item_name(var/obj/item/I)
 	return copytext(I.name, 1, findtext(I.name, "ON_DEHYDRATOR"))

--- a/code/modules/1713/production.dm
+++ b/code/modules/1713/production.dm
@@ -561,7 +561,7 @@
 // Alghorithm will try to rotate item if not empty space are found. For example 1x3 item (dry_size=9) not found a place, but dehydrator have free row, and item will placed 3x1 (as dry_size=3).
 // ====================================================================
 // Items must have an icon in 'icons/obj/food/dryer.dmi' named the same as icon_state of drying product
-// Items must have an icon in 'icons/obj/food/dryer.dmi' named as icon_state of drying product with additional "R" at end. For exapmle "rawcutletR"
+// Items must have an icon in 'icons/obj/food/dryer.dmi' named as icon_state of drying product with additional "R" at end. For example "rawcutletR"
 // Product (dried and ready) items must have an icons with normal and rotated states in 'icons/obj/food/dryer.dmi'
 // Items with size of 4 rows (dry_size=13..15) or equal side sizes (1x1, 2x2, 3x3) may not have an icon with additional "R".
 // For optimization try don't use dry_size 4, 8 and 12. Use instead 13, 14 and 15. Also, this will save you from having to draw two icons: straight and rotated; it will be enough to draw only one straight icon.
@@ -681,17 +681,18 @@
 
 /obj/structure/dehydrator/proc/dry_as_text(var/obj/item/I)
 	switch(get_dry_timer(I)/TIME_TO_DRY)
-		if (0 to 0.15) return "not dried"
-		if (0.15 to 0.4) return "a quarter dry"
+		if (0 to 0.15) return "drying"
+		if (0.15 to 0.4) return "quarter dried"
 		if (0.4 to 0.6) return "half dried"
-		if (0.6 to 0.85) return "three quarters dry"
+		if (0.6 to 0.85) return "three quarters dried"
 		if (1 to INFINITY)
 			if (!findtext(normal_item_name(I),"dried"))
 				if (!findtext(normal_item_name(I),"dry")) //two if for optimization purpose
 					return "dried"
 			else
 				return ""
-		else return "almost dry"
+		else
+			return "almost dried"
 
 /obj/structure/dehydrator/examine(mob/user, distance)
 	..(user, distance)
@@ -699,8 +700,8 @@
 	var/additional_info = in_range(user, src) || isghost(user)
 	if (storage.contents.len>0)
 		for(var/obj/item/I in storage.contents)
-			dryed_now += "[additional_info ? "[dry_as_text(I)] " : ""][normal_item_name(I)]"
-		user << "<span class='notice'>There [storage.contents.len == 1 ? "is dries" : "are drying"] [english_list(dryed_now, "")].</span>"
+			dryed_now += "[additional_info ? "[dry_as_text(I)]" : ""] [normal_item_name(I)]"
+		to_chat(user, SPAN_NOTICE("There is \a [english_list(dryed_now, and_text = " and a ")]."))
 
 /obj/structure/dehydrator/proc/normal_item_name(var/obj/item/I)
 	return copytext(I.name, 1, findtext(I.name, "ON_DEHYDRATOR"))
@@ -788,7 +789,7 @@
 						if (!P.dried_type)
 							set_dry_timer(P, TIME_TO_DRY+1)
 						qdel(I)
-						P.visible_message("[normal_item_name(P)] finishes drying.")
+						P.visible_message(SPAN_WARNING("\The [normal_item_name(P)] on \the [src] finishes drying."))
 						update_icon()
 		dry_process(this_process)
 

--- a/code/modules/1713/production.dm
+++ b/code/modules/1713/production.dm
@@ -701,7 +701,7 @@
 	if (storage.contents.len>0)
 		for(var/obj/item/I in storage.contents)
 			dryed_now += "[additional_info ? "[dry_as_text(I)]" : ""] [normal_item_name(I)]"
-		to_chat(user, SPAN_NOTICE("There hangs \a [esnglish_list(dryed_now, and_text = " and a ")].")) // \a because we need "there hangs an almost dried..."
+		to_chat(user, SPAN_NOTICE("There hangs \a [english_list(dryed_now, and_text = " and a ")].")) // \a because we need "there hangs an almost dried..."
 
 /obj/structure/dehydrator/proc/normal_item_name(var/obj/item/I)
 	return copytext(I.name, 1, findtext(I.name, "ON_DEHYDRATOR"))


### PR DESCRIPTION
* This fixes the punctuation and appending of the dried return text.

But it is worthy to note that a previous bug includes two spaces in-between "dried", I was unable to find the causation.


"There is dries not dried meat" now turns into:

![image](https://github.com/Civ13/Civ13/assets/131271192/898ca648-d524-4528-8a44-e3d74d28885b)

Whilst I have fixed the wording of the text and updated some of the code. I *was* **not** able to fix the following:

![image](https://github.com/Civ13/Civ13/assets/131271192/5d102dcc-8b20-4db6-b0bb-0a66c4a3aee5)

This was a bug before I worked on this code, so it was not caused by me.
I do not know how to fix it.
Maintainer edits have been allowed if you know.
I have asked in coder-bus as well.

Everything else is working aside from this.
