### PR TITLE
Compacts the description of the "flare gun", civilian version.

### DIFF
--- a/code/modules/1713/weapons/guns/rocket.dm
+++ b/code/modules/1713/weapons/guns/rocket.dm
@@ -321,7 +321,7 @@
 
 /obj/item/weapon/gun/launcher/flaregun/civilian
 	name = "flare gun"
-	desc = "A flare gun used in emergency situations for signaling to asking for help."
+	desc = "A flare gun issued for civilian use in case of an emergency."
 	icon_state = "flaregun_civ"
 	item_state = "flaregun_civ"
 	good_flare = /obj/item/ammo_casing/flare

--- a/code/modules/1713/weapons/guns/rocket.dm
+++ b/code/modules/1713/weapons/guns/rocket.dm
@@ -321,7 +321,7 @@
 
 /obj/item/weapon/gun/launcher/flaregun/civilian
 	name = "flare gun"
-	desc = "A flare gun issued for civilian use in case of an emergency."
+	desc = "A flare gun issued for civilian use in-case of an emergency."
 	icon_state = "flaregun_civ"
 	item_state = "flaregun_civ"
 	good_flare = /obj/item/ammo_casing/flare


### PR DESCRIPTION
Just in-case it gets worked on, they don't have to worry about this.

* Makes it more fluent, dominantly for civilians. Highlights use of only in emergency, for civilians.

# Reference (if necessary):

Normal "flare gun" for all use, not specified PR;

https://github.com/Civ13/Civ13/pull/2864