### PR TITLE
Mobs.dm clean-up; (procs)

### DIFF
--- a/code/__defines/math_physics.dm
+++ b/code/__defines/math_physics.dm
@@ -26,7 +26,7 @@
 #define RADIATOR_EXPOSED_SURFACE_AREA_RATIO 0.04 // (3 cm + 100 cm * sin(3deg))/(2*(3+100 cm)). Unitless ratio.
 #define HUMAN_EXPOSED_SURFACE_AREA		  5.2 //m^2, surface area of 1.7m (H) x 0.46m (D) cylinder
 
-#define Clamp(x, y, z) 	(x <= y ? y : (x >= z ? z : x))
+#define Clamp(x, y, z) 	(x <= y ? y : (x >= z ? z : x)) // Ensures that a value (x) is within a specified range (y to z). If x is less than y, it returns y; if x is greater than z, it returns z; otherwise, it returns x. This effectively clamps the value of x within the range specified by y and z.
 #define CLAMP01(x) max(0, min(1, x))
 #define CLAMP0100(x) max(0, min(100, x))
 

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -455,12 +455,12 @@ proc/age2agedescription(age)
 		if (2 to 3)				return "toddler"
 		if (4 to 12)			return "child"
 		if (13 to 18)			return "teenager"
-        if (19 to 29)			return "young adult"
-        if (30 to 44)			return "adult"
-        if (45 to 59)			return "middle-aged"
-        if (60 to 69)			return "aging"
-        if (70 to INFINITY)		return "elderly"
-        else					return "unknown"
+		if (19 to 29)			return "young adult"
+		if (30 to 44)			return "adult"
+		if (45 to 59)			return "middle-aged"
+		if (60 to 69)			return "aging"
+		if (70 to INFINITY)		return "elderly"
+		else					return "unknown"
 
 proc/ageAndGender2Desc(age, gender) // Radio name getters.
 	if(!gender || !isnum(age))

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -435,7 +435,7 @@ proc/skintone2racedescription(tone)
 	if(!isnum(tone))
 		CRASH("skintone2racedescription; proc called without correct tone (integer) argument.")
 
-	switch (tone)
+	switch(tone)
 		if (30 to INFINITY)		return "albino"
 		if (20 to 29)			return "pale"
 		if (5 to 19)			return "light skinned"
@@ -450,11 +450,11 @@ proc/age2agedescription(age)
 	if(!isnum(age))
 		CRASH("age2agedescription; proc called without correct age (integer) argument.")
 
-    switch(age)
-        if (0 to 1)				return "infant"
-        if (2 to 3)				return "toddler"
-        if (4 to 12)			return "child"
-        if (13 to 18)			return "teenager"
+	switch(age)
+		if (0 to 1)				return "infant"
+		if (2 to 3)				return "toddler"
+		if (4 to 12)			return "child"
+		if (13 to 18)			return "teenager"
         if (19 to 29)			return "young adult"
         if (30 to 44)			return "adult"
         if (45 to 59)			return "middle-aged"

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -417,65 +417,69 @@ proc/random_afrikaans_name(gender, species = "Human")
 		return current_species.get_random_afrikaans_name(gender)
 
 proc/random_skin_tone()
+	switch(rand(1, 100))
+		if(1 to 60)  // 60% chance (caucasian)
+			. = -10
+		if(61 to 75) // 15% chance (mulatto)
+			. = -115
+		if(76 to 85) // 10% chance (african)
+			. = -165
+		if(86 to 95) // 10% chance (latino)
+			. = -55
+		if(96 to 100) // 5% chance (albino/pale)
+			. = 34
 
-	var/skin_tone = "caucasian"
-	if (prob(60))
-		pass()
-	else if (prob(15))
-		skin_tone = "mulatto"
-	else if (prob(10))
-		skin_tone = "african"
-	else if (prob(10))
-		skin_tone = "latino"
-
-	switch(skin_tone)
-		if ("caucasian")		. = -10
-		if ("mulatto")	. = -115
-		if ("african")		. = -165
-		if ("latino")		. = -55
-		else				. = rand(-185,34)
-	return min(max( .+rand(-25, 25), -185),34)
+	return Clamp(. + rand(-25, 25), -185, 34) // Clamp() keeps the rand(-25, 25) variation of skin tone between -185 to 34.
 
 proc/skintone2racedescription(tone)
