### PR TITLE
axis.dm small clean-up + limits structure crushing to heavy axis

### DIFF
--- a/code/game/objects/controls.dm
+++ b/code/game/objects/controls.dm
@@ -10,6 +10,7 @@
 	not_movable = TRUE
 	not_disassemblable = TRUE
 	layer = 3.01
+	crushable = FALSE
 
 /obj/structure/gatecontrol/blastcontrol
 	name = "blast door control"
@@ -153,6 +154,7 @@
 	var/maxhealth = 600
 	not_movable = TRUE
 	not_disassemblable = TRUE
+	crushable = FALSE
 
 /obj/structure/gate/open
 	name = "gate"
@@ -401,6 +403,7 @@
 	open = FALSE
 	var/cooldown = 0
 	bound_width = 64
+	crushable = TRUE
 
 /obj/structure/gate/barrier/vertical
 	name = "barrier gate"
@@ -557,6 +560,7 @@
 	density = FALSE
 	not_movable = TRUE
 	not_disassemblable = TRUE
+	crushable = FALSE
 	var/next_activation = -1
 
 /obj/structure/elevator_button/attack_hand(var/mob/user as mob)

--- a/code/game/objects/map_metadata/the_art_of_the_deal.dm
+++ b/code/game/objects/map_metadata/the_art_of_the_deal.dm
@@ -807,6 +807,7 @@
 	anchored = TRUE
 	not_disassemblable = TRUE
 	not_movable = TRUE
+	crushable = FALSE
 
 /obj/structure/redmailbox/attackby(obj/item/I,mob/living/human/H)
 	if (istype(I,/obj/item/stack/component) && istype(map, /obj/map_metadata/art_of_the_deal))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -4,6 +4,7 @@
 
 	var/climbable = FALSE
 	var/breakable = FALSE
+	var/crushable = TRUE // If the structure can be crushed by vehicles.
 	var/parts
 	var/list/climbers = list()
 	var/low = FALSE

--- a/code/game/objects/structures/barricades.dm
+++ b/code/game/objects/structures/barricades.dm
@@ -245,6 +245,7 @@
 	material_name = "stone"
 	protection_chance = 90
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/sandstone_v
 	name = "sandstone wall"
@@ -257,6 +258,7 @@
 	material_name = "stone"
 	protection_chance = 90
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/sandstone_h/crenelated
 	name = "crenelated sandstone wall"
@@ -378,6 +380,7 @@
 	maxhealth = 2709
 	material_name = "steel"
 	protection_chance = 50
+	crushable = FALSE
 
 /obj/structure/barricade/antitank/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/weapon/weldingtool))
@@ -401,6 +404,7 @@
 	maxhealth = 500
 	material_name = "stone"
 	protection_chance = 90
+	crushable = FALSE
 	New()
 		..()
 		icon_state = "debris[rand(1,4)]"
@@ -426,6 +430,7 @@
 	material_name = "stone"
 	protection_chance = 90
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/stone_v
 	name = "stone wall"
@@ -438,6 +443,7 @@
 	material_name = "stone"
 	protection_chance = 90
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/stone_h/crenelated
 	name = "crenelated stone wall"
@@ -566,6 +572,7 @@
 	material_name = "stone"
 	protection_chance = 100
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/jap_h/New()
 	..()
@@ -601,6 +608,7 @@
 	material_name = "stone"
 	protection_chance = 100
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/jap_h_l/New()
 	..()
@@ -636,6 +644,7 @@
 	material_name = "stone"
 	protection_chance = 100
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/jap_h_r/New()
 	..()
@@ -671,6 +680,7 @@
 	material_name = "stone"
 	protection_chance = 100
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/jap_v/New()
 	..()
@@ -706,6 +716,7 @@
 	material_name = "stone"
 	protection_chance = 100
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/jap_v_t/New()
 	..()
@@ -741,6 +752,7 @@
 	material_name = "stone"
 	protection_chance = 100
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/jap_v_b/New()
 	..()
@@ -791,6 +803,7 @@
 	protection_chance = 100
 	opacity = TRUE
 	density = TRUE
+	crushable = FALSE
 
 /obj/structure/barricade/hescobastion/New()
 	..()
@@ -896,6 +909,7 @@
 	protection_chance = 80
 	bound_width = 64
 	layer = MOB_LAYER + 0.4
