### PR TITLE
Native American languages (still WIP) + minor fixes

### DIFF
--- a/code/__defines/faction_lang_defines.dm
+++ b/code/__defines/faction_lang_defines.dm
@@ -19,10 +19,18 @@
 #define GAELIC "GAELIC"
 #define ITALIAN "ITALIAN"
 #define CHEROKEE "CHEROKEE"
+#define IROQUOIS "IROQUOIS"
+#define SIOUX "SIOUX"
+#define APACHE "APACHE"
+#define NAVAJO "NAVAJO"
+#define CHINOOK "CHINOOK"
+#define COMANCHE "COMANCHE"
+#define MAYAN "MAYAN"
+#define AZTEC "AZTEC"
+#define HAWAIIAN "HAWAIIAN"
 #define INUIT "INUIT"
 #define OLDNNORSE "OLDNORSE"
 #define EGYPTIAN "EGYPTIAN"
-#define IROQUOIS "IROQUOIS"
 #define PASHTO "PASHTO"
 #define DARI "DARI"
 #define FARSI "FARSI"
@@ -54,222 +62,253 @@
 #define REDFACTION "REDFACTION"
 
 /proc/faction_const2name(constant,age = 0)
+	switch(constant)
+		if (PIRATES)
+			return "Pirates"
 
-	if (constant == PIRATES)
-		return "Pirates"
-
-	if (constant == BRITISH)
-		if (age >= 6)
-			return "United Kingdom"
-		else
-			if (map.ID == "TWOTRIBES")
-				return "Red Tribe"
-			else
-				return "British Empire"
-
-	if (constant == CIVILIAN)
-		if (map.ID == "TSARITSYN")
-			return "Red Army"
-		else if (map.ID == "YELTSIN")
-			return "Militia"
-		else if (map.ID == "AFRICAN_WARLORDS")
-			return "Yellowagwana Wartribe"
-		else if (map.ID == "TADOJSVILLE")
-			return "United Nations Peacekeepers"
-		else if (map.ID == "WHITERUN")
-			return "Stormcloaks"
-		else if (map.ID == "CAPITOL_HILL")
-			return "Rioters"
-		else if (map.ID == "WACO")
-			return "Branch Davidians"
-		else if (map.ID == "MISSIONARY_RIDGE")
-			return "Confederates"
-		else if (map.ID == "TANTIVEIV")
-			return "Rebels"
-		else if (map.ID == "RUHR_UPRISING")
-			return "Ruhr Red Army"
-		else if (map.ID == "MAGISTRAL")
-			return "DRA Army"
-		else if (map.ID == "BANK_ROBBERY" || map.ID == "DRUG_BUST")
-			return "Police Department"
-		else if (map.ID == "LONG_MARCH")
-			return "Red Army"
-		else if (map.ID == "EFT_FACTORY")
-			return "Scavs"
-		else
+		if (BRITISH)
 			if (age >= 6)
-				return "Civilians"
+				return "United Kingdom"
 			else
-				return "Colonists"
+				if (map.ID == "TWOTRIBES")
+					return "Red Tribe"
+				else
+					return "British Empire"
 
-	if (constant == INDIANS)
-		if (map.ID == "AFRICAN_WARLORDS")
-			return "Blugisi Wartribe"
-		else if (map.ID == "TADOJSVILLE")
-			return "Mercenary Warbands"
-		else if (map.ID == "EAST_LOS_SANTOS")
-			return "Ballas"
-		else
-			return "Native Tribe"
+		if (CIVILIAN)
+			switch(map.ID)
+				if ("TSARITSYN")
+					return "Red Army"
+				if ("YELTSIN")
+					return "Militia"
+				if ("AFRICAN_WARLORDS")
+					return "Yellowagwana Wartribe"
+				if ("TADOJSVILLE")
+					return "United Nations Peacekeepers"
+				if ("WHITERUN")
+					return "Stormcloaks"
+				if ("CAPITOL_HILL")
+					return "Rioters"
+				if ("WACO")
+					return "Branch Davidians"
+				if ("MISSIONARY_RIDGE")
+					return "Confederates"
+				if ("TANTIVEIV")
+					return "Rebels"
+				if ("RUHR_UPRISING")
+					return "Ruhr Red Army"
+				if ("MAGISTRAL")
+					return "DRA Army"
+				if ("BANK_ROBBERY" || "DRUG_BUST")
+					return "Police Department"
+				if ("LONG_MARCH")
+					return "Red Army"
+				if ("EFT_FACTORY")
+					return "Scavs"
+				else
+					if (age >= 6)
+						return "Civilians"
+					else
+						return "Colonists"
 
