### PR TITLE
Performance fixes: remove hot-path world scans, throttle Life() costs

### DIFF
--- a/civ13.dme
+++ b/civ13.dme
@@ -7,7 +7,6 @@
 #define FILE_DIR .
 // END_FILE_DIR
 // BEGIN_PREFERENCES
-#define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "code\__byond_version_compat.dm"

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -4,9 +4,8 @@
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
 
 // Comment this out if you are debugging problems that might be obscured by custom error handling in world/Error
-#ifdef DEBUG
+// (defined unconditionally so runtime logging keeps working in non-DEBUG production builds)
 #define USE_CUSTOM_ERROR_HANDLER
-#endif
 
 #ifdef TESTING
 #define DATUMVAR_DEBUGGING_MODE

--- a/code/game/mob/living/carbon/human/traits.dm
+++ b/code/game/mob/living/carbon/human/traits.dm
@@ -14,7 +14,7 @@
 		for (var/t in traits)
 			trait_cache[t] = TRUE
 		traits_dirty = FALSE
-	if (trait_cache[tt])
+	if (tt in trait_cache)
 		return TRUE
 var/global/list/trait_list = list(
 //	"Lactose Intolerance" = list(-1,list(),"You have the inability to digest dairy products and will get sick when you ingest them. (Get food poisoning from anytype of milk product)"),

--- a/code/game/mob/living/carbon/human/traits.dm
+++ b/code/game/mob/living/carbon/human/traits.dm
@@ -1,11 +1,20 @@
 /mob
 	var/list/traits = list()
+	// assoc cache so find_trait() is a hash lookup instead of a list scan;
+	// anything that changes 'traits' after spawn must set traits_dirty = TRUE
+	var/tmp/list/trait_cache = null
+	var/tmp/traits_dirty = TRUE
 //name = cost, exclusions, description
 
 /mob/proc/find_trait(var/tt = null)
 	if (!tt)
 		return FALSE
-	if (tt in traits)
+	if (traits_dirty || !trait_cache)
+		trait_cache = list()
+		for (var/t in traits)
+			trait_cache[t] = TRUE
+		traits_dirty = FALSE
+	if (trait_cache[tt])
 		return TRUE
 var/global/list/trait_list = list(
 //	"Lactose Intolerance" = list(-1,list(),"You have the inability to digest dairy products and will get sick when you ingest them. (Get food poisoning from anytype of milk product)"),

--- a/code/game/mob/living/life.dm
+++ b/code/game/mob/living/life.dm
@@ -1,5 +1,8 @@
 /mob/living/var/next_weather_sound = -1
 /mob/living/var/last_life_tick = 0
+/mob/living/var/next_weather_scan = 0
+/mob/living/var/cached_near_rainy_area = FALSE
+/mob/living/var/cached_rain_dist = 100
 /mob/living/Life()
 
 	..()
@@ -13,16 +16,29 @@
 
 		var/near_rainy_area = FALSE
 		var/rdist = 100
-		var/area/A = get_area(src)
-		if (A && A.weather == WEATHER_WET && findtext(A.icon_state,"rain"))
-			near_rainy_area = TRUE
-			rdist = 0
-		else
-			for (var/turf/T in view(7, src))
-				var/area/T_area = get_area(T)
-				if (T_area.weather == WEATHER_WET && findtext(T_area.icon_state,"rain"))
-					near_rainy_area = TRUE
-					rdist = min(rdist, get_dist(src, T))
+		// areas only get rainy icon_states while the global weather is wet/extreme,
+		// so we can skip all of this the rest of the time
+		if (weather == WEATHER_WET || weather == WEATHER_EXTREME)
+			var/area/A = get_area(src)
+			if (A && A.weather == WEATHER_WET && findtext(A.icon_state,"rain"))
+				near_rainy_area = TRUE
+				rdist = 0
+			else if (world.time >= next_weather_scan)
+				// the view(7) scan covers ~200 turfs; doing it every Life tick for
+				// every player is too expensive, so rescan at most every 5 seconds
+				next_weather_scan = world.time + 50
+				cached_near_rainy_area = FALSE
+				cached_rain_dist = 100
+				for (var/turf/T in view(7, src))
+					var/area/T_area = get_area(T)
+					if (T_area.weather == WEATHER_WET && findtext(T_area.icon_state,"rain"))
+						cached_near_rainy_area = TRUE
+						cached_rain_dist = min(cached_rain_dist, get_dist(src, T))
+				near_rainy_area = cached_near_rainy_area
+				rdist = cached_rain_dist
+			else
+				near_rainy_area = cached_near_rainy_area
+				rdist = cached_rain_dist
 
 		if (world.time >= next_weather_sound && near_rainy_area)
 			src << sound('sound/ambience/rain.ogg', channel = 778, volume = (100 - (rdist*2)))

--- a/code/game/objects/structures/door.dm
+++ b/code/game/objects/structures/door.dm
@@ -513,3 +513,11 @@
 	override_material = TRUE
 	anchored = TRUE
 	health = 1200
+
+/obj/structure/simple_door/blast/New(var/newloc, var/material_name)
+	..()
+	sub_blast_doors |= src
+
+/obj/structure/simple_door/blast/Destroy()
+	sub_blast_doors -= src
+	..()

--- a/code/modules/1713/jobs/nomads.dm
+++ b/code/modules/1713/jobs/nomads.dm
@@ -387,6 +387,7 @@
 				traits += "Heat Tolerance"
 			if (!f_sens)
 				traits += "Cold Sensitivity"
+			traits_dirty = TRUE
 		else if (mob_area.climate == "tundra" || mob_area.climate == "taiga")
 			var/f_res = FALSE
 			var/f_sens = FALSE
@@ -403,6 +404,7 @@
 				traits += "Cold Tolerance"
 			if (!f_sens)
 				traits += "Heat Sensitivity"
+			traits_dirty = TRUE
 
 ///////////////LANGUAGE PROC/////////////////////////
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -53,4 +53,7 @@
 	if(!check_rights(R_DEBUG))
 		return
 
+	if(!istype(GLOB.error_cache))
+		to_chat(usr, "<span class='warning'>Custom error handler is disabled; no runtimes to view.</span>")
+		return
 	GLOB.error_cache.show_to(usr.client)

--- a/code/modules/client/preferencesSQLite/preferences.dm
+++ b/code/modules/client/preferencesSQLite/preferences.dm
@@ -186,6 +186,7 @@ var/list/preferences_datums = list()
 		character.f_growth = facial_hair_styles_list[f_style].growth
 
 	character.traits = traits
+	character.traits_dirty = TRUE
 
 
 	//Debugging report to track down a bug, which randomly assigned the plural gender to people.

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -1,7 +1,7 @@
 GLOBAL_VAR_INIT(total_runtimes, 0)
 GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 
-#ifdef DEBUG
+#ifdef USE_CUSTOM_ERROR_HANDLER
 #define ERROR_USEFUL_LEN 2
 
 /world/Error(exception/e, datum/e_src)

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -7,10 +7,10 @@
 //   logged errors. Only one instance of this datum should ever exist, and it's
 //   right here:
 
-#ifdef DEBUG
+#ifdef USE_CUSTOM_ERROR_HANDLER
 GLOBAL_DATUM_INIT(error_cache, /datum/error_viewer/error_cache, new)
 #else
-// If debugging is disabled, there's nothing useful to log, so don't bother.
+// If the custom error handler is disabled, there's nothing useful to log, so don't bother.
 GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 #endif
 

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -10,8 +10,8 @@
 #ifdef USE_CUSTOM_ERROR_HANDLER
 GLOBAL_DATUM_INIT(error_cache, /datum/error_viewer/error_cache, new)
 #else
-// If the custom error handler is disabled, there's nothing useful to log, so don't bother.
-GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
+// If the custom error handler is disabled, still initialize the datum so callers don't get null.
+GLOBAL_DATUM_INIT(error_cache, /datum/error_viewer/error_cache, new)
 #endif
 
 // - error_source datums exist for each line (of code) that generates an error,

--- a/code/modules/submarine/flooding_controller.dm
+++ b/code/modules/submarine/flooding_controller.dm
@@ -85,7 +85,7 @@ var/global/list/sub_blast_doors = list()
 
 	// Bulkhead integrity check: if a bulkhead adjacent to a breached area is damaged,
 	// propagate water through it
-	for(var/B_ref in sub_bulkheads)
+	for(var/B_ref in sub_bulkheads.Copy())
 		var/turf/wall/sub_bulkhead/B = B_ref
 		if(!istype(B) || QDELETED(B))
 			sub_bulkheads -= B_ref
@@ -102,7 +102,7 @@ var/global/list/sub_blast_doors = list()
 						other_side.add_water(flow)
 
 	// Open blast door check: propagate water through open doors between compartments
-	for(var/obj/structure/simple_door/blast/D in sub_blast_doors)
+	for(var/obj/structure/simple_door/blast/D in sub_blast_doors.Copy())
 		if(QDELETED(D))
 			sub_blast_doors -= D
 			continue

--- a/code/modules/submarine/flooding_controller.dm
+++ b/code/modules/submarine/flooding_controller.dm
@@ -6,6 +6,12 @@
 
 var/global/datum/flooding_controller/subcom_flooding
 
+// Registered in New() so the per-second tick never has to scan the world.
+// Bulkheads are turfs: ChangeTurf() retypes them in place with no Destroy(),
+// so stale entries are pruned from the list when their type no longer matches.
+var/global/list/sub_bulkheads = list()
+var/global/list/sub_blast_doors = list()
+
 /datum/flooding_controller
 	// All tracked deck turfs, indexed by compartment_id
 	var/list/tracked_turfs = list()      // list of all /turf/floor/sub_deck
@@ -79,8 +85,11 @@ var/global/datum/flooding_controller/subcom_flooding
 
 	// Bulkhead integrity check: if a bulkhead adjacent to a breached area is damaged,
 	// propagate water through it
-	for(var/turf/wall/sub_bulkhead/B in world)
-		if(QDELETED(B)) continue
+	for(var/B_ref in sub_bulkheads)
+		var/turf/wall/sub_bulkhead/B = B_ref
+		if(!istype(B) || QDELETED(B))
+			sub_bulkheads -= B_ref
+			continue
 		if(!B.watertight && B.health > 0)
 			// This bulkhead was destroyed - check if adjacent deck turfs have water
 			for(var/direction in list(NORTH, SOUTH, EAST, WEST))
@@ -93,8 +102,10 @@ var/global/datum/flooding_controller/subcom_flooding
 						other_side.add_water(flow)
 
 	// Open blast door check: propagate water through open doors between compartments
-	for(var/obj/structure/simple_door/blast/D in world)
-		if(QDELETED(D)) continue
+	for(var/obj/structure/simple_door/blast/D in sub_blast_doors)
+		if(QDELETED(D))
+			sub_blast_doors -= D
+			continue
 		if(!D.state) continue  // Door is closed
 		// Door is open - check both sides for water
 		for(var/direction in list(NORTH, SOUTH, EAST, WEST))

--- a/code/modules/submarine/submarine_datum.dm
+++ b/code/modules/submarine/submarine_datum.dm
@@ -553,14 +553,13 @@ var/global/list/all_submarines = list()
 	r_scrammed[index] = TRUE
 	r_power_output[index] = 0
 	if(reactor_hum_channel)
-		for(var/mob/M in world)
-			if(M.client)
-				M << sound(null, channel = reactor_hum_channel)
+		for(var/client/C in clients)
+			C << sound(null, channel = reactor_hum_channel)
 		reactor_hum_channel = 0
-	
+
 	// Find the reactor core object for this index
 	var/obj/structure/machinery/sub_physical/reactor_core/the_core
-	for(var/obj/structure/machinery/sub_physical/reactor_core/R in world)
+	for(var/obj/structure/machinery/sub_physical/reactor_core/R in sub_physical_machines)
 		if(R.id == index)
 			the_core = R
 			break
@@ -931,7 +930,7 @@ var/global/list/all_submarines = list()
 		qdel(CM)
 
 	// Auto-detect crew from mobs on the sub's Z-level
-	for(var/mob/living/human/H in world)
+	for(var/mob/living/human/H in human_mob_list)
 		if(H.stat == DEAD) continue
 		var/turf/floor/sub_deck/T = get_turf(H)
 		if(T && istype(T) && (T in internal_turfs))

--- a/code/modules/submarine/submarine_machinery_physical.dm
+++ b/code/modules/submarine/submarine_machinery_physical.dm
@@ -1,3 +1,8 @@
+// All physical submarine machinery. Processed once per second by
+// /process/submarine — NOT via processing_objects, which would make
+// /process/obj call process() on these a second time.
+var/global/list/sub_physical_machines = list()
+
 /obj/structure/machinery/sub_physical
 	name = "submarine machinery"
 	icon = 'icons/obj/machines/submarine.dmi'
@@ -13,10 +18,10 @@
 	..()
 	if(global.all_submarines.len)
 		my_sub = global.all_submarines[1]
-	processing_objects += src
+	sub_physical_machines += src
 
 /obj/structure/machinery/sub_physical/Destroy()
-	processing_objects -= src
+	sub_physical_machines -= src
 	..()
 
 /obj/structure/machinery/sub_physical/proc/can_use_sub(mob/user)

--- a/code/modules/submarine/submarine_turfs.dm
+++ b/code/modules/submarine/submarine_turfs.dm
@@ -98,6 +98,7 @@
 
 /turf/wall/sub_bulkhead/New(var/newloc)
 	..(newloc,"submarine hull")
+	sub_bulkheads |= src
 
 /turf/wall/sub_bulkhead/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/weldingtool))