+	crushable = FALSE
 
 /obj/structure/barricade/car/New()
 	..()
@@ -917,6 +931,7 @@
 	var/adjusts = TRUE
 	applies_material_colour = FALSE
 	can_damage = FALSE
+	crushable = FALSE
 
 /obj/structure/barricade/jap/check_relatives(var/update_self = FALSE, var/update_others = FALSE)
 	if (!adjusts)
@@ -984,3 +999,4 @@
 	adjusts = TRUE
 	layer = MOB_LAYER + 0.1
 	can_damage = FALSE
+	crushable = FALSE

--- a/code/game/objects/structures/sign_flags.dm
+++ b/code/game/objects/structures/sign_flags.dm
@@ -208,6 +208,7 @@
 	name = "STOP sign"
 	desc = ""
 	icon_state = "stop"
+	crushable = FALSE // To preserve map decorations
 
 /obj/structure/sign/traffic/stop
 

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -561,6 +561,7 @@
 	layer = MOB_LAYER + 0.1
 	bound_width = 64
 	bound_height = 64
+	crushable = FALSE
 	var/adnumber
 
 /obj/structure/billboard/Destroy()

--- a/code/modules/1713/machinery/cables.dm
+++ b/code/modules/1713/machinery/cables.dm
@@ -45,6 +45,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/list/connections = list()
 	not_movable = FALSE
 	not_disassemblable = FALSE
+	crushable = FALSE
 	var/lastupdate = 0 //to prevent loops. Can only update once per decisecond. For turning on/off.
 	var/lastupdate2 = 0 //to prevent loops. Can only update once per decisecond. For power calculations.
 	var/cable_color = "red"

--- a/code/modules/1713/machinery/modular_vehicles/axis.dm
+++ b/code/modules/1713/machinery/modular_vehicles/axis.dm
@@ -466,26 +466,25 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 				FM.mwheel = MV
 	for(var/obj/structure/vehicleparts/movement/MV in wheels)
 		//Front-Right, Front-Left, Back-Right,Back-Left; FR, FL, BR, BL
-		switch(MV.connected)
-			if (corners[1])
-				MV.reversed = FALSE
-			if (corners[2])
-				if (MV.ntype == "wheel")
-					MV.reversed = TRUE
-				else
-					MV.reversed = FALSE
-			if (corners[3])
-				if (MV.ntype == "wheel")
-					MV.reversed = TRUE
-				else
-					MV.reversed = FALSE
-			if (corners[4])
-				if (MV.ntype == "wheel")
-					MV.reversed = TRUE
-				else
-					MV.reversed = TRUE
+		if (MV.connected == corners[1])
+			MV.reversed = FALSE
+		else if (MV.connected == corners[2])
+			if (MV.ntype == "wheel")
+				MV.reversed = TRUE
 			else
-				return
+				MV.reversed = FALSE
+		else if (MV.connected == corners[3])
+			if (MV.ntype == "wheel")
+				MV.reversed = TRUE
+			else
+				MV.reversed = FALSE
+		else if (MV.connected == corners[4])
+			if (MV.ntype == "wheel")
+				MV.reversed = TRUE
+			else
+				MV.reversed = TRUE
+		else
+			return
 
 		if (MV.reversed)
 			MV.dir = OPPOSITE_DIR(dir)

--- a/code/modules/1713/machinery/modular_vehicles/axis.dm
+++ b/code/modules/1713/machinery/modular_vehicles/axis.dm
@@ -23,7 +23,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 	for(var/obj/structure/vehicleparts/frame/F in components)
 		F.axis = null
 	wheel = null
-	visible_message("<span class='danger'>The [name] axis gets wrecked!</span>")
+	visible_message(SPAN_DANGER("The [name] axis gets wrecked!"))
 	qdel(src)
 */
 /obj/structure/vehicleparts/axis/proc/startmovementloop()
@@ -94,7 +94,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 			return FALSE
 		for(var/obj/structure/vehicleparts/movement/MV in wheels)
 			if (MV.broken)
-				visible_message("<span class = 'warning'>\The [name] can't move, a [MV.ntype] is broken!</span>")
+				visible_message(SPAN_WARNING("\The [name] can't move, a [MV.ntype] is broken!"))
 				moving = FALSE
 				stopmovementloop()
 				return FALSE