-	if (constant == PORTUGUESE)
-		return "Portuguese Empire"
+		if (INDIANS)
+			switch(map.ID)
+				if ("AFRICAN_WARLORDS")
+					return "Blugisi Wartribe"
+				if ("TADOJSVILLE")
+					return "Mercenary Warbands"
+				if ("EAST_LOS_SANTOS")
+					return "Ballas"
+				else
+					return "Native Tribe"
 
-	if (constant == SPANISH)
-		return "Spanish Empire"
+		if (PORTUGUESE)
+			return "Portuguese Empire"
 
-	if (constant == FRENCH)
-		if (age >= 4)
-			return "French Republic"
-		else
-			if (map.ID == "TWOTRIBES")
-				return "Blue Tribe"
+		if (SPANISH)
+			return "Spanish Empire"
+
+		if (FRENCH)
+			if (age >= 4)
+				return "French Republic"
 			else
-				return "French Empire"
+				if (map.ID == "TWOTRIBES")
+					return "Blue Tribe"
+				else
+					return "French Empire"
 
-	if (constant == DUTCH)
-		if (map.ID == "OPERATION_FALCON")
-			return "Dutch Royal Army"
-		else
+		if (DUTCH)
+			if (map.ID == "OPERATION_FALCON")
+				return "Dutch Royal Army"
+			else
+				if (age >= 6)
+					return "Dutch Monarchy"
+				else
+					return "Dutch Republic"
+
+		if (ITALIAN)
+			if (age >= 7)
+				return "Italian Republic"
+			else
+				return "Italian Monarchy"
+
+		if (JAPANESE)
+			return "Japanese Empire"
+
+		if (RUSSIAN)
+			switch(map.ID)
+				if ("YELTSIN")
+					return "Russian Army"
+				if ("GROZNY")
+					return "Russian Federal Forces"
+				if ("CONSTANTINOPOLI")
+					return "Slavo-Russian Imperial Army"
+				if ("TSARITSYN")
+					return "White Army"
+				if ("BANK_ROBBERY")
+					return "Robbers"
+				if ("DRUG_BUST")
+					return "Rednikov Mobsters"
+				if ("EFT_FACTORY")
+					return "BEAR"
+				else
+					switch(age)
+						if (6 to 7)
+							return "Soviet Union"
+						if (8)
+							return "Russian Federation"
+						else
+							return "Russian Empire"
+
+		if (ROMAN)
+			switch(map.ID)
+				if ("WHITERUN") 
+					return "Imperial Army"
+				if ( "CONSTANTINOPOLI")
+					return "Exercitus Latinus Imperialis"
+				else
+					return "Roman Republic"
+
+		if (CHECHEN)
+			return "Chechen Republic of Ichkeria"
+
+		if (FINNISH)
+			return "Republic of Finland"
+
+		if (NORWEGIAN)
+			if (map.ID == "CLASH")
+				return "Bear Clan"
+			else
+				return "Kingdom of Norway"
+
+		if (SWEDISH)
+			return "Kingdom of Sweden"
+
+		if (DANISH)
+			if (map.ID == "CLASH")
+				return "Raven Clan"
+			else
+				return "Kingdom of Denmark"
+
+		if (GERMAN)
+			if (age == 6)
+				return "Third Reich"
+			else if (age >= 7)
+				return "Federal Republic of Germany"
+			else if (map.ID == "RUHR_UPRISING")
+				return "Weimar Republic"
+			else
+				return "German Empire"
+		if (GREEK)
+			return "Greek States"
+
+		if (ARAB)
 			if (age >= 6)
