### PR TITLE
Allow the "emir" to eat whilst wearing an "emirate helmet"

### DIFF
--- a/code/modules/1713/apparel_medieval.dm
+++ b/code/modules/1713/apparel_medieval.dm
@@ -1217,6 +1217,7 @@
 	item_state = "emir_turban"
 	worn_state = "emir_turban"
 	body_parts_covered = HEAD|FACE
+	item_flags = FLEXIBLEMATERIAL // The emirate helmet does not block the face. body_parts_covered is used in armor calculation, masks with this flag will not prevent eating even if they are covering your "face".
 	flags_inv = BLOCKHEADHAIR
 	armor = list(melee = 55, arrow = 45, gun = 5, energy = 15, bomb = 60, bio = 30, rad = FALSE)
 	health = 45


### PR DESCRIPTION
* Adds a flag `FLEXIBILEMATERIAL` to allow the Emir to eat through his non-blocking helmet.

## Why this is good for the game.

The emirate helmet does not visually block the face, but the code says it does for... reasons~?

So yeah it should be able to be eaten through.