@@ -113,12 +113,12 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 			var/area/A = get_area(T)
 			if (map && A && map.caribbean_blocking_area_types.Find(A.type))
 				if (!map.faction1_can_cross_blocks() && !map.faction2_can_cross_blocks())
-					visible_message("<span class = 'danger'>You cannot cross the grace wall yet!</span>")
+					visible_message(SPAN_DANGER("You cannot cross the grace wall yet!"))
 					moving = FALSE
 					stopmovementloop()
 					return FALSE
 			if (map && map.check_caribbean_block(driver,T))
-				visible_message("<span class = 'danger'>You cannot cross the grace wall yet!</span>")
+				visible_message(SPAN_DANGER("You cannot cross the grace wall yet!"))
 				moving = FALSE
 				stopmovementloop()
 				return FALSE
@@ -133,7 +133,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 					MAT.trigger(FR)
 				else
 					qdel(MAT)
-					visible_message("<span class='warning'>\The [src] crushes \the [MAT]!</span>","<span class='warning'>You crush \the [MAT]!</span>")
+					visible_message(SPAN_WARNING("\The [src] crushes \the [MAT]!"),SPAN_WARNING("You crush \the [MAT]!"))
 			for (var/obj/item/mine/boobytrap/MAT in T)
 				if (MAT.anchored)
 					qdel(MAT)
@@ -161,7 +161,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 					protec = TRUE
 				if (!protec)
 					if (current_weight >= 800)
-						visible_message("<span class='warning'>\The [src] runs over \the [L]!</span>","<span class='warning'>You run over \the [L]!</span>")
+						visible_message(SPAN_WARNING("\The [src] runs over \the [L]!"),SPAN_WARNING("You run over \the [L]!"))
 						for(var/obj/item/I in L)
 							qdel(I)
 						L.crush()
@@ -172,16 +172,16 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 							var/mob/living/human/HH = L
 							HH.adjustBruteLoss(rand(7,16)*abs(currentspeed))
 							HH.Weaken(rand(2,5))
-							visible_message("<span class='warning'>\The [src] hits \the [L]!</span>","<span class='warning'>You hit \the [L]!</span>")
+							visible_message(SPAN_WARNING("\The [src] hits \the [L]!"),SPAN_WARNING("You hit \the [L]!"))
 							L.forceMove(get_turf(get_step(TT,dir)))
 						else if (istype(L,/mob/living/simple_animal))
 							var/mob/living/simple_animal/SA = L
 							SA.adjustBruteLoss(rand(7,16)*abs(currentspeed))
 							if (SA.mob_size >= 30)
-								visible_message("<span class='warning'>\The [src] hits \the [SA]!</span>","<span class='warning'>You hit \the [SA]!</span>")
+								visible_message(SPAN_WARNING("\The [src] hits \the [SA]!"),SPAN_WARNING("You hit \the [SA]!"))
 								L.forceMove(get_turf(get_step(TT,dir)))
 							else
-								visible_message("<span class='warning'>\The [src] runs over \the [SA]!</span>","<span class='warning'>You run over \the [SA]!</span>")
+								visible_message(SPAN_WARNING("\The [src] runs over \the [SA]!"),SPAN_WARNING("You run over \the [SA]!"))
 								for(var/obj/item/I in SA)
 									qdel(I)
 								SA.crush()
@@ -191,31 +191,31 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 				for (var/obj/structure/vehicleparts/frame/FM in O.loc)
 					done = TRUE
 					if (FM.axis != src)
-						visible_message("<span class='warning'>\The [src] hits \the [O]!</span>","<span class='warning'>You hit \the [O]!</span>")
+						visible_message(SPAN_WARNING("\The [src] hits \the [O]!"),SPAN_WARNING("You hit \the [O]!"))
 						moving = FALSE
 						stopmovementloop()
 						return FALSE
 				if (!done)