-				return "Dutch Monarchy"
+				switch(map.ID)
+					if ("ARAB_TOWN")
+						return "Hezbollah"
+					if ("KANDAHAR" || "HILL_3234" || "MAGISTRAL")
+						return "Mujahideen"
+					if ("SYRIA")
+						return "Syrian Armed Forces"
+					else
+						return "Insurgents"
 			else
-				return "Dutch Republic"
+				return "Arabic Caliphate"
 
-	if (constant == ITALIAN)
-		if (age >= 7)
-			return "Italian Republic"
-		else
-			return "Italian Monarchy"
+		if (AMERICAN)
+			switch(map.ID)
+				if ("ARAB_TOWN")
+					return "IDF"
+				if ("CAPITOL_HILL")
+					return "American Government"
+				if ("WACO")
+					return "ATF"
+				if ("TANTIVEIV")
+					return "Imperials"
+				if ("EAST_LOS_SANTOS")
+					return "Grove Street Families"
+				if ("EFT_FACTORY")
+					return "USEC"
+				if ("SYRIA")
+					return "Free Syrian Army"
+				else
+					return "United States"
 
-	if (constant == JAPANESE)
-		return "Japanese Empire"
+		if (VIETNAMESE)
+			return "Vietnamese"
 
-	if (constant == RUSSIAN)
-		if (map.ID == "YELTSIN")
-			return "Russian Army"
-		else if (map.ID == "GROZNY")
-			return "Russian Federal Forces"
-		else if (map.ID == "CONSTANTINOPOLI")
-			return "Slavo-Russian Imperial Army"
-		else if (map.ID == "TSARITSYN")
-			return "White Army"
-		else if (map.ID == "BANK_ROBBERY")
-			return "Robbers"
-		else if (map.ID == "DRUG_BUST")
-			return "Rednikov Mobsters"
-		else if (map.ID == "EFT_FACTORY")
-			return "BEAR"
-		else
-			if (age == 6 || age == 7)
-				return "Soviet Union"
-			else if (age >= 8)
-				return "Russian Federation"
+		if (POLISH)
+			if (map.ID == "WARSAW")
+				return "Polish Home Army"
 			else
-				return "Russian Empire"
+				return "Polish"
 
-	if (constant == ROMAN)
-		if (map.ID == "WHITERUN")
-			return "Imperial Army"
-		else if (map.ID == "CONSTANTINOPOLI")
-			return "Exercitus Latinus Imperialis"
-		else
-			return "Roman Republic"
-
-	if (constant == CHECHEN)
-		return "Chechen Republic of Ichkeria"
-
-	if (constant == FINNISH)
-		return "Republic of Finland"
-
-	if (constant == NORWEGIAN)
-		if (map.ID == "CLASH")
-			return "Bear Clan"
-		else
-			return "Kingdom of Norway"
-
-	if (constant == SWEDISH)
-		return "Kingdom of Sweden"
-
-	if (constant == DANISH)
-		if (map.ID == "CLASH")
-			return "Raven Clan"
-		else
-			return "Kingdom of Denmark"
-
-	if (constant == GERMAN)
-		if (age == 6)
-			return "Third Reich"
-		else if (age >= 7)
-			return "Federal Republic of Germany"
-		else if (map.ID == "RUHR_UPRISING")
-			return "Weimar Republic"
-		else
-			return "German Empire"
-	if (constant == GREEK)
-		return "Greek States"
-
-	if (constant == ARAB)
-		if (age >= 6)
-			if (map.ID == "ARAB_TOWN")
-				return "Hezbollah"
-			else if (map.ID == "KANDAHAR" || map.ID == "HILL_3234" || map.ID == "MAGISTRAL")
-				return "Mujahideen"
-			else if (map.ID == "SYRIA")
-				return "Syrian Armed Forces"
+		if (CHINESE)
+			if (map.ID == "LONG_MARCH")
+				return "National Army"
 			else
-				return "Insurgents"
-		else
-			return "Arabic Caliphate"
+				return "Chinese"
 
