### PR TITLE
FIxes wrenches/hammers going invisible.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -75,6 +75,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 // Click parameters is the params string from byond Click() code, see that documentation.
 /obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, params)
 	if (istype(target, /obj/structure/table))
+		if(!proximity_flag) return // if this afterattack was not called on something adjacent/in reach, to prevent the item from turning invisible (wrenches/hammers).
 		var/list/click_params = params2list(params)
 		//Center the icon where the user clicked.
 		pixel_x = (text2num(click_params["icon-x"]) - 16)


### PR DESCRIPTION
### I've directly incorped the proximity flag check into the table if block as was suggested earlier by Treez, this fixes the layering issue with held wrenches/hammers.

Held items are given layer 20. When this attack goes by, it does user.layer + 0.1, which makes the item 4.1, and thus under the HUD [invisible]