-					if (O.density == TRUE && !(O in transporting))
-						if (current_weight >= 400 && !istype(O, /obj/structure/redmailbox) && !istype(O, /obj/structure/barricade/antitank) && !istype(O, /obj/structure/vehicleparts/frame)&& !istype(O, /obj/structure/vehicleparts/movement)&& !istype(O, /obj/structure/barricade/stone_h)&& !istype(O, /obj/structure/barricade/stone_v)&& !istype(O, /obj/structure/barricade/jap_h) && !istype(O, /obj/structure/barricade/jap_v)&& !istype(O, /obj/structure/barricade/jap_h_l)&& !istype(O, /obj/structure/barricade/jap_h_r)&& !istype(O, /obj/structure/barricade/jap_v_b)&& !istype(O, /obj/structure/barricade/jap_v_t)&& !istype(O, /obj/structure/barricade/sandstone_h)&& !istype(O, /obj/structure/barricade/sandstone_v)&& !istype(O, /obj/structure/barricade/sandstone_v/crenelated)&& !istype(O, /obj/structure/barricade/sandstone_h/crenelated)&& !istype(O, /obj/structure/barricade/stone_v/crenelated) && !istype(O, /obj/structure/gate) && !istype(O, /obj/structure/billboard))
-							visible_message("<span class='warning'>\The [src] crushes \the [O]!</span>","<span class='warning'>You crush \the [O]!</span>")
+					if (O.density && !(O in transporting))
+						if (O.crushable && istype(src, /obj/structure/vehicleparts/axis/heavy))
+							visible_message(SPAN_WARNING("\The [src] crushes \the [O]!"),SPAN_WARNING("You crush \the [O]!"))
 							qdel(O)
 						else
-							visible_message("<span class='warning'>\The [src] hits \the [O]!</span>","<span class='warning'>You hit \the [O]!</span>")
+							visible_message(SPAN_WARNING("\The [src] hits \the [O]!"),SPAN_WARNING("You hit \the [O]!"))
 							return FALSE
-					else if (O.density == FALSE && !(O in transporting))
-						if (!istype(O, /obj/structure/sign/traffic/zebracrossing) && !istype(O, /obj/structure/sign/traffic/central) && !istype(O, /obj/structure/sign/traffic/side) && !istype(O, /obj/structure/sign/traffic/side) && !istype(O, /obj/structure/rails) && !istype(O, /obj/structure/cable) && !istype(O, /obj/structure/gate) && !istype(O, /obj/structure/lamp/lamppost_small/) && !istype(O, /obj/structure/lamp/lamp_big/alwayson) && !istype(O, /obj/structure/lamp/lamp_small/alwayson))
-	//						visible_message("<span class='warning'>\the [src] crushes \the [O]!</span>","<span class='warning'>You crush \the [O]!</span>")
+					else if (!O.density && !(O in transporting))
+						if (O.crushable)
+	//						visible_message(SPAN_WARNING("\the [src] crushes \the [O]!"),SPAN_WARNING("You crush \the [O]!"))
 							qdel(O)
 
-			if (T.density == TRUE)
-				visible_message("<span class='warning'>\The [src] hits \the [T]!</span>","<span class='warning'>You hit \the [T]!</span>")
+			if (T.density)
+				visible_message(SPAN_WARNING("\The [src] hits \the [T]!"),SPAN_WARNING("You hit \the [T]!"))
 				moving = FALSE
 				stopmovementloop()
 				return FALSE
 			for(var/obj/covers/CV in T)
 				if (CV.density)
-					visible_message("<span class='warning'>\the [src] hits \the [CV]!</span>","<span class='warning'>You hit \the [CV]!</span>")
+					visible_message(SPAN_WARNING("\the [src] hits \the [CV]!"),SPAN_WARNING("You hit \the [CV]!"))
 					moving = FALSE
 					stopmovementloop()
 					return FALSE
@@ -228,7 +228,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 				qdel(BO)
 			var/canpass = FALSE
 			for(var/obj/covers/CVV in T)
-				if (CVV.density == FALSE)
+				if (!CVV.density)
 					canpass = TRUE
 			if ((!istype(T, /turf/floor/beach/water/deep) ||  istype(T, /turf/floor/beach/water/deep) && canpass == TRUE) && T.density == FALSE  || istype(T, /turf/floor/trench/flooded))
 				canpass = TRUE
@@ -241,6 +241,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 		moving = FALSE
 		stopmovementloop()
 		return FALSE
+
 /obj/structure/vehicleparts/axis/proc/check_engine()
 	if (!engine)
 		return FALSE
@@ -248,7 +249,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 		engine.on = FALSE
 		return FALSE
 	else if (get_weight() > engine.maxpower*2 || get_weight() > maxpower)
