### PR TITLE
Status tab revert + russian jobs tweaks/clean up

### DIFF
--- a/code/game/mob/new_player/new_player.dm
+++ b/code/game/mob/new_player/new_player.dm
@@ -7,7 +7,7 @@
 
 /mob/new_player
 	var/ready = FALSE
-	var/spawning = FALSE//Referenced when you want to delete the new_player later on in the code.
+	var/spawning = FALSE //Referenced when you want to delete the new_player later on in the code.
 	var/totalPlayers = 0		 //Player counts for the Lobby tab
 	var/totalPlayersReady = 0
 	var/desired_job = null // job title. This is for join queues.
@@ -151,9 +151,8 @@ var/global/redirect_all_players = null
 	return
 
 /mob/new_player/Stat()
-
-// New way
-	if(ticker)
+// Commented out as it is not working as intended and bugs out the Status tab in the Statpanel.
+	/*if(ticker)
 		if(ticker.current_state == GAME_STATE_PLAYING)
 			src << browse(null, "window=playerlist")
 			return
@@ -170,9 +169,8 @@ var/global/redirect_all_players = null
 				//else
 				client << output(list2params(list("Player", "[player.client.key]")), "playerlist.browser:addPlayerCell")
 				client << output(list2params(list()), "playerlist.browser:renderPlayerList")
-				player.updateTimeToStart()
+				player.updateTimeToStart()*/
 
-// Old way
 	if (client.status_tabs && statpanel("Status") && ticker)
 		stat("")
 		stat(stat_header("Lobby"))

--- a/code/modules/1713/jobs/grozny.dm
+++ b/code/modules/1713/jobs/grozny.dm
@@ -200,8 +200,8 @@
 	uniform.attackby(armor, H)
 
 //suit
-	var/randsuits = rand(1,6)
-	switch(ransuits)
+	var/randsuit = rand(1,6)
+	switch(randsuit)
 		if (1)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/biker/lizard_jacket(H), slot_wear_suit)
 		if (2)

--- a/code/modules/1713/jobs/grozny.dm
+++ b/code/modules/1713/jobs/grozny.dm
@@ -1,18 +1,16 @@
 /////////Chechen Army//////////////
-
 /datum/job/arab/civilian/chechen/give_random_name(var/mob/living/human/H)
 	H.name = H.species.get_random_chechen_name(H.gender)
 	H.real_name = H.name
 	H.circumcised = TRUE
 
-
 /datum/job/arab/civilian/chechen/leader
 	title = "Chechen Warlord"
-	rank_abbreviation = "W."
 	spawn_location = "JoinLateCCWL"
-	is_grozny = TRUE
+	
 	is_commander = TRUE
-	is_ww2 = FALSE
+	is_officer = TRUE
+	is_grozny = TRUE
 	is_modernday = TRUE
 	whitelisted = TRUE
 
@@ -36,8 +34,6 @@
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/tt30(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak74/aks74/aks74u/aks74uso/kgb(H), slot_shoulder)
-
-
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/duffel(H), slot_back)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/chechoff(H), slot_belt)
 	var/obj/item/clothing/under/uniform = H.w_uniform
@@ -86,41 +82,41 @@
 
 //shoes
 	var/randshoe2 = rand(1,5)
-	if (randshoe2 == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
-	else if (randshoe2 == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
-	else if (randshoe2 == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-	else if (randshoe2 == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/leatherboots(H), slot_shoes)
-	else if (randshoe2 == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/winterboots(H), slot_shoes)
-
+	switch(randshoe2)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/leatherboots(H), slot_shoes)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/winterboots(H), slot_shoes)
 
 //clothes
 	var/randjack2 = rand(1,10)
-	if (randjack2 == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_black(H), slot_w_uniform)
-	else if (randjack2 == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand(H), slot_w_uniform)
-	else if (randjack2 == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand_dcu(H), slot_w_uniform)
-	else if (randjack2 == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand_green(H), slot_w_uniform)
-	else if (randjack2 == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/oldmansuit(H), slot_w_uniform)
-	else if (randjack2 == 6)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/engi(H), slot_w_uniform)
-	else if (randjack2 == 7)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand_woodland(H), slot_w_uniform)
-	else if (randjack2 == 8)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/mafia(H), slot_w_uniform)
-	else if (randjack2 == 9)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/civ1(H), slot_w_uniform)
-	else if (randjack2 == 10)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/civ2(H), slot_w_uniform)
-
+	switch(randjack2)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_black(H), slot_w_uniform)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand(H), slot_w_uniform)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand_dcu(H), slot_w_uniform)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand_green(H), slot_w_uniform)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/oldmansuit(H), slot_w_uniform)
+		if (6)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/engi(H), slot_w_uniform)
+		if (7)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/insurgent_sand_woodland(H), slot_w_uniform)
+		if (8)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/mafia(H), slot_w_uniform)
+		if (9)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/civ1(H), slot_w_uniform)
+		if (10)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/civ2(H), slot_w_uniform)
 
 //head
 	var/randhead2 = rand(1,6)