-	if (constant == AMERICAN)
-		if (map.ID == "ARAB_TOWN")
-			return "IDF"
-		else if (map.ID == "CAPITOL_HILL")
-			return "American Government"
-		else if (map.ID == "WACO")
-			return "ATF"
-		else if (map.ID == "TANTIVEIV")
-			return "Imperials"
-		else if (map.ID == "EAST_LOS_SANTOS")
-			return "Grove Street Families"
-		else if (map.ID == "EFT_FACTORY")
-			return "USEC"
-		else if (map.ID == "SYRIA")
-			return "Free Syrian Army"
-		else
-			return "United States"
+		if (EGYPTIAN)
+			return "Egyptian"
 
-	if (constant == VIETNAMESE)
-		return "Vietnamese"
+		if (KOREAN)
+			return "Korean"
 
-	if (constant == POLISH)
-		if (map.ID == "WARSAW")
-			return "Polish Home Army"
-		else
-			return "Polish"
+		if (IROQUOIS)
+			return "Iroquois"
+		
+		if (SIOUX) 
+			return "Sioux Natives"
 
-	if (constant == CHINESE)
-		if (map.ID == "LONG_MARCH")
-			return "National Army"
-		else
-			return "Chinese"
+		if (APACHE) 
+			return "Apache Natives"
 
-	if (constant == EGYPTIAN)
-		return "Egyptian"
+		if (NAVAJO) 
+			return "Navajo Natives"
 
-	if (constant == KOREAN)
-		return "Korean"
+		if (CHINOOK) 
+			return "Chinook Natives"
 
-	if (constant == IROQUOIS)
-		return "Iroquois"
+		if (COMANCHE) 
+			return "Comanche Natives"
 
-	if (constant == FILIPINO)
-		return "Filipino"
-	
-	if (constant == BLUEFACTION)
-		return "Blugoslavia"
-	
-	if (constant == REDFACTION)
-		return "Redmenia"
+		if (MAYAN) 
+			return "Mayans"
+
+		if (AZTEC)
+			return "Aztecs"
+
+		if (HAWAIIAN)
+			return "Hawaiians"
+
+		if (FILIPINO)
+			return "Filipino"
+		
+		if (BLUEFACTION)
+			return "Blugoslavia"
+		
+		if (REDFACTION)
+			return "Redmenia"
 

--- a/code/game/mob/language/earth.dm
+++ b/code/game/mob/language/earth.dm
@@ -522,7 +522,7 @@
     colour = "Chinook"
     flags = RESTRICTED | COMMON_VERBS
     syllables = CHINOOK_SYLLABLES
-    mutual_intelligibility = list(datum/language/iroquois = 6, /datum/language/inuit = 4)
+    mutual_intelligibility = list(/datum/language/iroquois = 6, /datum/language/inuit = 4)
 
 /datum/language/comanche
     name = "Comanche"
@@ -542,13 +542,13 @@
     syllables = MAYAN_SYLLABLES
     mutual_intelligibility = list(/datum/language/aztec = 6, /datum/language/cherokee = 2)
 
-/datum/language/nahuatl
+/datum/language/aztec
     name = "Aztec"
     desc = "Nahuatl language."
     key = "az"
     colour = "Aztec"
     flags = RESTRICTED | COMMON_VERBS
-    syllables = NAHUATL_SYLLABLES
+    syllables = AZTEC_SYLLABLES
     mutual_intelligibility = list(/datum/language/mayan = 6, /datum/language/cherokee = 2)
 
 /datum/language/hawaiian