-		visible_message("<span class='warning'>\The [engine] struggles and stalls!</span>")
+		visible_message(SPAN_WARNING("\The [engine] struggles and stalls!"))
 		return FALSE
 	else
 		if (engine && engine.fueltank && engine.fueltank.reagents && engine.fueltank.reagents.total_volume <= 0)
@@ -310,17 +311,17 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 					MAT.trigger(F)
 				else
 					qdel(MAT)
-					visible_message("<span class='warning'>\The [src] crushes \the [MAT]!</span>","<span class='warning'>You crush \the [MAT]!</span>")
+					visible_message(SPAN_WARNING("\The [src] crushes \the [MAT]!"),SPAN_WARNING("You crush \the [MAT]!"))
 			if (istype(M, /obj/item/mine/boobytrap))
 				var/obj/item/mine/boobytrap/BAT = M
 				if (BAT.anchored)
 					qdel(BAT)
-					visible_message("<span class='warning'>\The [src] crushes \the [BAT]!</span>","<span class='warning'>You crush \the [BAT]!</span>")
+					visible_message(SPAN_WARNING("\The [src] crushes \the [BAT]!"),SPAN_WARNING("You crush \the [BAT]!"))
 			if (istype(M, /obj/item/mine/ap))
 				var/obj/item/mine/ap/BAT = M
 				if (BAT.anchored)
 					qdel(BAT)
-					visible_message("<span class='warning'>\The [src] crushes \the [BAT]!</span>","<span class='warning'>You crush \the [BAT]!</span>")
+					visible_message(SPAN_WARNING("\The [src] crushes \the [BAT]!"),SPAN_WARNING("You crush \the [BAT]!"))
 			if ((istype(M, /mob/living) || istype(M, /obj/structure) || istype(M, /obj/item)) && !(M in transporting))
 				if (!istype(M, /obj/structure/sign/traffic/zebracrossing) && !istype(M, /obj/structure/sign/traffic/side) && !istype(M, /obj/structure/sign/traffic/central) && !istype(M, /obj/structure/rails) && !istype(M, /obj/structure/cable) && !istype(M, /obj/structure/redmailbox) && !istype(M, /obj/structure/gate) && !istype(M, /obj/structure/lamp/lamppost_small/) && !istype(M, /obj/structure/lamp/lamp_big/alwayson) && !istype(M, /obj/structure/lamp/lamp_small/alwayson) && !istype(M, /obj/structure/billboard))
 					transporting += M
@@ -404,6 +405,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 				matrix["[disx+1],[disy+1]"] = list(PV, disy+1, disx+1,"[disy+1],[disx+1]")
 
 	return TRUE
+
 /obj/structure/vehicleparts/axis/proc/check_corners()
 	corners = list(null, null, null, null) //Front-Right, Front-Left, Back-Right,Back-Left; FR, FL, BR, BL
 	for (var/obj/structure/vehicleparts/frame/F in components)
@@ -416,41 +418,45 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 					sides = "[sides][i]"
 		if (length(sides) == 2)
 			if (findtext(sides,"1") && findtext(sides,"4")) //SW corner
-				if (dir == SOUTH) //FR
-					corners[1] = F
-				else if (dir == NORTH) //BL
-					corners[4] = F
-				else if  (dir == WEST) //FL
-					corners[2] = F
-				else if (dir == EAST) // BR
-					corners[3] = F
+				switch(dir)
+					if (SOUTH) //FR
+						corners[1] = F
+					if (NORTH) //BL
+						corners[4] = F
+					if (WEST) //FL
+						corners[2] = F
+					if (EAST) // BR
+						corners[3] = F
 			if (findtext(sides,"1") && findtext(sides,"8")) //SE corner
-				if (dir == SOUTH) //FL
-					corners[2] = F
-				else if (dir == NORTH) //BR
-					corners[3] = F
-				else if  (dir == WEST) //BL
-					corners[4] = F
-				else if (dir == EAST) // FR
-					corners[1] = F
+				switch(dir)
+					if (SOUTH) //FL
+						corners[2] = F
+					if (NORTH) //BR
+						corners[3] = F
+					if (WEST) //BL
+						corners[4] = F
+					if (EAST) // FR
+						corners[1] = F
 			if (findtext(sides,"2") && findtext(sides,"4")) //NW corner