+	if(!isnum(tone))
+		CRASH("skintone2racedescription; proc called without correct tone (integer) argument.")
+
 	switch (tone)
 		if (30 to INFINITY)		return "albino"
-		if (20 to 30)			return "pale"
-		if (5 to 15)				return "light skinned"
-		if (-10 to 5)			return "white"
-		if (-25 to -10)			return "tan"
-		if (-45 to -25)			return "darker skinned"
-		if (-65 to -45)			return "brown"
-		if (-INFINITY to -65)	return "black"
+		if (20 to 29)			return "pale"
+		if (5 to 19)			return "light skinned"
+		if (-10 to 4)			return "white"
+		if (-25 to -9)			return "tan"
+		if (-45 to -24)			return "darker skinned"
+		if (-65 to -44)			return "brown"
+		if (-INFINITY to -64)	return "black"
 		else					return "unknown"
 
 proc/age2agedescription(age)
-	switch(age)
-		if (0 to 1)			return "infant"
-		if (1 to 3)			return "toddler"
-		if (3 to 13)			return "child"
-		if (13 to 19)		return "teenager"
-		if (19 to 30)		return "young adult"
-		if (30 to 45)		return "adult"
-		if (45 to 60)		return "middle-aged"
-		if (60 to 70)		return "aging"
-		if (70 to INFINITY)	return "elderly"
-		else				return "unknown"
+	if(!isnum(age))
+		CRASH("age2agedescription; proc called without correct age (integer) argument.")
 
-proc/ageAndGender2Desc(age, gender)//Used for the radio
-	if (gender == FEMALE)
-		switch(age)
-			if (0 to 15)			return "Girl"
-			if (15 to 25)		return "Young Woman"
-			if (25 to 60)		return "Woman"
-			if (60 to INFINITY)	return "Old Woman"
-			else				return "Unknown"
-	else
-		switch(age)
-			if (0 to 15)			return "Boy"
-			if (15 to 25)		return "Young Man"
-			if (25 to 60)		return "Man"
-			if (60 to INFINITY)	return "Old Man"
-			else				return "Unknown"
+    switch(age)
+        if (0 to 1)				return "infant"
+        if (2 to 3)				return "toddler"
+        if (4 to 12)			return "child"
+        if (13 to 18)			return "teenager"
+        if (19 to 29)			return "young adult"
+        if (30 to 44)			return "adult"
+        if (45 to 59)			return "middle-aged"
+        if (60 to 69)			return "aging"
+        if (70 to INFINITY)		return "elderly"
+        else					return "unknown"
+
+proc/ageAndGender2Desc(age, gender) // Radio name getters.
+	if(!gender || !isnum(age))
+		CRASH("ageAndGender2Desc; proc called without age/gender argument.")
+
+	switch(gender)
+		if(MALE)
+			switch(age)
+				if (0 to 15)		return "Boy"
+				if (16 to 25)		return "Young Man"
+				if (26 to 60)		return "Man"
+				if (61 to INFINITY)	return "Old Man"
+		if(FEMALE)
+			switch(age)
+				if (0 to 15)		return "Girl"
+				if (16 to 25)		return "Young Woman"
+				if (26 to 60)		return "Woman"
+				if (61 to INFINITY)	return "Old Woman"
+	return "Unknown"
 
 proc/get_body_build(gender, body_build = "Default")
 	if (gender == MALE)

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -417,19 +417,14 @@ proc/random_afrikaans_name(gender, species = "Human")
 		return current_species.get_random_afrikaans_name(gender)
 
 proc/random_skin_tone()
