### PR TITLE
Fix a small visible emote typo for pig emotes.

### DIFF
--- a/code/game/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/game/mob/living/simple_animal/friendly/farm_animals.dm
@@ -367,7 +367,7 @@
 	icon_living = "pig_boar"
 	icon_dead = "pig_boar_dead"
 	speak = list("OINK!","SQWEEEL!")
-	emote_see = list("rolls on the ground", "lays with it's belly up", "snorts")
+	emote_see = list("rolls on the ground", "lays with its belly up", "snorts")
 	speak_chance = 1
 	move_to_delay = 5
 	see_in_dark = 6
@@ -399,7 +399,7 @@
 	icon_living = "pig_gilt"
 	icon_dead = "pig_gilt_dead"
 	speak = list("OINK!","SQWEEEL!")
-	emote_see = list("rolls on the ground", "lays with it's belly up", "snorts")
+	emote_see = list("rolls on the ground", "lays with its belly up", "snorts")
 	speak_chance = 1
 	move_to_delay = 5
 	see_in_dark = 6
@@ -542,7 +542,7 @@
 	icon_living = "boar_boar"
 	icon_dead = "boar_dead"
 	speak = list("Gweeeeiiirrr!","Ghhhhhhh!","Oeerrrrhhh!")
-	emote_see = list("rolls on the ground", "lays with it's belly up", "snorts")
+	emote_see = list("rolls on the ground", "lays with its belly up", "snorts")
 	speak_chance = 1
 	move_to_delay = 5
 	see_in_dark = 6
@@ -576,7 +576,7 @@
 	icon_living = "boar_gilt"
 	icon_dead = "boar_dead"
 	speak = list("Gweeeeiiirrr!","Ghhhhhhh!","Oeerrrrhhh!")
-	emote_see = list("rolls on the ground", "lays with it's belly up", "snorts")
+	emote_see = list("rolls on the ground", "lays with its belly up", "snorts")
 	speak_chance = 1
 	move_to_delay = 5
 	see_in_dark = 6


### PR DESCRIPTION
`it is` --> `its`!!!

* they're different.

## additional information

You could probably use `map.ordinal_age` to set different playsounds for `Corpsman` variations, otherwise there's no emote restriction on `*medic`.

It shouldn't say `medic` and yell for a `corpsman`. They're essentially different. I don't like small issues.