@@ -149,7 +145,6 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/watch/watch(H), slot_gloves)
 		if (4)
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/watch/specialwatch(H), slot_gloves)
-
 
 //misc
 	var/randmisc2 = rand(1,6)
@@ -206,18 +201,19 @@
 
 //suit
 	var/randsuits = rand(1,6)
-	if (randsuits == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/biker/lizard_jacket(H), slot_wear_suit)
-	else if (randsuits == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/bomberjacketbrown(H), slot_wear_suit)
-	else if (randsuits == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/b3(H), slot_wear_suit)
-	else if (randsuits == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/expensivecoat(H), slot_wear_suit)
-	else if (randsuits == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/sovcoat2(H), slot_wear_suit)
-	else if (randsuits == 6)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/winter_coat(H), slot_wear_suit)
+	switch(ransuits)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/biker/lizard_jacket(H), slot_wear_suit)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/bomberjacketbrown(H), slot_wear_suit)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/b3(H), slot_wear_suit)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/expensivecoat(H), slot_wear_suit)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/sovcoat2(H), slot_wear_suit)
+		if (6)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/winter_coat(H), slot_wear_suit)
 
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction1(H), slot_wear_id)
 
@@ -261,7 +257,6 @@
 	is_medic = TRUE
 	is_grozny = TRUE
 	is_modernday = TRUE
-	is_ww2 = FALSE
 
 	min_positions = 3
 	max_positions = 10
@@ -323,7 +318,7 @@
 
 /datum/job/russian/ruff_lieutenant
 	title = "Russian Federal Forces Lieutenant"
-	rank_abbreviation = "Lt."
+	rank_abbreviation = "Leyt."
 
 	spawn_location = "JoinLateRUCap"
 
@@ -331,7 +326,6 @@
 	is_officer = TRUE
 	is_commander = TRUE
 	is_modernday = TRUE
-	is_ww2 = FALSE
 	whitelisted = TRUE
 
 	min_positions = 1
@@ -399,7 +393,6 @@
 
 	is_grozny = TRUE
 	is_modernday = TRUE
-	is_ww2 = FALSE
 	is_squad_leader = TRUE
 	uses_squads = TRUE
 
@@ -475,7 +468,6 @@
 	is_medic = TRUE
 	is_grozny = TRUE
 	is_modernday = TRUE
-	is_ww2 = FALSE
 
 	min_positions = 2
 	max_positions = 8
@@ -551,7 +543,6 @@
 	is_radioman = TRUE
 	uses_squads = TRUE
 	is_modernday = TRUE
-	is_ww2 = FALSE
 
 	min_positions = 1
 	max_positions = 5
@@ -644,7 +635,6 @@
 
 	is_grozny = TRUE
 	is_modernday = TRUE
-	is_ww2 = FALSE
 
 	uses_squads = TRUE
 
@@ -746,7 +736,6 @@
 	whitelisted = TRUE
 	is_grozny = TRUE
 	is_modernday = TRUE
-	is_ww2 = FALSE
 
 	uses_squads = TRUE
 

--- a/code/modules/1713/jobs/russian.dm
+++ b/code/modules/1713/jobs/russian.dm
@@ -282,6 +282,7 @@
 
 
 	return TRUE
+	
 /datum/job/russian/infantry
 	title = "Ryadovoy"
 	en_meaning = "Soldier Second-class"
@@ -315,7 +316,6 @@
 	uniform.attackby(russbando, H)
 	for (var/i=1, i<= 4, i++)
 		russbando.attackby(new/obj/item/ammo_magazine/mosin, H)
-	give_random_name(H)
 	give_random_name(H)
 	H.add_note("Role", "You are a <b>[title]</b>, a simple soldier second-class employed by the Imperial Russian Army. Follow your <b>Officer's</b> orders!")
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -393,11 +393,11 @@
 	spawn_location = "JoinLateRUCap"
 	is_officer = TRUE
 	whitelisted = TRUE
-	is_karelia = TRUE
 	is_ww2 = TRUE
+	is_karelia = TRUE
 
 	min_positions = 1
-	max_positions = 1
+	max_positions = 2
 
 /datum/job/russian/nkvd_soviet/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
@@ -506,10 +506,12 @@
 	rank_abbreviation = "Srj."
 
 	spawn_location = "JoinLateRUDoc"
-	is_karelia = TRUE
 	is_ww2 = TRUE
-	is_bordersov = FALSE
 	is_medic = TRUE
