### PR TITLE
Remove an unreachable `else` in a switch of a global proc.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -423,7 +423,6 @@ proc/random_skin_tone()
 		if("african")		. = -165
 		if("latino")		. = -55
 		if("albino")		. = 34
-		else			. = rand(-185,34)
 	return clamp(. + rand(-25, 25), -185, 34) // Clamp() keeps the rand(-25, 25) variation of skin tone between -185 to 34.
 
 proc/skintone2racedescription(tone)


### PR DESCRIPTION
code\_helpers\mobs.dm

`proc/random_skin_tone` HAD an unreachable else.

This has been fixed.