### PR TITLE
"richochetes" spelling mistake fix.

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -63,7 +63,7 @@
 		if (prob(66) && density)
 			return TRUE
 		else
-			visible_message(SPAN_WARNING("The [mover.name] ricochets off \the [src]!"))
+			visible_message(SPAN_WARNING("\The [mover.name] ricochets off \the [src]!"))
 			return FALSE
 	else
 		return ..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -63,7 +63,7 @@
 		if (prob(66) && density)
 			return TRUE
 		else
-			visible_message(SPAN_WARNING("The [mover.name] ricochetes off \the [src]!"))
+			visible_message(SPAN_WARNING("The [mover.name] ricochets off \the [src]!"))
 			return FALSE
 	else
 		return ..()


### PR DESCRIPTION
* Fixes `richochetes` --> `ricochets`

* Adds a backslash - `The` to `\The`