+
+	is_karelia = TRUE
+	is_bordersov = FALSE
+	
 	min_positions = 1
 	max_positions = 4
 
@@ -553,10 +555,10 @@
 	rank_abbreviation = ""
 
 	spawn_location = "JoinLateRU"
-	is_karelia = TRUE
 	is_ww2 = TRUE
 	uses_squads = TRUE
 
+	is_karelia = TRUE
 
 	min_positions = 2
 	max_positions = 12
@@ -604,10 +606,10 @@
 	rank_abbreviation = ""
 
 	spawn_location = "JoinLateRU"
-	is_karelia = TRUE
 	is_ww2 = TRUE
 	uses_squads = TRUE
 
+	is_karelia = TRUE
 
 	min_positions = 2
 	max_positions = 8
@@ -944,7 +946,7 @@
 				var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svt/frag/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svt/frag(null)
 				uniform.attackby(webbing, H)
 		if (2)
-			if (prob(70))
+			if (prob(30))
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppd(H), slot_shoulder)
 			else
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_shoulder)
@@ -2209,39 +2211,39 @@
 	if (!H)	return FALSE
 //shoes
 	var/randshoe2 = rand(1,5)
-	if (randshoe2 == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
-	else if (randshoe2 == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
-	else if (randshoe2 == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-	else if (randshoe2 == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/leatherboots(H), slot_shoes)
-	else if (randshoe2 == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/winterboots(H), slot_shoes)
-
+	switch(randshoe2)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/leatherboots(H), slot_shoes)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/winterboots(H), slot_shoes)
 
 //clothes
 	var/randjack2 = rand(1,9)
-	if (randjack2 == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/farmer_outfit(H), slot_w_uniform)
-	else if (randjack2 == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/mechanic_outfit(H), slot_w_uniform)
-	else if (randjack2 == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/civ1(H), slot_w_uniform)
-	else if (randjack2 == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/civ4(H), slot_w_uniform)
-	else if (randjack2 == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/oldmansuit(H), slot_w_uniform)
-	else if (randjack2 == 6)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/engi(H), slot_w_uniform)
-	else if (randjack2 == 7)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/civ6(H), slot_w_uniform)
-	else if (randjack2 == 8)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/civ5(H), slot_w_uniform)
-	else if (randjack2 == 9)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/industrial5(H), slot_w_uniform)
-
+	switch(randjack2)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/farmer_outfit(H), slot_w_uniform)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/mechanic_outfit(H), slot_w_uniform)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/civ1(H), slot_w_uniform)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/civ4(H), slot_w_uniform)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/oldmansuit(H), slot_w_uniform)
+		if (6)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/engi(H), slot_w_uniform)
+		if (7)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/civ6(H), slot_w_uniform)
+		if (8)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/civ5(H), slot_w_uniform)
+		if (9)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/industrial5(H), slot_w_uniform)
 
 //head
 	var/randhead2 = rand(1,7)

--- a/code/modules/1713/jobs/russian.dm
+++ b/code/modules/1713/jobs/russian.dm
@@ -863,7 +863,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/heavyboots/wrappedboots(H), slot_shoes)
 //clothes
 	if (map.ID == MAP_KARELIA || map.ID == MAP_STALINGRAD || map.ID == MAP_SMALLINGRAD || map.ID == MAP_SMALLSIEGEMOSCOW || map.ID == MAP_GULAG13)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/soviet_berezka(H), slot_w_uniform)
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/soviet_amoeba/winter(H), slot_w_uniform)
 	else
 		if (prob(70))
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/soviet_amoeba(H), slot_w_uniform)
@@ -2858,17 +2858,17 @@
 //shoes
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/modern(H), slot_shoes)
 //clothes
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/russian(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/russian/vdv(H), slot_w_uniform)
 //armor
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/armor/coldwar/plates/b45/b45 = new /obj/item/clothing/accessory/armor/coldwar/plates/b45(null)
-	uniform.attackby(b45, H)
+	var/obj/item/clothing/accessory/armor/coldwar/plates/b46/b46 = new /obj/item/clothing/accessory/armor/coldwar/plates/b46(null)
+	uniform.attackby(b46, H)
 	var/obj/item/weapon/armorplates/plates1 = new /obj/item/weapon/armorplates(null)
 	var/obj/item/weapon/armorplates/plates2 = new /obj/item/weapon/armorplates(null)
 	uniform.attackby(plates1, H)
 	uniform.attackby(plates2, H)
 //equipment
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret_rus_vdv(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret_rus_vdv/modern(H), slot_head)
 
 	var/obj/item/weapon/gun/projectile/submachinegun/ak74m/HGUN = new/obj/item/weapon/gun/projectile/submachinegun/ak74m(H)
 	H.equip_to_slot_or_del(HGUN, slot_shoulder)
