### PR TITLE
Reduces overhead of to_chatting `browse()`s

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -62,7 +62,7 @@
 	var/filename
 	for (key in stylesheets)
 		filename = "[ckey(key)].css"
-		user << browse_rsc(stylesheets[key], filename))
+		user << browse_rsc(stylesheets[key], filename)
 		head_content += "<link rel='stylesheet' type='text/css' href='[filename]'>"
 
 	for (key in scripts)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -62,12 +62,12 @@
 	var/filename
 	for (key in stylesheets)
 		filename = "[ckey(key)].css"
-		to_chat(user, browse_rsc(stylesheets[key], filename))
+		user << browse_rsc(stylesheets[key], filename))
 		head_content += "<link rel='stylesheet' type='text/css' href='[filename]'>"
 
 	for (key in scripts)
 		filename = "[ckey(key)].js"
-		to_chat(user, browse_rsc(scripts[key], filename))
+		user << browse_rsc(scripts[key], filename))
 		head_content += "<script type='text/javascript' src='[filename]'></script>"
 
 	var/title_attributes = "class='uiTitle'"
@@ -104,12 +104,12 @@
 	var/window_size = ""
 	if (width && height)
 		window_size = "size=[width]x[height];"
-	to_chat(user, browse(get_content(), "window=[window_id];[window_size][window_options]"))
+	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
 	if (use_onclose)
 		onclose(user, window_id, ref)
 
 /datum/browser/proc/close()
-	to_chat(user, browse(null, "window=[window_id]"))
+	user << browse(null, "window=[window_id]")
 
 // This will allow you to show an icon in the browse window
 // This is added to mob so that it can be used without a reference to the browser object
@@ -136,7 +136,7 @@
 // e.g. canisters, timers, etc.
 //
 // windowid should be the specified window name
-// e.g. code is	: to_chat(user, browse(text, "window=fred")
+// e.g. code is	: user << browse(text, "window=fred")
 // then use 	: onclose(user, "fred")
 //
 // Optionally, specify the "ref" parameter as the controlled atom (usually src)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -67,7 +67,7 @@
 
 	for (key in scripts)
 		filename = "[ckey(key)].js"
-		user << browse_rsc(scripts[key], filename))
+		user << browse_rsc(scripts[key], filename)
 		head_content += "<script type='text/javascript' src='[filename]'></script>"
 
 	var/title_attributes = "class='uiTitle'"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -152,7 +152,7 @@
 	out += "<hr>"
 	out += "</table><hr>"
 
-	to_chat(usr, browse(out, "window=edit_memory[src]"))
+	usr << browse(out, "window=edit_memory[src]")
 
 /datum/mind/Topic(href, href_list)
 	if (!check_rights(R_ADMIN))	return

--- a/code/game/mob/groups/factions.dm
+++ b/code/game/mob/groups/factions.dm
@@ -564,6 +564,6 @@
 			</body></html>
 		"}
 
-		to_chat(usr, browse(body,"window=artillery_window;border=1;can_close=1;can_resize=1;can_minimize=0;titlebar=1;size=250x450"))
+		usr << browse(body,"window=artillery_window;border=1;can_close=1;can_resize=1;can_minimize=0;titlebar=1;size=250x450")
 	else
 		return

--- a/code/game/mob/groups/religions.dm
+++ b/code/game/mob/groups/religions.dm
@@ -561,6 +561,6 @@ obj/structure/altar/iron
 			</body></html>
 		"}
 
-		to_chat(usr, browse(body,"window=artillery_window;border=1;can_close=1;can_resize=1;can_minimize=0;titlebar=1;size=250x450"))
+		usr << browse(body,"window=artillery_window;border=1;can_close=1;can_resize=1;can_minimize=0;titlebar=1;size=250x450")
 	else
 		return

--- a/code/game/mob/living/carbon/carbon.dm
+++ b/code/game/mob/living/carbon/carbon.dm
@@ -440,7 +440,7 @@
 	<BR><A href='?src=\ref[user];refresh=1'>Refresh</A>
 	<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>
 	<BR>"}
-	to_chat(user, browse(dat, text("window=mob[];size=325x500", name)))
+	user << browse(dat, text("window=mob[];size=325x500", name))
 	onclose(user, "mob[name]")
 	return
 

--- a/code/game/mob/living/carbon/human/human.dm
+++ b/code/game/mob/living/carbon/human/human.dm
@@ -332,7 +332,7 @@ var/list/coefflist = list()
 	dat += "<BR><A href='?src=\ref[user];refresh=1'>Refresh</A>"
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
-	to_chat(user, browse(dat, text("window=mob[name];size=340x540")))
+	user << browse(dat, text("window=mob[name];size=340x540"))
 	onclose(user, "mob[name]")
 	return
 

--- a/code/game/mob/living/carbon/human/stripping.dm
+++ b/code/game/mob/living/carbon/human/stripping.dm
@@ -4,7 +4,7 @@
 		return
 
 	if (user.incapacitated()  || !user.Adjacent(src))
-		to_chat(user, browse(null, text("window=mob[name]")))
+		user << browse(null, text("window=mob[name]"))
 		return
 
 	var/obj/item/target_slot = get_equipped_item(text2num(slot_to_strip))

--- a/code/game/mob/mob.dm
+++ b/code/game/mob/mob.dm
@@ -469,7 +469,7 @@
 		to_chat(usr, SPAN_NOTICE("<b>You must be dead to use this!</b>"))
 		return
 
-	to_chat(src, browse(null, "window=memory"))
+	src << browse(null, "window=memory")
 
 	to_chat(src, "You can respawn now, enjoy your new life!")
 	stop_ambience(usr)
@@ -551,11 +551,11 @@
 	if (href_list["mach_close"])
 		var/t1 = text("window=[href_list["mach_close"]]")
 		unset_using_object()
-		to_chat(src, browse(null, t1))
+		src << browse(null, t1)
 
 	if (href_list["flavor_more"])
 		if (src in view(usr))
-			to_chat(usr, browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name)))
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
 			onclose(usr, "[name]")
 	if (href_list["flavor_change"])
 		update_flavor_text()

--- a/code/game/objects/items/clipboard.dm
+++ b/code/game/objects/items/clipboard.dm
@@ -87,7 +87,7 @@
 	for (var/obj/item/weapon/photo/Ph in src)
 		dat += "<A href='?src=\ref[src];remove=\ref[Ph]'>Remove</A> <A href='?src=\ref[src];rename=\ref[Ph]'>Rename</A> - <A href='?src=\ref[src];look=\ref[Ph]'>[Ph.name]</A><BR>"
 
-	to_chat(user, browse(dat, "window=clipboard"))
+	user << browse(dat, "window=clipboard")
 	onclose(user, "clipboard")
 	add_fingerprint(usr)
 	return

--- a/code/modules/1713/siege/turret.dm
+++ b/code/modules/1713/siege/turret.dm
@@ -141,7 +141,7 @@
 	if (using_turret)
 		using_turret.clear_aiming_line(src)
 		to_chat(src, SPAN_NOTICE("You have stopped using the [using_turret.name]."))
-		to_chat(src, browse(null, "window=artillery_window"))
+		src << browse(null, "window=artillery_window")
 		using_turret = null
 
 /obj/structure/turret/proc/place_user(var/mob/living/M)


### PR DESCRIPTION
* Removes `to_chat`s from browse elements, as it just makes performance worse.

> The only reason to do it is if you're doing operations to the string before passing it to the chat, and you're doing that across various different version of it (like how we have span, danger, etc.) so putting it in other parts of the code is detrimental