### PR TITLE
Fixes not being able to destroy ant-hills.

### DIFF
--- a/code/game/mob/living/simple_animal/friendly/static.dm
+++ b/code/game/mob/living/simple_animal/friendly/static.dm
@@ -182,13 +182,13 @@
 	spawn(600) // 1 minute 
 		check_food()
 
-/obj/structure/anthill/attackby(var/obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/anthill/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/branch))
 		var/obj/item/weapon/branch/B = W
-		user.visible_message(SPAN_WARNING("You start poking inside \the [src] with the stick."), SPAN_WARNING("[user] starts poking inside \the [src] with the stick."))
+		user.visible_message(SPAN_WARNING("[user] starts poking inside \the [src] with \the [B]."), SPAN_WARNING("You start poking inside \the [src] with \the [B]."))
 		if (do_after(user, 120, src))
 			if (prob(75))
-				to_chat(user, SPAN_WARNING("You get some ants on your stick!"))
+				to_chat(user, SPAN_WARNING("You get some ants on \the [src]!"))
 				B.ants = TRUE
 				B.icon_state = "ant_stick"
 			else
@@ -196,7 +196,7 @@
 				return
 	else if (istype(W, /obj/item/weapon/reagent_containers) && W.reagents.has_reagent("water", 10)) // If holds reagents and has 10 units of water.
 		W.reagents.remove_reagent("water", 10)
-		user.visible_message(SPAN_NOTICE("You pour water onto \the [src], destroying it!"), SPAN_NOTICE("[user] pours water onto \the [src], destroying it!"))
+		user.visible_message(SPAN_NOTICE("[user] pours water onto \the [src], destroying it!"), SPAN_NOTICE("You pour water onto \the [src], destroying it!"))
 		visible_message(SPAN_WARNING("A bunch of red ants suddenly rush out of \the destroyed [src]!"))
 		new/obj/structure/ants(loc) // The ants delete in 1 minute if they do not find food.
 		qdel(src) // Delete the ant-hill.

--- a/code/game/mob/living/simple_animal/friendly/static.dm
+++ b/code/game/mob/living/simple_animal/friendly/static.dm
@@ -164,7 +164,7 @@
 
 /obj/structure/anthill
 	name = "anthill"
-	desc = "A anthill of giant red ants. Keep your food away!"
+	desc = "A hill of giant red ants. Keep your food away!"
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "anthill"
 	anchored = TRUE
@@ -181,18 +181,25 @@
 			done = TRUE
 	spawn(600) // 1 minute 
 		check_food()
-/obj/structure/anthill/attackby(var/obj/item/stack/W as obj, var/mob/living/human/H as mob)
+
+/obj/structure/anthill/attackby(var/obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/branch))
 		var/obj/item/weapon/branch/B = W
-		H.visible_message("[H] starts poking inside the anthill with the stick.")
-		if (do_after(H, 120, src))
-			if (prob(40))
-				H << "You get some ants on your stick."
+		user.visible_message(SPAN_WARNING("You start poking inside \the [src] with the stick."), SPAN_WARNING("[user] starts poking inside \the [src] with the stick."))
+		if (do_after(user, 120, src))
+			if (prob(75))
+				to_chat(user, SPAN_WARNING("You get some ants on your stick!"))
 				B.ants = TRUE
 				B.icon_state = "ant_stick"
 			else
-				H << "You can't seem to get any ants to react..."
+				to_chat(user, SPAN_NOTICE("You can't seem to get any ants to react..."))
 				return
+	else if (istype(W, /obj/item/weapon/reagent_containers) && W.reagents.has_reagent("water", 10)) // If holds reagents and has 10 units of water.
+		W.reagents.remove_reagent("water", 10)
+		user.visible_message(SPAN_NOTICE("You pour water onto \the [src], destroying it!"), SPAN_NOTICE("[user] pours water onto \the [src], destroying it!"))
+		visible_message(SPAN_WARNING("A bunch of red ants suddenly rush out of \the destroyed [src]!"))
+		new/obj/structure/ants(loc) // The ants delete in 1 minute if they do not find food.
+		qdel(src) // Delete the ant-hill.
 
 /obj/structure/ants
 	name = "red ants"
@@ -208,7 +215,6 @@
 	spawn(600) // 1 minute
 		if (src)
 			qdel(src)
-
 
 /obj/structure/ants/proc/check_food()
 	spawn(400)

--- a/code/game/objects/items/weapons/material/ooga_booga_weapons.dm
+++ b/code/game/objects/items/weapons/material/ooga_booga_weapons.dm
@@ -69,10 +69,10 @@
 
 /obj/item/weapon/branch/attack_self(mob/living/human/user as mob)
 	if (ants)
-		user << "You start licking some ants off the stick..."
+		to_chat(user, SPAN_NOTICE("You start licking some ants off the stick..."))
 		if (do_after(user, 50, src))
 			if (src && ants)
-				user << "You finish eating some ants."
+				to_chat(user, SPAN_NOTICE("You finish eating some ants."))
 				icon_state = "sharpened_stick"
 				ants = FALSE
 				if (user.gorillaman)
@@ -85,6 +85,7 @@
 				return
 	else
 		..()
+
 /obj/item/weapon/branch/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (W.edge && !sharpened)
 		user << "You start sharpening the stick..."


### PR DESCRIPTION
### The way to destroy ant-hills is temporary, only destroyable by 10u water now.

* Fixes not being able to destroy ant-hills. To be improved.

* Adds SPANs and fixes a grammar mistake in the description of str/anthill.

## Misc changes

* ~~The visible message won't seem to be able to properly discern the first and second argument, resulting in third-person perspective being shown to both. I am unsure as to why this happens.~~ fixed