--- a/code/game/mob/language/earth.dm
+++ b/code/game/mob/language/earth.dm
@@ -28,6 +28,14 @@
 #define EGYPTIAN_SYLLABLES list("ura","ure", "nuf", "nif", "pha", "phe", "phi", "fenet", "fanat", "uneph", "uniph", "ophset", "uphset", "un", "ne", "nef", "nak", "naf", "rak", "raf", "ru", "ri", "tu", "ti", "ta", "te", "ut", "it", "pher", "phir", "inet", "uot","eunet", "runet", "aunet", "mun", "mon", "min", "am", "em", "im", "oka", "okef", "okif", "okuf", "kha", "onet", "kama", "umet", "khe", "khuf", "nem", "nim", "net", "nit", "phet", "phat", "phat", "om", "am", "um", "im", "yut", "yat", "yit", "eim", "uim", "iem", "het", "uminet", "nieter", "umerter", "omier", "kepne", "kepher", "kuph", "keph", "kiph", "ieun", "iaun", "ioun", "onetfer", "unetfer", "enetfer", "ferneh", "pherneh", "miu", "mih", "mie", "kek")
 #define KOREAN_SYLLABLES list("gya", "ga", "geo", "gyeo", "go", "gyo", "gu", "gyu", "geu", "gi", "na", "nya", "neo", "nyeo", "no", "nyo", "nu", "nyu", "neu", "ni", "da", "dya", "deo", "dyeo", "do", "dyo", "du", "dyu", "deu", "di", "ra", "rya", "reo", "ryeo", "ro", "ryo", "ru", "ryu", "reu", "ri", "ma", "mya", "meo", "myeo", "mo", "myo", "mu", "myu", "meu", "mi", "ba", "bya", "beo", "byeo", "bo", "byo", "bu", "byu", "beu", "bi", "sa", "sya", "seo", "syeo", "so", "syo", "su", "syu", "seu", "si", "a", "ya", "eo", "yeo", "o", "yo", "u", "yu", "eu", "i", "ja", "jya", "jeo", "jyeo", "jo", "jyo", "ju", "jyu", "jeu", "ji", "cha", "chya", "cheo", "chyeo", "cho", "chyo", "chu", "chyu", "cheu", "chi", "ka", "kya", "keo", "kyeo", "ko", "kyo", "ku", "kyu", "keu", "ki", "ta", "tya", "teo", "tyeo", "to", "tyo", "tu", "tyu", "teu", "ti", "pa", "pya", "peo", "pyeo", "po", "pyo", "pu", "pyu", "peu", "pi", "ha", "hya", "heo", "hyeo", "ho", "hyo", "hu", "hyu", "heu", "hi")
 #define IROQUOIS_SYLLABLES list("a", "ga", "ka", "ha", "la", "ma", "na", "hna", "nah", "qua", "s", "sa", "da", "ta", "dla", "tla", "tsa", "wa", "ya", "e", "ge", "he", "le", "me", "ne", "que", "se", "de", "te", "tle", "tse", "we", "ye", "i", "gi", "hi", "li", "mi", "ni", "qui", "si", "di", "tli", "tsi", "twi", "wi", "yi", "ti", "o", "go", "ho", "lo", "mo", "no", "quo", "so", "do", "tio", "tso", "wo", "yo", "u", "gu", "hu", "lu", "mu", "nu", "quu", "su", "du", "tlu", "tsu", "wu", "yu", "v", "gv", "hv", "lv", "nv", "quv", "sv", "dv", "tlv", "wv", "yv")