@@ -3097,11 +3097,7 @@
 	else
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/heavyboots/wrappedboots(H), slot_shoes)
 //clothes
-	if (prob(80))
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/soviet_berezka(H), slot_w_uniform)
-	else
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/soviet_amoeba/winter(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/weapon/attachment/scope/adjustable/binoculars/binoculars(H), slot_wear_id)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/ww2/soviet_berezka(H), slot_w_uniform)
 //glove
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/combat(H), slot_gloves)
 //gun

--- a/code/modules/1713/jobs/yeltsin.dm
+++ b/code/modules/1713/jobs/yeltsin.dm
@@ -13,19 +13,16 @@
 	whitelisted = TRUE
 
 	min_positions = 1
-	max_positions = 2
+	max_positions = 1
 
 /datum/job/russian/ra/lieutenant/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/soldiershoes(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/soviet(H), slot_shoes)
 
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rus_vsr93(H), slot_w_uniform)
-	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat/officer(H), slot_gloves)
 //head
-	if (prob(50))
-		H.equip_to_slot_or_del(new /obj/item/clothing/glasses/gglasses(H), slot_eyes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret_rus_vdv(H), slot_head)
 
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
@@ -36,7 +33,7 @@
 	var/obj/item/clothing/under/uniform = H.w_uniform
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
-	var/obj/item/clothing/accessory/armor/coldwar/plates/platecarriergreen/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/platecarriergreen(null)
+	var/obj/item/clothing/accessory/armor/coldwar/plates/b5/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/b5(null)
 	var/obj/item/weapon/armorplates/plates1 = new /obj/item/weapon/armorplates(null)
 	var/obj/item/weapon/armorplates/plates2 = new /obj/item/weapon/armorplates(null)
 	armour.attackby(plates1, H)
@@ -137,13 +134,13 @@
 	is_yeltsin = TRUE
 	is_grozny = FALSE
 
-	min_positions = 2
+	min_positions = 1
 	max_positions = 8
 
 /datum/job/russian/ra/medic/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/soldiershoes(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/modern(H), slot_shoes)
 
 //clothes
 	if (prob(40))
@@ -198,25 +195,24 @@
 
 	uses_squads = TRUE
 
-	min_positions = 10
-	max_positions = 50
+	min_positions = 1
+	max_positions = 40
 
 /datum/job/russian/ra/omon/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/iogboots/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/modern(H), slot_shoes)
 
 //clothes
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/omon(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/armor/coldwar/plates/platecarrierblack/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/platecarrierblack(null)
+	var/obj/item/clothing/accessory/armor/coldwar/plates/b5/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/b5(null)
 	uniform.attackby(armour, H)
 	var/obj/item/clothing/accessory/holster/hip/holsterh = new /obj/item/clothing/accessory/holster/hip(null)
 	uniform.attackby(holsterh, H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat(H), slot_gloves)
 //head
-	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/tactical_goggles(H), slot_eyes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/russia(H), slot_wear_mask)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/modern/zsh2(H), slot_head)
 //back
@@ -224,18 +220,19 @@
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/makarov(H), slot_l_hand)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/smallpouches/green/sov_swat(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/shield/balistic(H), slot_back)
+	
 	H.civilization = "Russian Army"
 	give_random_name(H)
-	H.add_note("Role", "You are a <b>[title]</b>, part of the OMON, the Special Purpouse Mobile Unit of the Minitry of Internal Affairs. Use your superior training and gear to control the miltia!")
+	H.add_note("Role", "You are a <b>[title]</b>, part of the OMON, the Special Purpose Mobile Unit of the Minitry of Internal Affairs. Use your superior training and gear to control the miltia!")
 	H.setStat("strength", STAT_HIGH)
-	H.setStat("crafting", STAT_HIGH)
-	H.setStat("rifle", STAT_HIGH)
+	H.setStat("crafting", STAT_NORMAL)
+	H.setStat("rifle", STAT_MEDIUM_HIGH)
 	H.setStat("dexterity", STAT_HIGH)
-	H.setStat("swords", STAT_NORMAL)
+	H.setStat("swords", STAT_LOW)
 	H.setStat("pistol", STAT_VERY_HIGH)
-	H.setStat("bows", STAT_NORMAL)
-	H.setStat("medical", STAT_NORMAL)
-	H.setStat("machinegun", STAT_HIGH)
+	H.setStat("bows", STAT_LOW)
+	H.setStat("medical", STAT_LOW)
+	H.setStat("machinegun", STAT_NORMAL)
 	return TRUE
 
 /datum/job/russian/ra/soldier
@@ -249,20 +246,18 @@
 
 	uses_squads = TRUE
 
-	min_positions = 10
-	max_positions = 200
+	min_positions = 1
+	max_positions = 100
 
 /datum/job/russian/ra/soldier/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