--- a/code/processes/submarine.dm
+++ b/code/processes/submarine.dm
@@ -18,7 +18,7 @@
 	if(global.subcom_flooding)
 		global.subcom_flooding.process_tick()
 	// Process physical submarine machinery (bilge pumps, scrubbers, etc.)
-	for(var/obj/structure/machinery/sub_physical/M in sub_physical_machines)
+	for(var/obj/structure/machinery/sub_physical/M in sub_physical_machines.Copy())
 		if(!QDELETED(M))
 			M.process()
 		else

--- a/code/processes/submarine.dm
+++ b/code/processes/submarine.dm
@@ -18,6 +18,8 @@
 	if(global.subcom_flooding)
 		global.subcom_flooding.process_tick()
 	// Process physical submarine machinery (bilge pumps, scrubbers, etc.)
-	for(var/obj/structure/machinery/sub_physical/M in processing_objects)
+	for(var/obj/structure/machinery/sub_physical/M in sub_physical_machines)
 		if(!QDELETED(M))
 			M.process()
+		else
+			sub_physical_machines -= M


### PR DESCRIPTION
This PR removes the biggest runtime hotspots found in a performance review of the codebase. Compiles clean on BYOND 516.1684 (0 errors, 0 warnings).

## What changed

**Submarine/flooding tick no longer scans the world (SUBCOM13).** The flooding controller ran two `for (... in world)` scans every second (bulkheads and blast doors) — that iterates every atom in the game per tick. Bulkheads and blast doors now register themselves in global lists on creation, and the tick iterates those. Since `ChangeTurf()` retypes turfs in place without calling `Destroy()`, stale bulkhead entries are pruned with an `istype` check in the loop. The crew auto-detect scan, meltdown sound stop, and reactor-core lookup in `submarine_datum.dm` now use `human_mob_list` / `clients` / the machinery list instead of world scans.