+#define SIOUX_SYLLABLES list("a", "i", "u", "e", "o", "ka", "kha", "ga", "gha", "ma", "na", "nga", "pa", "pha", "ba", "cha", "chang", "wa", "ya", "za", "ha", "la", "sha", "ta", "tha", "da", "cha", "chang", "wang", "yang", "zha", "sa", "mang", "nang")
+#define APACHE_SYLLABLES list("a", "i", "o", "u", "ba", "da", "ga", "ka", "la", "ma", "na", "pa", "sa", "ta", "tsa", "za", "cha", "ha", "wa", "ya", "nga", "nda", "nka", "nna", "nwa", "nya", "bai", "dai", "gai", "kai", "lai", "mai", "nai", "pai", "sai", "tai", "tsai", "zai", "chai", "hai", "wai", "yai", "ngai", "ndai", "nkai", "nnai", "nwai", "nyai")
+#define NAVAJO_SYLLABLES list("a", "e", "i", "o", "u", "ha", "ba", "cha", "da", "ga", "ja", "ka", "la", "ma", "na", "pa", "sa", "ta", "tsa", "za", "wa", "ya", "aa", "ee", "ii", "oo", "uu", "baa", "daa", "gaa", "jaa", "kaa", "naa", "paa", "saa", "taa", "tsaa", "zaa", "waa", "yaa", "hai", "bai", "dai", "gai", "jai", "kai", "lai", "mai", "nai", "pai", "sai", "tai", "tsai", "zai", "wai", "yai")
+#define CHINOOK_SYLLABLES list("a", "i", "u", "e", "o", "ka", "kha", "ga", "gha", "ma", "na", "nga", "pa", "pha", "ba", "cha", "chang", "wa", "ya", "za", "ha", "la", "sa", "ta", "tha", "da", "cha", "chang", "wang", "yang", "zha", "sa", "mang", "nang")
+#define COMANCHE_SYLLABLES list("a", "e", "i", "o", "u", "wa", "we", "wi", "wo", "wu", "ma", "me", "mi", "mo", "mu", "na", "ne", "ni", "no", "nu", "pa", "pe", "pi", "po", "pu", "ta", "te", "ti", "to", "tu", "ha", "he", "hi", "ho", "hu", "sa", "se", "si", "so", "su", "ya", "ye", "yi", "yo", "yu")
+#define MAYAN_SYLLABLES list("a", "e", "i", "o", "u", "ka", "ke", "ki", "ko", "ku", "ma", "me", "mi", "mo", "mu", "na", "ne", "ni", "no", "nu", "pa", "pe", "pi", "po", "pu", "ta", "te", "ti", "to", "tu", "cha", "che", "chi", "cho", "chu", "ja", "je", "ji", "jo", "ju", "sa", "se", "si", "so", "su", "wa", "we", "wi", "wo", "wu", "ya", "ye", "yi", "yo", "yu")
+#define AZTEC_SYLLABLES list("a", "e", "i", "o", "u", "ka", "ke", "ki", "ko", "ku", "ca", "ce", "ci", "co", "cu", "ma", "me", "mi", "mo", "mu", "na", "ne", "ni", "no", "nu", "pa", "pe", "pi", "po", "pu", "ta", "te", "ti", "to", "tu", "cha", "che", "chi", "cho", "chu", "ya", "ye", "yi", "yo", "yu", "tl", "tla", "tle", "tli", "tlo", "tlu", "xa", "xe", "xi", "xo", "xu")
+#define HAWAIIAN_SYLLABLES list("a", "e", "i", "o", "u", "ka", "ke", "ki", "ko", "ku", "la", "le", "li", "lo", "lu", "ma", "me", "mi", "mo", "mu", "na", "ne", "ni", "no", "nu", "pa", "pe", "pi", "po", "pu", "wa", "we", "wi", "wo", "wu", "ha", "he", "hi", "ho", "hu")
 #define FILIPINO_SYLLABLES list("a", "b", "da", "fa", "ga", "gra", "ha", "han", "hon", "ka", "la", "lat", "ma", "na", "nga", "pa", "pra", "ra", "sa", "sal", "ta", "tra", "wa", "e", "be", "bre", "de", "dre", "ge", "he", "ke", "le", "me", "ne", "pe", "pre", "re", "se", "te", "tre", "i", "bi", "di", "fi", "gi", "hi", "ki", "li", "mi", "ni", "pi", "pri", "ri", "si", "ti", "o", "ong", "oo", "bo", "bro", "do", "dro", "go", "ho", "ko", "lo", "mo", "no", "ngo", "po", "pro", "ro", "so", "to", "tro", "yo", "u", "bu", "du", "gu", "hu", "ku", "lu", "mu", "pu", "yu")
 #define ITALIAN_SYLLABLES list("pi", "za", "pe", "pp", "er", "on", "i", "ma", "mia", "na", "va", "ta", "ra", "ga", "da", "na", "sa", "la", "te", "re", "ge", "de", "ne", "se", "le", "ti", "ri", "gi", "di", "ni", "si")
 #define CHECHEN_SYLLABLES list("la", "ma", "nakh", "dukh", "duy", "lu", "sal", "shi", "shov", "dansh", "en", "be", "kha", "ja", "bal", "tsa", "mol", "ush", "jin", "khor", "gie", "buylsh", "or", "ga", "tha", "zan", "dakh", "gash", "det", "mekh", "sa", "salam", "al", "kum", "ha", "at", "qo", "di", "ste", "aid")
@@ -478,7 +486,79 @@
     colour = "Iroquois"
     flags = RESTRICTED | COMMON_VERBS
     syllables = IROQUOIS_SYLLABLES