-	var/randshoes = rand(1,3)
+	var/randshoes = rand(1,2)
 	switch(randshoes)
 		if(1)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/modern(H), slot_shoes)
 		if(2)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/soviet(H), slot_shoes)
-		if(3)
-			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/soldiershoes(H), slot_shoes)
 
 //clothes
 	if (prob(20))
@@ -276,7 +271,9 @@
 
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/armor/coldwar/plates/b3/armour2 = new /obj/item/clothing/accessory/armor/coldwar/plates/b3(null)
+	var/obj/item/clothing/accessory/armor/coldwar/plates/b3/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/b3(null)
+	var/obj/item/weapon/armorplates/plates1 = new /obj/item/weapon/armorplates(null)
+	armour.attackby(plates1, H)
 	uniform.attackby(armour2, H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/combat(H), slot_gloves)
 
@@ -310,12 +307,11 @@
 	spawn_location = "JoinLateRUsptz"
 	whitelisted = TRUE
 	is_yeltsin = TRUE
-	is_grozny = FALSE
 
 	uses_squads = TRUE
 
 	min_positions = 1
-	max_positions = 10
+	max_positions = 8
 
 /datum/job/russian/ra/spetsnaz/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
@@ -326,7 +322,7 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/gorka(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/weapon/radio/walkietalkie/faction2(H), slot_wear_id)
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/armor/coldwar/plates/platecarriergreen/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/platecarriergreen(null)
+	var/obj/item/clothing/accessory/armor/coldwar/plates/b5/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/b5(null)
 	var/obj/item/weapon/armorplates/plates1 = new /obj/item/weapon/armorplates(null)
 	var/obj/item/weapon/armorplates/plates2 = new /obj/item/weapon/armorplates(null)
 	armour.attackby(plates1, H)
@@ -352,7 +348,7 @@
 
 	H.civilization = "Russian Army"
 	give_random_name(H)
-	H.add_note("Role", "You are a <b>[title]</b>, part of the Spetznaz Response Team. You are the best of the best; end this conflict!")
+	H.add_note("Role", "You are a <b>[title]</b>, an elite operator part of the FSB's \"Alfa\" Spetznaz Response Team.")
 	H.setStat("strength", STAT_HIGH)
 	H.setStat("crafting", STAT_NORMAL)
 	H.setStat("rifle", STAT_VERY_HIGH)
@@ -416,7 +412,7 @@
 
 
 /datum/job/civilian/russian/kgb
-	title = "KGB officer"
+	title = "KGB Officer"
 	rank_abbreviation = "KGB"
 
 	spawn_location = "JoinLatessm"
@@ -472,50 +468,49 @@
 
 ////////////MILITIAS/////////////
 
-/datum/job/civilian/russian/rus_militia
-	title = "Proletariate"
-	en_meaning = "Improvised Weapon Militia"
-	rank_abbreviation = ""
+/datum/job/civilian/russian/sov_militia
+	title = "Opposition Militia"
 	spawn_location = "JoinLateCiv"
-	min_positions = 10
-	max_positions = 300
+	min_positions = 1
+	max_positions = 250
+	
 	is_yeltsin = TRUE
 
-/datum/job/civilian/russian/rus_militia/equip(var/mob/living/human/H)
+/datum/job/civilian/russian/sov_militia/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
 	var/randshoe = rand(1,5)
-	if (randshoe == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
-	else if (randshoe == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
-	else if (randshoe == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-	else if (randshoe == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/leatherboots(H), slot_shoes)
-	else if (randshoe == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/winterboots(H), slot_shoes)
-
+	switch(randshoe)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/leatherboots(H), slot_shoes)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/winterboots(H), slot_shoes)
 
 //clothes
-	var/randjack = rand(1,8)
-	if (randjack == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/farmer_outfit(H), slot_w_uniform)
-	else if (randjack == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/mechanic_outfit(H), slot_w_uniform)
-	else if (randjack == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/scavfit(H), slot_w_uniform)
-	else if (randjack == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/motorist(H), slot_w_uniform)
-	else if (randjack == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/oldmansuit(H), slot_w_uniform)
-	else if (randjack == 6)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/engi(H), slot_w_uniform)
-	else if (randjack == 7)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/cozyoldy(H), slot_w_uniform)
-	else if (randjack == 8)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/expensive(H), slot_w_uniform)
-
+	var/randuni = rand(1,8)
+	switch(randuni)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/farmer_outfit(H), slot_w_uniform)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/mechanic_outfit(H), slot_w_uniform)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/scavfit(H), slot_w_uniform)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/motorist(H), slot_w_uniform)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/oldmansuit(H), slot_w_uniform)
+		if (6)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/engi(H), slot_w_uniform)
+		if (7)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/cozyoldy(H), slot_w_uniform)
+		if (8)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/expensive(H), slot_w_uniform)
 
 //head
 	var/randhead = rand(1,6)
