### PR TITLE
This should properly register shelves and other child types not flipped.

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -181,7 +181,7 @@
 	if (!istype(T) || !istype(U))
 		return FALSE
 
-	// Check if the target turf is a table or a crate
+	// Check if the target turf is a crate or a barricade.
 	if (istype(src, /obj/structure/closet/crate) || istype(src, /obj/structure/barricade)) // we check for barricades because [sand]stone walls are under this.
 		if (user.loc == src.loc)
 			to_chat(user, SPAN_WARNING("You're already on this!"))

--- a/code/game/objects/structures/table_rack.dm
+++ b/code/game/objects/structures/table_rack.dm
@@ -3,7 +3,7 @@
 	desc = "Different from the Middle Ages version."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "rack"
-	flipped = -1
+	flipped = FALSE
 	low = TRUE
 	fixedsprite = TRUE
 
@@ -26,7 +26,7 @@
 	desc = "An old expensive table."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "fancytable"
-	flipped = -1
+	flipped = FALSE
 	low = TRUE
 	fixedsprite = TRUE
 
@@ -35,7 +35,7 @@
 	desc = "A night stand."
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "nightstand"
-	flipped = -1
+	flipped = FALSE
 	low = TRUE
 	fixedsprite = TRUE
 


### PR DESCRIPTION
* This fixes the 'You must be directly against this barrier to vault it.' When trying to climb shelves and rack subtypes.