### PR TITLE
Fixes wrenching on structures. (Industrial Drill Fix.) #2

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -40,11 +40,11 @@
 				if (T != src && T.anchored)
 					to_chat(user, SPAN_WARNING("You can't anchor \the [src] here, there's already \a [T] anchored here."))
 					return
-				if (do_after(user, 15, src))
-					playsound(loc, 'sound/items/Ratchet.ogg', 100, TRUE)
-					to_chat(user, (src.anchored ? SPAN_NOTICE("You unfasten \the [src] from the floor.") : SPAN_NOTICE("You secure \the [src] to the floor.")))
-					src.anchored = !src.anchored
-					return
+		if (do_after(user, 15, src))
+			playsound(loc, 'sound/items/Ratchet.ogg', 100, TRUE)
+			to_chat(user, (src.anchored ? SPAN_NOTICE("You unfasten \the [src] from the floor.") : SPAN_NOTICE("You secure \the [src] to the floor.")))
+			src.anchored = !src.anchored
+			return
 	else if (istype(O, /obj/item/weapon/hammer) && !not_disassemblable)
 		playsound(loc, 'sound/items/Screwdriver.ogg', 75, TRUE)
 		to_chat(user, SPAN_NOTICE("You begin dismantling \the [src]."))


### PR DESCRIPTION
During the indentation fixes back when my visual studio code was bugging out. 

The last `if` statement was merged into the table indentation.

It should wrench at the end if everything passes.

### Do note that `not_movable` is TRUE by default in `obj/structure`, so !not_movable is checking if it is FALSE

Good catch on my last PR... I haven't drank coffee.. And I am so tired..