@@ -532,8 +527,6 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/soviet_tanker(H), slot_head)
 		if (6)
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/commando_bandana(H), slot_head)
-
-
 //gloves
 	var/randglove = rand(1,4)
 	switch(randglove)
@@ -545,31 +538,48 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/watch/watch(H), slot_gloves)
 		if (4)
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/watch/specialwatch(H), slot_gloves)
-
-
 //misc
-	var/randmisc = rand(1,6)
-	switch(randmisc)
-		if (1)
-			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/pilot(H), slot_eyes)
-		if (2)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/shemagh/greykerchief(H), slot_wear_mask)
-		if (3)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/shemagh/redkerchief(H), slot_wear_mask)
-		if (4)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette(H), slot_wear_mask)
-		if (5)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette/cigar(H), slot_wear_mask)
-		if (6)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette(H), slot_wear_mask)
-
-//weapon
+	if (prob(60))
+		var/randmisc = rand(1,5)
+		switch(randmisc)
+			if (1)
+				H.equip_to_slot_or_del(new /obj/item/clothing/glasses/pilot(H), slot_eyes)
+			if (2)
+				H.equip_to_slot_or_del(new /obj/item/clothing/mask/shemagh/greykerchief(H), slot_wear_mask)
+			if (3)
+				H.equip_to_slot_or_del(new /obj/item/clothing/mask/shemagh/redkerchief(H), slot_wear_mask)
+			if (4)
+				H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette(H), slot_wear_mask)
+			if (5)
+				H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette/cigar(H), slot_wear_mask)
+//weapons
+	// guns
+	if (prob(60))
+		var/randgun = rand(1,3)
+		switch(randgun)
+			if (1)
+				if (prob(75))
+					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/tt30(H), slot_belt)
+				else
+					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/revolver/nagant_revolver(H), slot_belt)
+			if (2)
+				if (prob(60))
+					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak47(H), slot_shoulder)
+				else
+					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak47/akms(H), slot_shoulder)
+			if (3)
+				if (prob(75))
+					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+				else
+					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/obrez(H), slot_shoulder)
+	
+	// melee
 	var/randimpw = rand(1,8)
 	switch(randimpw)
 		if (1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/material/fancycane(H), slot_l_hand)
+			H.equip_to_slot_or_del(new /obj/item/weapon/material/hatchet/steel(H), slot_l_hand)
 		if (2)
-			H.equip_to_slot_or_del(new /obj/item/weapon/material/kitchen/utensil/knife/hook(H), slot_l_hand)
+			H.equip_to_slot_or_del(new /obj/item/weapon/material/kitchen/utensil/knife/bowie(H), slot_l_hand)
 		if (3)
 			H.equip_to_slot_or_del(new /obj/item/weapon/material/scythe(H), slot_l_hand)
 		if (4)
@@ -580,43 +590,24 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/hammer/modern(H), slot_l_hand)
 		if (7)
 			H.equip_to_slot_or_del(new /obj/item/weapon/broken_bottle(H), slot_l_hand)
-		if (8)
-			H.equip_to_slot_or_del(new /obj/item/weapon/material/kitchen/utensil/knife/bowie(H), slot_l_hand)
-		if (9)
-			H.equip_to_slot_or_del(new /obj/item/weapon/material/hatchet(H), slot_l_hand)
-
-//vodka
-	if (prob(30))
-		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/molotov/vodka(H), slot_r_hand)
-
-
-//pockets
-	var/ranpocl = rand(1,2)
-	switch(ranpocl)
-		if (1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/material/shard/glass(H), slot_l_store)
-		if (2)
-			H.equip_to_slot_or_del(new /obj/item/weapon/flint/sharpened(H), slot_l_store)
-
-	H.equip_to_slot_or_del(new /obj/item/weapon/flame/lighter/zippo(H), slot_r_store)
-
 //suit
-	var/randsuits = rand(1,6)
-	if (randsuits == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/black_suit(H), slot_wear_suit)
-	else if (randsuits == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/bomberjacketbrown(H), slot_wear_suit)
-	else if (randsuits == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/biker/lizard_jacket(H), slot_wear_suit)
-	else if (randsuits == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/russian_rcw(H), slot_wear_suit)
-	else if (randsuits == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/soviet(H), slot_wear_suit)
-	else if (randsuits == 6)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/coveralls(H), slot_wear_suit)
+	var/randsuit = rand(1,6)
+	switch(randsuit)
+		if (1)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/black_suit(H), slot_wear_suit)
+		if (2)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/bomberjacketbrown(H), slot_wear_suit)
+		if (3)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/biker/lizard_jacket(H), slot_wear_suit)
+		if (4)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/russian_rcw(H), slot_wear_suit)
+		if (5)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/soviet(H), slot_wear_suit)
+		if (6)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/coveralls(H), slot_wear_suit)
 
 
-	H.add_note("Role", "You are a <b>[title]</b>, insurging against Yeltsin's tyranny. Your life for the dream of the people!")
+	H.add_note("Role", "You are a <b>[title]</b>, insurging against Yeltsin's tyranny. You're ready to give your life for the dream of the people!")
 	H.civilization = "Militia"
 	give_random_name(H)
 	H.setStat("strength", STAT_MEDIUM_HIGH)