-				if (dir == SOUTH) //BR
-					corners[3] = F
-				else if (dir == NORTH) //FL
-					corners[2] = F
-				else if  (dir == WEST) //FR
-					corners[1] = F
-				else if (dir == EAST) // BL
-					corners[4] = F
+				switch(dir)
+					if (SOUTH) //BR
+						corners[3] = F
+					if (NORTH) //FL
+						corners[2] = F
+					if (WEST) //FR
+						corners[1] = F
+					if (EAST) // BL
+						corners[4] = F
 			if (findtext(sides,"2") && findtext(sides,"8")) //NE corner
-				if (dir == SOUTH) //BL
-					corners[4] = F
-				else if (dir == NORTH) //FR
-					corners[1] = F
-				else if  (dir == WEST) //BR
-					corners[3] = F
-				else if (dir == EAST) // FL
-					corners[2] = F
+				switch(dir)
+					if (SOUTH) //BL
+						corners[4] = F
+					if (NORTH) //FR
+						corners[1] = F
+					if (WEST) //BR
+						corners[3] = F
+					if (EAST) // FL
+						corners[2] = F
 	maxdist=1+max(abs(corners[1].x-corners[2].x),abs(corners[1].y-corners[3].y),abs(corners[1].y-corners[2].y),abs(corners[1].x-corners[3].x))
 	for(var/obj/structure/vehicleparts/frame/FM in components)
 		for(var/obj/structure/vehicleparts/movement/MV in wheels)
@@ -460,25 +466,26 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 				FM.mwheel = MV
 	for(var/obj/structure/vehicleparts/movement/MV in wheels)
 		//Front-Right, Front-Left, Back-Right,Back-Left; FR, FL, BR, BL
-		if (MV.connected == corners[1])
-			MV.reversed = FALSE
-		else if (MV.connected == corners[2])
-			if (MV.ntype == "wheel")
-				MV.reversed = TRUE
-			else
+		switch(MV.connected)
+			if (corners[1])
 				MV.reversed = FALSE
-		else if (MV.connected == corners[3])
-			if (MV.ntype == "wheel")
-				MV.reversed = TRUE
+			if (corners[2])
+				if (MV.ntype == "wheel")
+					MV.reversed = TRUE
+				else
+					MV.reversed = FALSE
+			if (corners[3])
+				if (MV.ntype == "wheel")
+					MV.reversed = TRUE
+				else
+					MV.reversed = FALSE
+			if (corners[4])
+				if (MV.ntype == "wheel")
+					MV.reversed = TRUE
+				else
+					MV.reversed = TRUE
 			else
-				MV.reversed = FALSE
-		else if (MV.connected == corners[4])
-			if (MV.ntype == "wheel")
-				MV.reversed = TRUE
-			else
-				MV.reversed = TRUE
-		else
-			return
+				return
 
 		if (MV.reversed)
 			MV.dir = OPPOSITE_DIR(dir)
@@ -574,35 +581,35 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 						var/obj/structure/vehicleparts/frame/ship/FRM = O
 						if (FRM.axis != src)
 							if (user)
-								user << "<span class = 'warning'>You can't turn in that direction, the way is blocked by [FRM]!</span>"
+								to_chat(user, SPAN_WARNING("You can't turn in that direction, the way is blocked by [FRM]!"))
 							return FALSE
 					if (istype(O, /obj/structure/vehicleparts/frame))
 						var/obj/structure/vehicleparts/frame/FRM = O
 						if (FRM.axis != src)
 							if (user)
-								user << "<span class = 'warning'>You can't turn in that direction, the way is blocked by [FRM]!</span>"
+								to_chat(user, SPAN_WARNING("You can't turn in that direction, the way is blocked by [FRM]!"))
 							return FALSE
 					else if (istype(O, /obj/structure/barricade))
 						var/obj/structure/barricade/B = O
 						if(B.density > 0 && B.health > 600)
 							if (user)
-								user << "<span class = 'warning'>You can't turn in that direction, the way is blocked by [B]!</span>"
+								to_chat(user, SPAN_WARNING("You can't turn in that direction, the way is blocked by [B]!"))
 							return FALSE
 					else if (istype(O, /obj/covers))
 						if(O.density)
 							if (user)
