### PR TITLE
Comments out un-used code by paint.dm

### DIFF
--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -17,6 +17,8 @@ var/global/list/cached_icons = list()
 	flags = OPENCONTAINER
 	var/paint_type = "red"
 
+// Over-ridden by attack_turf() in parent which does a better job of this old-code.
+/*
 	afterattack(turf/target, mob/user, proximity)
 		if (!proximity) return
 		if (istype(target) && reagents.total_volume > 5)
@@ -24,7 +26,7 @@ var/global/list/cached_icons = list()
 			reagents.trans_to_turf(target, 5)
 		else
 			return ..()
-
+*/
 	New()
 		if (paint_type && length(paint_type) > 0)
 			name = paint_type + " " + name


### PR DESCRIPTION
This code does not work, and should be commented out.

attack_turf() code in `parent` for reference:
![image](https://github.com/Civ13/Civ13/assets/131271192/04828326-e154-4738-8170-934f39250c36)

`proper_spill()` handles pouring water,etc (floods)

### this directly does what afterattack seeks out to do, the paint buckets now use this `attack_turf()` code.