@@ -629,162 +620,7 @@
 	H.setStat("medical", STAT_MEDIUM_LOW)
 	return TRUE
 
-/datum/job/civilian/russian/rus_patriot
-	title = "Russian Patriot"
-	en_meaning = "Firearms Militia"
-	rank_abbreviation = ""
-	spawn_location = "JoinLateCiv"
-	min_positions = 10
-	max_positions = 50
-	is_yeltsin = TRUE
-
-/datum/job/civilian/russian/rus_patriot/equip(var/mob/living/human/H)
-	if (!H)	return FALSE
-
-//shoes
-	var/randshoe2 = rand(1,5)
-	if (randshoe2 == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
-	else if (randshoe2 == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
-	else if (randshoe2 == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-	else if (randshoe2 == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/leatherboots(H), slot_shoes)
-	else if (randshoe2 == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/winterboots(H), slot_shoes)
-
-
-//clothes
-	var/randjack2 = rand(1,8)
-	if (randjack2 == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/farmer_outfit(H), slot_w_uniform)
-	else if (randjack2 == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/mechanic_outfit(H), slot_w_uniform)
-	else if (randjack2 == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/scavfit(H), slot_w_uniform)
-	else if (randjack2 == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/motorist(H), slot_w_uniform)
-	else if (randjack2 == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/oldmansuit(H), slot_w_uniform)
-	else if (randjack2 == 6)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/engi(H), slot_w_uniform)
-	else if (randjack2 == 7)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/cozyoldy(H), slot_w_uniform)
-	else if (randjack2 == 8)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/expensive(H), slot_w_uniform)
-
-
-//head
-	var/randhead2 = rand(1,7)
-	switch(randhead2)
-		if (1)
-			H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/soviet(H), slot_head)
-		if (2)
-			H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/sov_ushanka(H), slot_head)
-		if (3)
-			H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/soviet(H), slot_head)
-		if (4)
-			H.equip_to_slot_or_del(new /obj/item/clothing/head/fedora(H), slot_head)
-		if (5)
-			H.equip_to_slot_or_del(new /obj/item/clothing/head/ww2/soviet_tanker(H), slot_head)
-		if (6)
-			H.equip_to_slot_or_del(new /obj/item/clothing/head/commando_bandana(H), slot_head)
-		if (7)
-			H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ww2/soviet(H), slot_head)
-
-//gloves
-	var/randglove2 = rand(1,4)
-	switch(randglove2)
-		if (1)
-			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/leather(H), slot_gloves)
-		if (2)
-			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/fingerless(H), slot_gloves)
-		if (3)
-			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/watch/watch(H), slot_gloves)
-		if (4)
-			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/watch/specialwatch(H), slot_gloves)
-
-
-//misc
-	var/randmisc2 = rand(1,6)
-	switch(randmisc2)
-		if (1)
-			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/pilot(H), slot_eyes)
-		if (2)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/shemagh/greykerchief(H), slot_wear_mask)
-		if (3)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/shemagh/redkerchief(H), slot_wear_mask)
-		if (4)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette(H), slot_wear_mask)
-		if (5)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette/cigar(H), slot_wear_mask)
-		if (6)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/smokable/cigarette(H), slot_wear_mask)
-
-//weapon
-	var/randarmw = rand(1,3)
-	switch(randarmw)
-		if (1)
-			if (prob(75))
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/pistol/tt30(H), slot_l_hand)
-			else
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/revolver/nagant_revolver(H), slot_l_hand)
-
-		if (2)
-			if (prob(25))
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/shotgun/pump/remington870(H), slot_l_hand)
-			else
-				if (prob(60))
-					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak47(H), slot_l_hand)
-				else
-					H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ak47/akms(H), slot_l_hand)
-		if (3)
-			if (prob(75))
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_l_hand)
-			else
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/obrez(H), slot_l_hand)
-
-//vodka
-	if (prob(15))
-		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka(H), slot_r_hand)
-
-
-	H.equip_to_slot_or_del(new /obj/item/weapon/material/machete(H), slot_belt)
-
-	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/obj/item/clothing/accessory/armor/modern/plate/armor = new /obj/item/clothing/accessory/armor/modern/plate(null)
-	uniform.attackby(armor, H)
-
-//suit
-	var/randsuits = rand(1,6)
-	if (randsuits == 1)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/black_suit(H), slot_wear_suit)
-	else if (randsuits == 2)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/bomberjacketbrown(H), slot_wear_suit)
-	else if (randsuits == 3)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/biker/lizard_jacket(H), slot_wear_suit)
-	else if (randsuits == 4)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/russian_rcw(H), slot_wear_suit)
-	else if (randsuits == 5)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/soviet(H), slot_wear_suit)
-	else if (randsuits == 6)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/coveralls(H), slot_wear_suit)
-
-	H.add_note("Role", "You are a <b>[title]</b>, insurging against Yeltsin's tyranny. You're ready to give your life for the dream of the people!")
-	H.civilization = "Militia"
-	give_random_name(H)
-	H.setStat("strength", STAT_NORMAL)
-	H.setStat("crafting", STAT_MEDIUM_HIGH)
-	H.setStat("rifle", STAT_HIGH)
-	H.setStat("dexterity", STAT_NORMAL)
-	H.setStat("swords", STAT_MEDIUM_HIGH)
-	H.setStat("pistol", STAT_HIGH)
-	H.setStat("bows", STAT_NORMAL)
-	H.setStat("medical", STAT_MEDIUM_LOW)
-	return TRUE
-
-/datum/job/civilian/russian/rus_doctor
+/datum/job/civilian/russian/militia_medic
 	title = "Militia Medic"
 	en_meaning = "Doctor"
 	rank_abbreviation = "Dr."
