### PR TITLE
Adds a backslash to "the" in bow.dm

### DIFF
--- a/code/modules/1713/weapons/guns/bow.dm
+++ b/code/modules/1713/weapons/guns/bow.dm
@@ -211,7 +211,7 @@
 		if (caliber != C.caliber)
 			return //incompatible
 		if (loaded.len >= max_shells)
-			user << "<span class='warning'>the [src] already has \a [projtype] ready!</span>"
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [projtype] ready!"))
 			return
 
 		user.remove_from_mob(C)


### PR DESCRIPTION
This fixes the output message you get when you try and load a projectile onto a bow.

It USED to say:
![image](https://github.com/Civ13/Civ13/assets/131271192/f386df3e-0e63-49fc-ab76-239d70b43b30)

It now says:
`The crossbow already has a bolt ready!`


Nothing else was changed.