-	switch(rand(1, 100))
-		if(1 to 60)  // 60% chance (caucasian)
-			. = -10
-		if(61 to 75) // 15% chance (mulatto)
-			. = -115
-		if(76 to 85) // 10% chance (african)
-			. = -165
-		if(86 to 95) // 10% chance (latino)
-			. = -55
-		if(96 to 100) // 5% chance (albino/pale)
-			. = 34
-
-	return Clamp(. + rand(-25, 25), -185, 34) // Clamp() keeps the rand(-25, 25) variation of skin tone between -185 to 34.
+	switch(pick(60;"caucasian", 15;"afroamerican", 10;"african", 10;"latino", 5;"albino"))
+		if("caucasian")		. = -10
+		if("afroamerican")	. = -115
+		if("african")		. = -165
+		if("latino")		. = -55
+		if("albino")		. = 34
+		else			. = rand(-185,34)
+	return min(max( .+rand(-25, 25), -185),34)
 
 proc/skintone2racedescription(tone)
 	if(!isnum(tone))
@@ -443,24 +438,24 @@ proc/skintone2racedescription(tone)
 		if (-25 to -9)			return "tan"
 		if (-45 to -24)			return "darker skinned"
 		if (-65 to -44)			return "brown"
-		if (-INFINITY to -64)	return "black"
-		else					return "unknown"
+		if (-INFINITY to -64)		return "black"
+		else				return "unknown"
 
 proc/age2agedescription(age)
 	if(!isnum(age))
 		CRASH("age2agedescription; proc called without correct age (integer) argument.")
 
 	switch(age)
-		if (0 to 1)				return "infant"
-		if (2 to 3)				return "toddler"
+		if (0 to 1)			return "infant"
+		if (2 to 3)			return "toddler"
 		if (4 to 12)			return "child"
-		if (13 to 18)			return "teenager"
-		if (19 to 29)			return "young adult"
+		if (13 to 17)			return "teenager"
+		if (18 to 29)			return "young adult"
 		if (30 to 44)			return "adult"
 		if (45 to 59)			return "middle-aged"
 		if (60 to 69)			return "aging"
 		if (70 to INFINITY)		return "elderly"
-		else					return "unknown"
+		else				return "unknown"
 
 proc/ageAndGender2Desc(age, gender) // Radio name getters.
 	if(!gender || !isnum(age))

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -458,22 +458,21 @@ proc/age2agedescription(age)
 		else				return "unknown"
 
 proc/ageAndGender2Desc(age, gender) // Radio name getters.
-	if(!gender || !isnum(age))
+	if (!gender || !isnum(age))
 		CRASH("ageAndGender2Desc; proc called without age/gender argument.")
 
-	switch(gender)
-		if(MALE)
-			switch(age)
-				if (0 to 15)		return "Boy"
-				if (16 to 25)		return "Young Man"
-				if (26 to 60)		return "Man"
-				if (61 to INFINITY)	return "Old Man"
-		if(FEMALE)
-			switch(age)
-				if (0 to 15)		return "Girl"
-				if (16 to 25)		return "Young Woman"
-				if (26 to 60)		return "Woman"
-				if (61 to INFINITY)	return "Old Woman"
+	if (gender == MALE)
+		switch(age)
+			if (0 to 15)		return "Boy"
+			if (16 to 25)		return "Young Man"
+			if (26 to 60)		return "Man"
+			if (61 to INFINITY)	return "Old Man"
+	else
+		switch(age)
+			if (0 to 15)		return "Girl"
+			if (16 to 25)		return "Young Woman"
+			if (26 to 60)		return "Woman"
+			if (61 to INFINITY)	return "Old Woman"
 	return "Unknown"
 
 proc/get_body_build(gender, body_build = "Default")


### PR DESCRIPTION
These procedures were established in `2010`, I've cleaned them up a bit for the best performance. Not that it matters that much.

![image](https://github.com/Civ13/Civ13/assets/131271192/385f9cad-657d-4665-a6c3-f89c84ee49ef)

### **_The switch instruction is MUCH more efficient than a lengthy "else-if" chain._**

> Once a matching switch condition is found, no further conditions will be tested.

* Adds a run-time `CRASH()` to alert of wrong arguments being called.

### **_Inclusivity error in the switches._**

Before this PR.
Switches were over-lapping.

```
switch(age)
        if(0 to 1)            return "infant"
        if(1 to 3)            return "toddler"
```

Here the first condition is checked, let's **assume** `age` is 1.

`age` is 1, therefore no further conditions will be tested.
This means that `toddler` would never get returned, however, it is also misleading.
I've corrected this by adjusting all numbers to be exclusive, rather than inclusive, in terms of the conditions.