-    mutual_intelligibility = list(/datum/language/inuit = 10)
+    mutual_intelligibility = list(/datum/language/inuit = 10, /datum/language/sioux = 6)
+
+/datum/language/sioux
+    name = "Sioux"
+    desc = "Lakotan, the language spoken by the Sioux."
+    key = "sx"
+    colour = "Sioux"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = SIOUX_SYLLABLES
+    mutual_intelligibility = list(/datum/language/cherokee = 10, /datum/language/iroquois = 6)
+
+/datum/language/apache
+    name = "Apache"
+    desc = "Western Apache."
+    key = "ap"
+    colour = "Apache"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = APACHE_SYLLABLES
+    mutual_intelligibility = list(/datum/language/navajo = 10, /datum/language/cherokee = 4)
+
+/datum/language/navajo
+    name = "Navajo"
+    desc = "Diné Bizaad."
+    key = "nv"
+    colour = "Navajo"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = NAVAJO_SYLLABLES
+    mutual_intelligibility = list(/datum/language/apache = 10, /datum/language/cherokee = 4)
+
+/datum/language/chinook
+    name = "Chinook"
+    desc = "Chinook Jargon."
+    key = "cj"
+    colour = "Chinook"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = CHINOOK_SYLLABLES
+    mutual_intelligibility = list(datum/language/iroquois = 6, /datum/language/inuit = 4)
+
+/datum/language/comanche
+    name = "Comanche"
+    desc = "Numu Tekwapu."
+    key = "cm"
+    colour = "Comanche"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = COMANCHE_SYLLABLES
+    mutual_intelligibility = list(/datum/language/cherokee = 8, /datum/language/apache = 6)
+
+/datum/language/mayan
+    name = "Mayan"
+    desc = "Maya T'aan."
+    key = "my"
+    colour = "Mayan"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = MAYAN_SYLLABLES
+    mutual_intelligibility = list(/datum/language/aztec = 6, /datum/language/cherokee = 2)
+
+/datum/language/nahuatl
+    name = "Aztec"
+    desc = "Nahuatl language."
+    key = "az"
+    colour = "Aztec"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = NAHUATL_SYLLABLES
+    mutual_intelligibility = list(/datum/language/mayan = 6, /datum/language/cherokee = 2)
+
+/datum/language/hawaiian
+    name = "Hawaiian"
+    desc = "Ōlelo Hawai'i."
+    key = "hw"
+    colour = "Hawaiian"
+    flags = RESTRICTED | COMMON_VERBS
+    syllables = HAWAIIAN_SYLLABLES
+    mutual_intelligibility = list(/datum/language/chinook = 4, /datum/language/inuit = 2)
 
 /datum/language/filipino
     name = "Filipino"

--- a/code/game/objects/map_metadata/kandahar.dm
+++ b/code/game/objects/map_metadata/kandahar.dm
@@ -51,10 +51,10 @@
 	custom_civs += newnameb
 	custom_civs += newnamec
 	custom_civs += newnamed
-	handle_flags() //Called once in the beginning to set up DRA flags
 	spawn(100)
 		load_new_recipes("config/crafting/material_recipes_sovafghan.txt")
 		override_global_recipes = "sovafghan"
+		handle_flags() //Called once in the beginning to set up DRA flags
 	spawn(4800)
 		points_check()
 

--- a/code/modules/1713/barbwire.dm
+++ b/code/modules/1713/barbwire.dm
@@ -122,3 +122,10 @@
 					H.updatehealth()
 					if (!(H.species && (H.species.flags)))
 						H.Weaken(1)
+
+/obj/item/stack/material/barbwire/attack_self(mob/user as mob)
+	var/mob/living/human/H = user
+	for (var/obj/structure/barbwire/B in get_turf(H))
+		to_chat(H, SPAN_WARNING("There's already some barbed wire here."))
+		return
+	..()


### PR DESCRIPTION
- Adds the basis for Sioux (Lakotan), Apache, Navajo, Chinook, Comanche, Mayan, Aztec and Hawaiian languages (TO-DO: names and their related procs)
- Cleans up faction_lang_defines.dm
- Attempts to fix Kandahar capture point flags at roundstart by giving the first call of the related proc a delay
- Prevents building barbed wire on a turf that already has one (no more "kill turfs", still mappable)