### PR TITLE
Operation Falcon: BMD-2 fix, adds the CV90 to the Dutch

### DIFF
--- a/civ13.dme
+++ b/civ13.dme
@@ -1158,5 +1158,5 @@
 #include "code\processes\lighting\sources.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\campaign\campaign1.dmm"
+#include "maps\1943\smallingrad.dmm"
 // END_INCLUDE

--- a/code/modules/1713/computers/programs.dm
+++ b/code/modules/1713/computers/programs.dm
@@ -2058,6 +2058,7 @@
 
 	var/list/dutch_choice = list(
 		"2A6 Leopard Tank (1000)",
+		"CV90 IFV (800)",
 		"Mercedes-Benz Jeep with MG (400)",
 		"DAF YA-4442 Supply Truck (300)",
 		"Mercedes-Benz Jeep (200)",
@@ -2245,6 +2246,8 @@
 		switch (href_list["vehiclegiver"])
 			if ("2A6 Leopard Tank (1000)")
 				PV = new /obj/effects/premadevehicles/tank/leopard2a6(locate(origin.x+3,origin.y-5,origin.z))
+			if ("CV90 IFV (800)")
+				PV = new /obj/effects/premadevehicles/apc/cv90(locate(origin.x+3,origin.y-5,origin.z))
 			if ("Mercedes-Benz Jeep with MG (400)")
 				PV = new /obj/effects/premadevehicles/car/mercedes/mg(locate(origin.x+3,origin.y-5,origin.z))
 			if ("DAF YA-4442 Supply Truck (300)")
@@ -2255,7 +2258,7 @@
 			if ("T-90A Tank (1200)")
 				PV = new /obj/effects/premadevehicles/tank/t90a(locate(origin.x+3,origin.y-5,origin.z))
 			if ("BMD-2 IFV (900)")
-				PV = new /obj/structure/vehicleparts/axis/heavy/bmd2(locate(origin.x+3,origin.y-5,origin.z))
+				PV = new /obj/effects/premadevehicles/apc/bmd2(locate(origin.x+3,origin.y-5,origin.z))
 			if ("BTR-80 APC (700)")
 				PV = new /obj/effects/premadevehicles/apc/btr80(locate(origin.x+3,origin.y-5,origin.z))
 			if ("Tigr-M Humvee with MG (400)")


### PR DESCRIPTION
Fixes the BMD-2 spawn being wrong on Falcon, adds the CV90 IFV to the Dutch as they were lacking in the vehicle department.