-								user << "<span class = 'warning'>You can't turn in that direction, the way is blocked by [O]!</span>"
+								to_chat(user, SPAN_WARNING("You can't turn in that direction, the way is blocked by [O]!"))
 							return 
 					else if (istype(O, /obj/structure/barricade))
 						var/obj/structure/barricade/B = O
 						if(B.density > 0 && B.health > 600)
 							if (user)
-								user << "<span class = 'warning'>You can't turn in that direction, the way is blocked!</span>"
+								to_chat(user, SPAN_WARNING("You can't turn in that direction, the way is blocked!"))
 							return FALSE
 					else if (istype(O, /obj/covers))
 						if(O.density)
 							if (user)
-								user << "<span class = 'warning'>You can't turn in that direction, the way is blocked!</span>"
+								to_chat(user, SPAN_WARNING("You can't turn in that direction, the way is blocked!"))
 							return FALSE
 					else
 						todestroy += O
@@ -690,17 +697,17 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 	if (!ishuman(H))
 		return
 	for(var/obj/structure/vehicleparts/frame/F1 in get_turf(get_step(src, WEST)))
-		H << "<span class='notice'>The axis needs to be placed at the <b>TOP LEFT</b> corner!</span>"
+		to_chat(H, SPAN_NOTICE("The axis needs to be placed at the <b>TOP LEFT</b> corner!"))
 		return
 	for(var/obj/structure/vehicleparts/frame/F2 in get_turf(get_step(src, NORTH)))
-		H << "<span class='notice'>The axis needs to be placed at the <b>TOP LEFT</b> corner!</span>"
+		to_chat(H, SPAN_NOTICE("The axis needs to be placed at the <b>TOP LEFT</b> corner!"))
 		return
 	for(var/obj/structure/vehicleparts/frame/ship/SH in range(4,src))
 		var/turf/TT = get_turf(SH)
 		if (!istype(TT, /turf/floor/beach/water) && !istype(TT, /turf/floor/trench/flooded))
-			H << "<span class='notice'>All ship parts must be in a water tile.</span>"
+			to_chat(H, SPAN_WARNING("All ship parts must be on a water tile."))
 			return
-	var/inp = WWinput(H, "Are you sure you wan't to assemble a vehicle here? This has to be the top left corner.", "Vehicle Assembly", "No", list("No", "Yes"))
+	var/inp = WWinput(H, "Are you sure that you want to assemble a vehicle here? This has to be the <b>top-left</b> corner of the vehicle.", "Vehicle Assembly", "No", list("No", "Yes"))
 	if (inp == "No")
 		return
 	for(var/obj/structure/vehicleparts/frame/F in loc)
@@ -754,7 +761,7 @@ var/global/list/tank_names_nato = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 				chooseturret += "_turret"
 		dir = 1
 		new/obj/effect/autoassembler(locate(x+2,y-2,z))
-		H << "<span class='warning'>Vehicle assembled.</span>"
+		to_chat(H, SPAN_NOTICE("Vehicle assembled."))
 		for (var/obj/O in components)
 			O.update_icon()
 		return

--- a/code/modules/1713/machinery/modular_vehicles/frame.dm
+++ b/code/modules/1713/machinery/modular_vehicles/frame.dm
@@ -28,6 +28,7 @@
 	var/override_frame_icon = null
 	not_movable = TRUE
 	not_disassemblable = TRUE
+	crushable = FALSE
 	var/broken = FALSE
 	var/override_color = null
 	var/hasoverlay = null

--- a/code/modules/1713/machinery/modular_vehicles/movement.dm
+++ b/code/modules/1713/machinery/modular_vehicles/movement.dm
@@ -6,6 +6,7 @@
 	var/base_icon = "wheel_t_dark"
 	var/movement_icon = "wheel_t_dark_m"
 	layer = 2.99
+	crushable = FALSE
 	var/reversed = FALSE
 	var/obj/structure/vehicleparts/axis/axis = null
 	var/obj/structure/vehicleparts/frame/connected = null

--- a/code/modules/1713/modern_items.dm
+++ b/code/modules/1713/modern_items.dm
@@ -12,6 +12,7 @@
 	var/on = FALSE
 	not_movable = FALSE
 	not_disassemblable = TRUE
+	crushable = FALSE
 	powerneeded = 2
 	var/light_amt = 6 //light range
 	layer = 3.95