@@ -794,33 +630,29 @@
 	is_medic = TRUE
 	is_yeltsin = TRUE
 
-	min_positions = 3
+	min_positions = 1
 	max_positions = 10
 
-/datum/job/civilian/russian/rus_doctor/equip(var/mob/living/human/H)
+/datum/job/civilian/russian/militia_medic/equip(var/mob/living/human/H)
 	if (!H)	return FALSE
 //shoes
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
-
 //clothes
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/peakyblinder(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/scrubs/darkgreen(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/doctor(H), slot_wear_suit)
 
 //head
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/ww/papakha/white(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/surgical_cap/darkgreen(H), slot_head)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/sterile(H), slot_wear_mask)
 //back
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(H), slot_back)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/combat/modern(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/surgery(H), slot_l_hand)
-	H.equip_to_slot_or_del(new /obj/item/weapon/watch/pocket(H), slot_wear_id)
-	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/white(H), slot_gloves)
-//vodka
-	if (prob(15))
-		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka(H), slot_r_hand)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/sterile(H), slot_gloves)
 
-	if (H.f_style != "Full Beard" && H.f_style != "Medium Beard" && H.f_style != "Long Beard")
-		H.f_style = pick("Full Beard","Medium Beard","Long Beard")
+//misc
+	H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka(H), slot_r_hand)
+
 	H.add_note("Role", "You are a <b>[title]</b>. Keep your comrades healthy and motivated!")
 	H.civilization = "Militia"
 	give_random_name(H)

--- a/code/modules/1713/jobs/yeltsin.dm
+++ b/code/modules/1713/jobs/yeltsin.dm
@@ -274,7 +274,7 @@
 	var/obj/item/clothing/accessory/armor/coldwar/plates/b3/armour = new /obj/item/clothing/accessory/armor/coldwar/plates/b3(null)
 	var/obj/item/weapon/armorplates/plates1 = new /obj/item/weapon/armorplates(null)
 	armour.attackby(plates1, H)
-	uniform.attackby(armour2, H)
+	uniform.attackby(armour, H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/combat(H), slot_gloves)
 
 //head

--- a/code/modules/client/client_verbs.dm
+++ b/code/modules/client/client_verbs.dm
@@ -84,14 +84,14 @@
 			Lines += entry
 	else
 		for (var/client/C in clients)
-			var/entry = "Player <b>[C.key]</b> - Playing as <i>[C.mob.real_name]</i>"
+			var/entry = "<b>[C.key]</b>"
 			Lines += entry
 
 	for (var/line in sortList(Lines))
 		msg += "[line]\n"
 
 	msg += "<b>Total Players: [length(Lines)]</b>"
-	src << msg
+	to_chat(src, msg)
 
 /client/verb/adminwho()
 	set category = "Help!"


### PR DESCRIPTION
- Reverts the code for the "Status" tab
- Removes "playing as ..." for regular player (to limit metagaming; info is kept for mods/admins)
- Partially cleans up a bunch of job code for the russian/soviet team (makes a few small loadout tweaks, merges the mitilia role on Yeltsin to a single role)