**Fixed double-processing of submarine machinery.** `sub_physical` machinery was in `processing_objects` (processed by `/process/obj` every 2s) *and* processed again by `/process/submarine` every 1s. It now lives in its own `sub_physical_machines` list, processed once per second by the submarine process only. Note this changes the effective process() cadence for bilge pumps, scrubbers, reactors etc. from ~1.5x/sec to exactly 1x/sec.

**Rain ambience scan throttled.** `/mob/living/Life()` ran a ~200-turf `view(7)` scan every second for every player to find nearby rain. It is now skipped entirely unless the global weather is `WEATHER_WET`/`WEATHER_EXTREME` (areas cannot have rain icon_states otherwise), and when it does run the result is cached for 5 seconds. The rain sound loop is 145s long, so onset latency is imperceptible.

**`find_trait()` is now a hash lookup.** It did a linear string-list scan on every call (14x per human Life tick, 67 call sites including combat code). It now builds an assoc-list cache lazily with a dirty bit. The only two places that mutate mob traits after spawn (nomads seasonal tolerance swap, spawn-time preferences assignment) set the dirty flag. This also avoids a staleness hazard: preferences code calls `find_trait("Baldness")` *before* assigning `character.traits`.

**Release builds no longer compile with `#define DEBUG`.** DEBUG compiled debug info into every proc server-wide. The custom error handler (`world/Error`, runtime logging, admin error viewer) was gated on DEBUG, so it is re-gated on `USE_CUSTOM_ERROR_HANDLER`, which `_compile_options.dm` now defines unconditionally — runtime logging keeps working in release builds. What is lost: per-proc debug symbols (less detailed backtraces) and two ASSERT blocks in the dmm_suite map loader. Devs can re-enable DEBUG locally via Build → Preferences in Dream Maker.

## For reviewers

- The bulkhead list prune relies on typed-var filtering plus explicit `istype` checks because turfs are never `Destroy()`ed on type change.
- `sub_physical` machinery no longer being in `processing_objects` is intentional — `/process/submarine` is its only processor now.
- Worth capturing a Dream Daemon profile on a live round before/after merge to quantify the win, especially on the subcom13 map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)