--- a/code/modules/1713/structures.dm
+++ b/code/modules/1713/structures.dm
@@ -903,6 +903,7 @@
 	bound_width = 128
 	bound_height = 128
 	bound_x = 32
+	crushable = FALSE
 
 /obj/structure/broken_hind_tail
 	name = "helicopter tail"
@@ -918,6 +919,7 @@
 	bound_width = 128
 	bound_height = 128
 	bound_x = 32
+	crushable = FALSE
 
 /obj/structure/props/marketstall
 	name = "market stall"
@@ -981,6 +983,7 @@
 	density = TRUE
 	opacity = TRUE
 	anchored = TRUE
+	crushable = FALSE
 
 /obj/structure/flag
 	icon = 'icons/obj/flags.dmi'
@@ -993,6 +996,7 @@
 	flammable = TRUE
 	not_movable = FALSE
 	not_disassemblable = TRUE
+	crushable = FALSE
 
 /obj/structure/flag/ex_act(severity)
 	switch(severity)
@@ -1583,6 +1587,7 @@
 	layer = 5
 	density = FALSE
 	anchored = TRUE
+	crushable = FALSE
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////TORCH STAND/////////////////////////////////////////////
@@ -1601,6 +1606,7 @@
 	var/obj/item/weapon/storage/internal/storage
 	var/max_storage = 3
 	var/brightness_on = 5 //luminosity when on
+	crushable = FALSE
 
 /obj/structure/torch_stand/update_icon()
 	if (dir == 1)
@@ -1711,6 +1717,7 @@
 	not_disassemblable = TRUE
 	bound_width = 96
 	bound_height = 64
+	crushable = FALSE
 
 /obj/structure/cargo_container/New()
 	var/number = rand(1,5)
@@ -1729,6 +1736,7 @@
 	not_disassemblable = TRUE
 	bound_width = 96
 	bound_height = 96
+	crushable = FALSE
 
 /obj/structure/machinery/construction_crane
 	name = "crane"
@@ -1741,6 +1749,7 @@
 	not_disassemblable = TRUE
 	bound_width = 64
 	bound_height = 64
+	crushable = FALSE
 
 /obj/structure/machinery/construction_crane/New()
 	if (dir == NORTH || dir == EAST)//Need to find another way to displace bounds than bound_x;bound_y
@@ -1766,6 +1775,7 @@
 	not_disassemblable = TRUE
 	bound_width = 64
 	bound_height = 64
+	crushable = FALSE
 
 /obj/structure/machinery/construction_crane/New()
 	if (dir == NORTH || dir == EAST)//Need to find another way to displace bounds than bound_x;bound_y
@@ -1787,6 +1797,7 @@
 	not_disassemblable = TRUE
 	bound_width = 64
 	bound_height = 128
+	crushable = FALSE
 
 /obj/structure/radome
 	name = "radio dome"
@@ -1799,6 +1810,7 @@
 	not_disassemblable = TRUE
 	bound_width = 128
 	bound_height = 128
+	crushable = FALSE
 
 /obj/structure/medical_divider
 	name = "medical divider"
@@ -1806,8 +1818,10 @@
 	icon_state = "medical_divider_half"
 	density = FALSE
 	flammable = TRUE
+	anchored = TRUE
 
 /obj/structure/medical_divider/full
 	icon_state = "medical_divider_full"
 	density = TRUE
 	flammable = TRUE
+	anchored = TRUE

--- a/code/modules/1713/trains.dm
+++ b/code/modules/1713/trains.dm
@@ -8,6 +8,7 @@
 	opacity = FALSE
 	not_movable = TRUE
 	not_disassemblable = FALSE
+	crushable = FALSE
 	flammable = FALSE
 	layer = 2.5
 	var/switched = "forward"


### PR DESCRIPTION
- Light cars can't crush structures anymore, only tanks and APCs (or any vehicle contaning the "axis/heavy "subtype). This is done to reduce cars potentials as griefing machines (which they already can be used as...)
- Adds a "crushable" variable to structures, set to TRUE by default, any structure that needs prevention from crushing (because it's a barricade, wall or just for decoration preservation purposes needs it to be set to FALSE in their code or during mapping)

TO-DO:
- Fix up the "add_transporting" proc and the "todestroy" list in the do_matrix proc, which are exploit and bug friendly.
- Clean up other vehicle-related .dms